### PR TITLE
Remove GSL from actions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.ACTIONS }}
           submodules: recursive
       - run: sudo apt-get update -y
-      - run: sudo apt-get install -y libgsl0-dev curl build-essential python3
+      - run: sudo apt-get install -y curl build-essential python3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -43,8 +43,6 @@ jobs:
           - stable
           - nightly
     steps:
-      - run: brew update
-      - run: brew install gsl
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.ACTIONS }}


### PR DESCRIPTION
We have an unnecessary, and GPL3, dependency in the actions.  Remove.