### PR TITLE
Bind tsk variables

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,6 @@ fn main() {
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     //let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
-        .write_to_file("src/bindings.rs")
+        .write_to_file("src/auto_bindings.rs")
         .expect("Couldn't write bindings!");
 }

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,10 @@ fn main() {
         .clang_arg("-Isubprojects/tskit/c/subprojects/kastore")
         .whitelist_type("tsk.*")
         .whitelist_function("tsk.*")
+        .whitelist_type("TSK_.*")
+        .whitelist_var("TSK_.*")
+        .whitelist_type("KAS_.*")
+        .whitelist_var("KAS_.*")
         .whitelist_type("kastore.*")
         .whitelist_function("kastore.*")
         // Tell cargo to invalidate the built crate whenever any of the

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,0 +1,8 @@
+// re-export the auto-generate bindings
+pub use crate::auto_bindings::*;
+
+// tskit defines this via a type cast
+// in a macro. bindgen thus misses it.
+// See bindgen issue 316.
+pub const TSK_NULL: tsk_id_t = -1;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,5 +31,8 @@
 /// This module contains the same types/functions with the same names.
 pub mod bindings;
 
+mod auto_bindings;
+
 // Testing modules
 mod test_table_collection;
+mod test_tsk_variables;

--- a/src/test_tsk_variables.rs
+++ b/src/test_tsk_variables.rs
@@ -1,0 +1,21 @@
+// These tests basically make sure that we
+// can actually bind these things
+
+#[cfg(test)]
+mod tests
+{
+    use crate::*;
+
+    #[test]
+    fn test_node_is_sample()
+    {
+        let mut x = bindings::TSK_NODE_IS_SAMPLE;
+        assert!(x > 0);
+    }
+
+    #[test]
+    fn test_tsk_null()
+    {
+        assert_eq!(bindings::TSK_NULL, -1);
+    }
+}


### PR DESCRIPTION
This binds TSK_* and KAS_*, unless they are defined via a C-style type cast.  TSK_NULL is defined like that, so we manually do it.