### PR TITLE
Replace tskit submodule with stable version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "subprojects/tskit"]
-	path = subprojects/tskit
-	url = https://github.com/tskit-dev/tskit

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package provides the following:
 
 The overview is:
 
-1. `tskit` and `kastore` are submodules.
+1. `tskit` and `kastore` source from `tskit 0.3.4` are include in `subprojects/`
 2. These two tools are compiled into the `rust` package.
 3. Then `bindgen` generates the bindings.
 4. Finally, the entire rust package is generated.

--- a/build.rs
+++ b/build.rs
@@ -5,18 +5,18 @@ fn main() {
     pkg_config::Config::new().atleast_version("1.2");
 
     let src = [
-        "subprojects/tskit/c/tskit/convert.c",
-        "subprojects/tskit/c/tskit/core.c",
-        "subprojects/tskit/c/tskit/genotypes.c",
-        "subprojects/tskit/c/tskit/haplotype_matching.c",
-        "subprojects/tskit/c/tskit/stats.c",
-        "subprojects/tskit/c/tskit/tables.c",
-        "subprojects/tskit/c/tskit/trees.c",
-        "subprojects/tskit/c/subprojects/kastore/kastore.c",
+        "subprojects/tskit/tskit/convert.c",
+        "subprojects/tskit/tskit/core.c",
+        "subprojects/tskit/tskit/genotypes.c",
+        "subprojects/tskit/tskit/haplotype_matching.c",
+        "subprojects/tskit/tskit/stats.c",
+        "subprojects/tskit/tskit/tables.c",
+        "subprojects/tskit/tskit/trees.c",
+        "subprojects/kastore/kastore.c",
     ];
 
-    let tskit_path = Path::new("subprojects/tskit/c");
-    let kastore_path = Path::new("subprojects/tskit/c/subprojects/kastore");
+    let tskit_path = Path::new("subprojects/tskit/");
+    let kastore_path = Path::new("subprojects/kastore/");
     let mut builder = cc::Build::new();
     let build = builder
         .files(src.iter())
@@ -32,8 +32,8 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
-        .clang_arg("-Isubprojects/tskit/c")
-        .clang_arg("-Isubprojects/tskit/c/subprojects/kastore")
+        .clang_arg("-Isubprojects/tskit")
+        .clang_arg("-Isubprojects/kastore")
         .whitelist_type("tsk.*")
         .whitelist_function("tsk.*")
         .whitelist_type("TSK_.*")
@@ -51,8 +51,8 @@ fn main() {
         .expect("Unable to generate bindings");
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.
-    //let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
-        .write_to_file("src/auto_bindings.rs")
+        .write_to_file(out_path.join("auto_bindings.rs"))
         .expect("Couldn't write bindings!");
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -24,8 +24,7 @@
 //! Those docs describe the most important parts of the C API.
 //! This module contains the same types/functions with the same names.
 
-// re-export the auto-generate bindings
-pub use crate::auto_bindings::*;
+include!(concat!(env!("OUT_DIR"), "/auto_bindings.rs"));
 
 // tskit defines this via a type cast
 // in a macro. bindgen thus misses it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 
 pub mod bindings;
 
-mod auto_bindings;
-
 mod _macros; // Starts w/_ to be sorted at front by rustfmt!
 mod edge_table;
 pub mod error;

--- a/subprojects/kastore/kastore.c
+++ b/subprojects/kastore/kastore.c
@@ -1,0 +1,1088 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+
+#include "kastore.h"
+
+/* Private flag used to indicate when we have opened the file ourselves
+ * and need to free it. */
+#define OWN_FILE (1 << 31)
+
+const char *
+kas_strerror(int err)
+{
+    const char *ret = "Unknown error";
+
+    switch (err) {
+        case KAS_ERR_GENERIC:
+            ret = "Generic error; please file a bug report";
+            break;
+        case KAS_ERR_IO:
+            if (errno != 0) {
+                ret = strerror(errno);
+            } else {
+                ret = "I/O error with errno unset. Please file a bug report";
+            }
+            break;
+        case KAS_ERR_BAD_MODE:
+            ret = "Bad open mode; must be \"r\", \"w\", or \"a\"";
+            break;
+        case KAS_ERR_BAD_FLAGS:
+            ret = "Unknow flags specified. Only KAS_READ_ALL or 0 allowed.";
+            break;
+        case KAS_ERR_NO_MEMORY:
+            ret = "Out of memory";
+            break;
+        case KAS_ERR_BAD_FILE_FORMAT:
+            ret = "File not in KAS format";
+            break;
+        case KAS_ERR_VERSION_TOO_OLD:
+            ret = "File format version is too old. Please upgrade using "
+                  "'kas upgrade <filename>'";
+            break;
+        case KAS_ERR_VERSION_TOO_NEW:
+            ret = "File format version is too new. Please upgrade your "
+                  "kastore library version";
+            break;
+        case KAS_ERR_BAD_TYPE:
+            ret = "Unknown data type";
+            break;
+        case KAS_ERR_DUPLICATE_KEY:
+            ret = "Duplicate key provided";
+            break;
+        case KAS_ERR_KEY_NOT_FOUND:
+            ret = "Key not found";
+            break;
+        case KAS_ERR_EMPTY_KEY:
+            ret = "Keys cannot be empty";
+            break;
+        case KAS_ERR_ILLEGAL_OPERATION:
+            ret = "Cannot perform the requested operation in the current mode";
+            break;
+        case KAS_ERR_TYPE_MISMATCH:
+            ret = "Mismatch between requested and stored types for array";
+            break;
+        case KAS_ERR_EOF:
+            ret = "End of file";
+            break;
+    }
+    return ret;
+}
+
+kas_version_t
+kas_version(void)
+{
+    kas_version_t version;
+
+    version.major = KAS_VERSION_MAJOR;
+    version.minor = KAS_VERSION_MINOR;
+    version.patch = KAS_VERSION_PATCH;
+    return version;
+}
+
+static size_t
+type_size(int type)
+{
+    const size_t type_size_map[] = { 1, 1, 2, 2, 4, 4, 8, 8, 4, 8 };
+    assert(type < KAS_NUM_TYPES);
+    return type_size_map[type];
+}
+
+/* Compare item keys lexicographically. */
+static int
+compare_items(const void *a, const void *b)
+{
+    const kaitem_t *ia = (const kaitem_t *) a;
+    const kaitem_t *ib = (const kaitem_t *) b;
+    size_t len = ia->key_len < ib->key_len ? ia->key_len : ib->key_len;
+    int ret = memcmp(ia->key, ib->key, len);
+    if (ret == 0) {
+        ret = (ia->key_len > ib->key_len) - (ia->key_len < ib->key_len);
+    }
+    return ret;
+}
+
+/* When a read error occurs we don't know whether this is because the file
+ * ended unexpectedly or an IO error occured. If the file ends unexpectedly
+ * this is a file format error.
+ */
+static int KAS_WARN_UNUSED
+kastore_get_read_io_error(kastore_t *self)
+{
+    int ret = KAS_ERR_IO;
+
+    if (feof(self->file) || errno == 0) {
+        ret = KAS_ERR_BAD_FILE_FORMAT;
+    }
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_write_header(kastore_t *self)
+{
+    int ret = 0;
+    char header[KAS_HEADER_SIZE];
+    uint16_t version_major = KAS_FILE_VERSION_MAJOR;
+    uint16_t version_minor = KAS_FILE_VERSION_MINOR;
+    uint32_t num_items = (uint32_t) self->num_items;
+    uint64_t file_size = (uint64_t) self->file_size;
+
+    memset(header, 0, sizeof(header));
+    memcpy(header, KAS_MAGIC, 8);
+    memcpy(header + 8, &version_major, 2);
+    memcpy(header + 10, &version_minor, 2);
+    memcpy(header + 12, &num_items, 4);
+    memcpy(header + 16, &file_size, 8);
+    /* Rest of header is reserved */
+    if (fwrite(header, KAS_HEADER_SIZE, 1, self->file) != 1) {
+        ret = KAS_ERR_IO;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_read_header(kastore_t *self)
+{
+    int ret = 0;
+    char header[KAS_HEADER_SIZE];
+    uint16_t version_major, version_minor;
+    uint32_t num_items;
+    uint64_t file_size;
+    size_t count;
+
+    count = fread(header, 1, KAS_HEADER_SIZE, self->file);
+    if (count == 0 && feof(self->file)) {
+        ret = KAS_ERR_EOF;
+        goto out;
+    } else if (count != KAS_HEADER_SIZE) {
+        ret = kastore_get_read_io_error(self);
+        goto out;
+    }
+    if (strncmp(header, KAS_MAGIC, 8) != 0) {
+        ret = KAS_ERR_BAD_FILE_FORMAT;
+        goto out;
+    }
+    memcpy(&version_major, header + 8, 2);
+    memcpy(&version_minor, header + 10, 2);
+    memcpy(&num_items, header + 12, 4);
+    memcpy(&file_size, header + 16, 8);
+    self->file_version[0] = (int) version_major;
+    self->file_version[1] = (int) version_minor;
+    if (self->file_version[0] < KAS_FILE_VERSION_MAJOR) {
+        ret = KAS_ERR_VERSION_TOO_OLD;
+        goto out;
+    } else if (self->file_version[0] > KAS_FILE_VERSION_MAJOR) {
+        ret = KAS_ERR_VERSION_TOO_NEW;
+        goto out;
+    }
+    self->num_items = num_items;
+    self->file_size = (size_t) file_size;
+    if (self->file_size < KAS_HEADER_SIZE) {
+        ret = KAS_ERR_BAD_FILE_FORMAT;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+/* Compute the locations of the keys and arrays in the file. */
+static void
+kastore_pack_items(kastore_t *self)
+{
+    size_t j, offset, remainder;
+
+    /* Pack the keys */
+    offset = KAS_HEADER_SIZE + self->num_items * KAS_ITEM_DESCRIPTOR_SIZE;
+    for (j = 0; j < self->num_items; j++) {
+        self->items[j].key_start = offset;
+        offset += self->items[j].key_len;
+    }
+    /* Pack the arrays */
+    for (j = 0; j < self->num_items; j++) {
+        remainder = offset % KAS_ARRAY_ALIGN;
+        if (remainder != 0) {
+            offset += KAS_ARRAY_ALIGN - remainder;
+        }
+        self->items[j].array_start = offset;
+        offset += self->items[j].array_len * type_size(self->items[j].type);
+    }
+    self->file_size = offset;
+}
+
+static int KAS_WARN_UNUSED
+kastore_write_descriptors(kastore_t *self)
+{
+    int ret = 0;
+    size_t j;
+    uint8_t type;
+    uint64_t key_start, key_len, array_start, array_len;
+    char descriptor[KAS_ITEM_DESCRIPTOR_SIZE];
+
+    for (j = 0; j < self->num_items; j++) {
+        memset(descriptor, 0, KAS_ITEM_DESCRIPTOR_SIZE);
+        type = (uint8_t) self->items[j].type;
+        key_start = (uint64_t) self->items[j].key_start;
+        key_len = (uint64_t) self->items[j].key_len;
+        array_start = (uint64_t) self->items[j].array_start;
+        array_len = (uint64_t) self->items[j].array_len;
+        memcpy(descriptor, &type, 1);
+        /* Bytes 1-8 are reserved */
+        memcpy(descriptor + 8, &key_start, 8);
+        memcpy(descriptor + 16, &key_len, 8);
+        memcpy(descriptor + 24, &array_start, 8);
+        memcpy(descriptor + 32, &array_len, 8);
+        /* Rest of descriptor is reserved */
+        if (fwrite(descriptor, sizeof(descriptor), 1, self->file) != 1) {
+            ret = KAS_ERR_IO;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_read_descriptors(kastore_t *self)
+{
+    int ret = KAS_ERR_BAD_FILE_FORMAT;
+    size_t j;
+    uint8_t type;
+    uint64_t key_start, key_len, array_start, array_len;
+    char *descriptor;
+    size_t descriptor_offset, offset, remainder, size, count;
+    char *read_buffer = NULL;
+
+    size = self->num_items * KAS_ITEM_DESCRIPTOR_SIZE;
+    if (size + KAS_HEADER_SIZE > self->file_size) {
+        goto out;
+    }
+    read_buffer = malloc(size);
+    if (read_buffer == NULL) {
+        ret = KAS_ERR_NO_MEMORY;
+        goto out;
+    }
+    count = fread(read_buffer, size, 1, self->file);
+    if (count == 0) {
+        ret = kastore_get_read_io_error(self);
+        goto out;
+    }
+
+    descriptor_offset = 0;
+    for (j = 0; j < self->num_items; j++) {
+        descriptor = read_buffer + descriptor_offset;
+        descriptor_offset += KAS_ITEM_DESCRIPTOR_SIZE;
+        memcpy(&type, descriptor, 1);
+        memcpy(&key_start, descriptor + 8, 8);
+        memcpy(&key_len, descriptor + 16, 8);
+        memcpy(&array_start, descriptor + 24, 8);
+        memcpy(&array_len, descriptor + 32, 8);
+
+        if (type >= KAS_NUM_TYPES) {
+            ret = KAS_ERR_BAD_TYPE;
+            goto out;
+        }
+        self->items[j].type = (int) type;
+        if (key_start + key_len > self->file_size) {
+            goto out;
+        }
+        self->items[j].key_start = (size_t) key_start;
+        self->items[j].key_len = (size_t) key_len;
+        if (array_start + array_len * type_size(type) > self->file_size) {
+            goto out;
+        }
+        self->items[j].array_start = (size_t) array_start;
+        self->items[j].array_len = (size_t) array_len;
+    }
+
+    /* Check the integrity of the key and array packing. Keys must
+     * be packed sequentially starting immediately after the descriptors. */
+    offset = KAS_HEADER_SIZE + self->num_items * KAS_ITEM_DESCRIPTOR_SIZE;
+    for (j = 0; j < self->num_items; j++) {
+        if (self->items[j].key_start != offset) {
+            ret = KAS_ERR_BAD_FILE_FORMAT;
+            goto out;
+        }
+        offset += self->items[j].key_len;
+    }
+    for (j = 0; j < self->num_items; j++) {
+        /* Arrays are 8 byte aligned and adjacent */
+        remainder = offset % KAS_ARRAY_ALIGN;
+        if (remainder != 0) {
+            offset += KAS_ARRAY_ALIGN - remainder;
+        }
+        if (self->items[j].array_start != offset) {
+            ret = KAS_ERR_BAD_FILE_FORMAT;
+            goto out;
+        }
+        offset += self->items[j].array_len * type_size(self->items[j].type);
+    }
+    if (offset != self->file_size) {
+        ret = KAS_ERR_BAD_FILE_FORMAT;
+        goto out;
+    }
+    ret = 0;
+out:
+    kas_safe_free(read_buffer);
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_write_data(kastore_t *self)
+{
+    int ret = 0;
+    size_t j, size, offset, padding;
+    char pad[KAS_ARRAY_ALIGN] = { 0, 0, 0, 0, 0, 0, 0 };
+
+    offset = KAS_HEADER_SIZE + self->num_items * KAS_ITEM_DESCRIPTOR_SIZE;
+
+    /* Write the keys. */
+    for (j = 0; j < self->num_items; j++) {
+        assert(offset == self->items[j].key_start);
+        if (fwrite(self->items[j].key, self->items[j].key_len, 1, self->file) != 1) {
+            ret = KAS_ERR_IO;
+            goto out;
+        }
+        offset += self->items[j].key_len;
+    }
+    /* Write the arrays. */
+    for (j = 0; j < self->num_items; j++) {
+        padding = self->items[j].array_start - offset;
+        assert(padding < KAS_ARRAY_ALIGN);
+        if (padding > 0 && fwrite(pad, padding, 1, self->file) != 1) {
+            ret = KAS_ERR_IO;
+            goto out;
+        }
+        size = self->items[j].array_len * type_size(self->items[j].type);
+        if (size > 0 && fwrite(self->items[j].array, size, 1, self->file) != 1) {
+            ret = KAS_ERR_IO;
+            goto out;
+        }
+        offset = self->items[j].array_start + size;
+    }
+out:
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_read_file(kastore_t *self)
+{
+    int ret = 0;
+    size_t count, size, offset, j;
+    bool read_all = !!(self->flags & KAS_READ_ALL);
+
+    offset = KAS_HEADER_SIZE + self->num_items * KAS_ITEM_DESCRIPTOR_SIZE;
+
+    size = self->file_size;
+    if (!read_all) {
+        /* Read in up to the start of first array. This will contain all the keys. */
+        size = self->items[0].array_start;
+    }
+
+    assert(size > offset);
+    size -= offset;
+
+    self->read_buffer = malloc(size);
+    if (self->read_buffer == NULL) {
+        ret = KAS_ERR_NO_MEMORY;
+        goto out;
+    }
+    count = fread(self->read_buffer, size, 1, self->file);
+    if (count == 0) {
+        ret = kastore_get_read_io_error(self);
+        goto out;
+    }
+    /* Assign the pointers for the keys and arrays */
+    for (j = 0; j < self->num_items; j++) {
+        self->items[j].key = self->read_buffer + self->items[j].key_start - offset;
+        if (read_all) {
+            self->items[j].array
+                = self->read_buffer + self->items[j].array_start - offset;
+        }
+    }
+out:
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_read_item(kastore_t *self, kaitem_t *item)
+{
+    int ret = 0;
+    int err;
+    size_t size = item->array_len * type_size(item->type);
+    size_t count;
+
+    item->array = malloc(size == 0 ? 1 : size);
+    if (item->array == NULL) {
+        ret = KAS_ERR_NO_MEMORY;
+        goto out;
+    }
+    if (size > 0) {
+        err = fseek(self->file, self->file_offset + (long) item->array_start, SEEK_SET);
+        if (err != 0) {
+            ret = KAS_ERR_IO;
+            goto out;
+        }
+        count = fread(item->array, size, 1, self->file);
+        if (count == 0) {
+            ret = kastore_get_read_io_error(self);
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_write_file(kastore_t *self)
+{
+    int ret = 0;
+
+    qsort(self->items, self->num_items, sizeof(kaitem_t), compare_items);
+    kastore_pack_items(self);
+    ret = kastore_write_header(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = kastore_write_descriptors(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = kastore_write_data(self);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_read(kastore_t *self)
+{
+    int ret = 0;
+
+    if (!(self->flags & KAS_READ_ALL)) {
+        /* Record the current file offset, in case this is a multi-store file,
+         * so that we can seek to the correct location in kastore_read_item().
+         */
+        self->file_offset = ftell(self->file);
+        if (self->file_offset == -1) {
+            ret = KAS_ERR_IO;
+            goto out;
+        }
+    }
+    ret = kastore_read_header(self);
+    if (ret != 0) {
+        goto out;
+    }
+    if (self->num_items > 0) {
+        self->items = calloc(self->num_items, sizeof(*self->items));
+        if (self->items == NULL) {
+            ret = KAS_ERR_NO_MEMORY;
+            goto out;
+        }
+        ret = kastore_read_descriptors(self);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = kastore_read_file(self);
+        if (ret != 0) {
+            goto out;
+        }
+    } else if (self->file_size != KAS_HEADER_SIZE) {
+        ret = KAS_ERR_BAD_FILE_FORMAT;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int KAS_WARN_UNUSED
+kastore_insert_all(kastore_t *self, kastore_t *other)
+{
+    size_t j;
+    int ret = 0;
+    kaitem_t item;
+
+    for (j = 0; j < other->num_items; j++) {
+        item = other->items[j];
+        ret = kastore_put(
+            self, item.key, item.key_len, item.array, item.array_len, item.type, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_open(kastore_t *self, const char *filename, const char *mode, int flags)
+{
+    int ret = 0;
+    const char *file_mode;
+    bool appending = false;
+    kastore_t tmp;
+    FILE *file;
+    int err;
+
+    memset(self, 0, sizeof(*self));
+    memset(&tmp, 0, sizeof(tmp));
+    if (strlen(mode) != 1) {
+        ret = KAS_ERR_BAD_MODE;
+        goto out;
+    }
+    if (strncmp(mode, "r", 1) == 0) {
+        file_mode = "rb";
+    } else if (strncmp(mode, "w", 1) == 0) {
+        file_mode = "wb";
+    } else if (strncmp(mode, "a", 1) == 0) {
+        mode = "w";
+        file_mode = "wb";
+        appending = true;
+    } else {
+        ret = KAS_ERR_BAD_MODE;
+        goto out;
+    }
+    if (appending) {
+        ret = kastore_open(&tmp, filename, "r", KAS_READ_ALL);
+        if (ret != 0) {
+            goto out;
+        }
+        /* tmp will now have read all of the data into memory. We can now
+         * close its file. We have to do this for Windows. */
+        err = fclose(tmp.file);
+        tmp.file = NULL;
+        if (err != 0) {
+            ret = KAS_ERR_IO;
+        }
+    }
+    file = fopen(filename, file_mode);
+    if (file == NULL) {
+        ret = KAS_ERR_IO;
+        goto out;
+    }
+    ret = kastore_openf(self, file, mode, flags);
+    if (ret != 0) {
+        (void) fclose(file);
+    } else {
+        self->flags |= OWN_FILE;
+        if (appending) {
+            ret = kastore_insert_all(self, &tmp);
+        }
+    }
+out:
+    if (appending) {
+        kastore_close(&tmp);
+    }
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_openf(kastore_t *self, FILE *file, const char *mode, int flags)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(*self));
+    if (strlen(mode) != 1) {
+        ret = KAS_ERR_BAD_MODE;
+        goto out;
+    }
+    if (strncmp(mode, "r", 1) == 0) {
+        self->mode = KAS_READ;
+    } else if (strncmp(mode, "w", 1) == 0) {
+        self->mode = KAS_WRITE;
+    } else {
+        ret = KAS_ERR_BAD_MODE;
+        goto out;
+    }
+    if (!(flags == 0 || flags == KAS_READ_ALL)) {
+        ret = KAS_ERR_BAD_FLAGS;
+        goto out;
+    }
+
+    self->flags = flags;
+    self->file = file;
+    if (self->mode == KAS_READ) {
+        ret = kastore_read(self);
+    }
+out:
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_close(kastore_t *self)
+{
+    int ret = 0;
+    int err;
+    size_t j;
+
+    if (self->mode == KAS_WRITE) {
+        if (self->file != NULL) {
+            ret = kastore_write_file(self);
+            if (ret != 0) {
+                /* Ignore errors on close now */
+                if (self->flags & OWN_FILE) {
+                    fclose(self->file);
+                }
+                self->file = NULL;
+            }
+        }
+        if (self->items != NULL) {
+            /* We only alloc memory for the keys and arrays in write mode */
+            for (j = 0; j < self->num_items; j++) {
+                kas_safe_free(self->items[j].key);
+                kas_safe_free(self->items[j].array);
+            }
+        }
+    } else {
+        kas_safe_free(self->read_buffer);
+        if (!(self->flags & KAS_READ_ALL)) {
+            /* The arrays have been individually malloced on demand. */
+            if (self->items != NULL) {
+                for (j = 0; j < self->num_items; j++) {
+                    kas_safe_free(self->items[j].array);
+                }
+            }
+        }
+    }
+    kas_safe_free(self->items);
+    if (self->file != NULL && (self->flags & OWN_FILE)) {
+        err = fclose(self->file);
+        if (err != 0) {
+            ret = KAS_ERR_IO;
+        }
+    }
+    memset(self, 0, sizeof(*self));
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_contains(kastore_t *self, const char *key, size_t key_len)
+{
+    void *array;
+    size_t array_len;
+    int type;
+    int ret = kastore_get(self, key, key_len, &array, &array_len, &type);
+
+    if (ret == 0) {
+        ret = 1;
+    } else if (ret == KAS_ERR_KEY_NOT_FOUND) {
+        ret = 0;
+    }
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_containss(kastore_t *self, const char *key)
+{
+    return kastore_contains(self, key, strlen(key));
+}
+
+int KAS_WARN_UNUSED
+kastore_get(kastore_t *self, const char *key, size_t key_len, void **array,
+    size_t *array_len, int *type)
+{
+    int ret = KAS_ERR_KEY_NOT_FOUND;
+    kaitem_t search;
+    kaitem_t *item;
+    search.key = malloc(key_len);
+    search.key_len = key_len;
+
+    if (self->mode != KAS_READ) {
+        ret = KAS_ERR_ILLEGAL_OPERATION;
+        goto out;
+    }
+    if (search.key == NULL) {
+        ret = KAS_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(search.key, key, key_len);
+    item = bsearch(
+        &search, self->items, self->num_items, sizeof(kaitem_t), compare_items);
+    if (item == NULL) {
+        goto out;
+    }
+    if (item->array == NULL) {
+        ret = kastore_read_item(self, item);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    *array = item->array;
+    *array_len = item->array_len;
+    *type = item->type;
+    ret = 0;
+out:
+    kas_safe_free(search.key);
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_gets(
+    kastore_t *self, const char *key, void **array, size_t *array_len, int *type)
+{
+    return kastore_get(self, key, strlen(key), array, array_len, type);
+}
+
+static int KAS_WARN_UNUSED
+kastore_gets_type(
+    kastore_t *self, const char *key, void **array, size_t *array_len, int type)
+{
+    int loaded_type;
+    int ret;
+
+    ret = kastore_get(self, key, strlen(key), array, array_len, &loaded_type);
+    if (ret != 0) {
+        goto out;
+    }
+    if (type != loaded_type) {
+        ret = KAS_ERR_TYPE_MISMATCH;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_int8(kastore_t *self, const char *key, int8_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_INT8);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_uint8(kastore_t *self, const char *key, uint8_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_UINT8);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_int16(kastore_t *self, const char *key, int16_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_INT16);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_uint16(
+    kastore_t *self, const char *key, uint16_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_UINT16);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_int32(kastore_t *self, const char *key, int32_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_INT32);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_uint32(
+    kastore_t *self, const char *key, uint32_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_UINT32);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_int64(kastore_t *self, const char *key, int64_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_INT64);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_uint64(
+    kastore_t *self, const char *key, uint64_t **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_UINT64);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_float32(kastore_t *self, const char *key, float **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_FLOAT32);
+}
+
+int KAS_WARN_UNUSED
+kastore_gets_float64(kastore_t *self, const char *key, double **array, size_t *array_len)
+{
+    return kastore_gets_type(self, key, (void **) array, array_len, KAS_FLOAT64);
+}
+
+int KAS_WARN_UNUSED
+kastore_put(kastore_t *self, const char *key, size_t key_len, const void *array,
+    size_t array_len, int type, int flags)
+{
+    int ret;
+    size_t array_size;
+    void *array_copy = NULL;
+
+    if (type < 0 || type >= KAS_NUM_TYPES) {
+        ret = KAS_ERR_BAD_TYPE;
+        goto out;
+    }
+    array_size = type_size(type) * array_len;
+    array_copy = malloc(array_size == 0 ? 1 : array_size);
+    if (array_copy == NULL) {
+        ret = KAS_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(array_copy, array, array_size);
+
+    ret = kastore_oput(self, key, key_len, array_copy, array_len, type, flags);
+    if (ret == 0) {
+        /* Kastore has taken ownership of the array, so we don't need to free it */
+        array_copy = NULL;
+    }
+out:
+    kas_safe_free(array_copy);
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_oput(kastore_t *self, const char *key, size_t key_len, void *array,
+    size_t array_len, int type, int KAS_UNUSED(flags))
+{
+    int ret = 0;
+    kaitem_t *new_item;
+    void *p;
+    size_t j;
+
+    if (self->mode != KAS_WRITE) {
+        ret = KAS_ERR_ILLEGAL_OPERATION;
+        goto out;
+    }
+    if (type < 0 || type >= KAS_NUM_TYPES) {
+        ret = KAS_ERR_BAD_TYPE;
+        goto out;
+    }
+    if (key_len == 0) {
+        ret = KAS_ERR_EMPTY_KEY;
+        goto out;
+    }
+    /* This isn't terribly efficient, but we're not expecting large
+     * numbers of items. */
+    p = realloc(self->items, (self->num_items + 1) * sizeof(*self->items));
+    if (p == NULL) {
+        ret = KAS_ERR_NO_MEMORY;
+        goto out;
+    }
+    self->items = p;
+    new_item = self->items + self->num_items;
+
+    memset(new_item, 0, sizeof(*new_item));
+    new_item->type = type;
+    new_item->key_len = key_len;
+    new_item->array_len = array_len;
+    new_item->array = array;
+    new_item->key = malloc(key_len);
+    if (new_item->key == NULL) {
+        kas_safe_free(new_item->key);
+        ret = KAS_ERR_NO_MEMORY;
+        goto out;
+    }
+    self->num_items++;
+    memcpy(new_item->key, key, key_len);
+
+    /* Check if this key is already in here. OK, this is a quadratic time
+     * algorithm, but we're not expecting to have lots of items (< 100). In
+     * this case, the simple algorithm is probably better. If/when we ever
+     * deal with more items than this, then we will need a better algorithm.
+     */
+    for (j = 0; j < self->num_items - 1; j++) {
+        if (compare_items(new_item, self->items + j) == 0) {
+            /* Free the key memory and remove this item */
+            self->num_items--;
+            kas_safe_free(new_item->key);
+            ret = KAS_ERR_DUPLICATE_KEY;
+            goto out;
+        }
+    }
+out:
+
+    return ret;
+}
+
+int KAS_WARN_UNUSED
+kastore_puts(kastore_t *self, const char *key, const void *array, size_t array_len,
+    int type, int flags)
+{
+    return kastore_put(self, key, strlen(key), array, array_len, type, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_int8(
+    kastore_t *self, const char *key, const int8_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_INT8, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_uint8(
+    kastore_t *self, const char *key, const uint8_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT8, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_int16(
+    kastore_t *self, const char *key, const int16_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_INT16, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_uint16(
+    kastore_t *self, const char *key, const uint16_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT16, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_int32(
+    kastore_t *self, const char *key, const int32_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_INT32, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_uint32(
+    kastore_t *self, const char *key, const uint32_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT32, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_int64(
+    kastore_t *self, const char *key, const int64_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_INT64, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_uint64(
+    kastore_t *self, const char *key, const uint64_t *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT64, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_float32(
+    kastore_t *self, const char *key, const float *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_FLOAT32, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_puts_float64(
+    kastore_t *self, const char *key, const double *array, size_t array_len, int flags)
+{
+    return kastore_puts(self, key, (const void *) array, array_len, KAS_FLOAT64, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs(
+    kastore_t *self, const char *key, void *array, size_t array_len, int type, int flags)
+{
+    return kastore_oput(self, key, strlen(key), array, array_len, type, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_int8(
+    kastore_t *self, const char *key, int8_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_INT8, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_uint8(
+    kastore_t *self, const char *key, uint8_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT8, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_int16(
+    kastore_t *self, const char *key, int16_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_INT16, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_uint16(
+    kastore_t *self, const char *key, uint16_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT16, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_int32(
+    kastore_t *self, const char *key, int32_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_INT32, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_uint32(
+    kastore_t *self, const char *key, uint32_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT32, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_int64(
+    kastore_t *self, const char *key, int64_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_INT64, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_uint64(
+    kastore_t *self, const char *key, uint64_t *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT64, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_float32(
+    kastore_t *self, const char *key, float *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_FLOAT32, flags);
+}
+
+int KAS_WARN_UNUSED
+kastore_oputs_float64(
+    kastore_t *self, const char *key, double *array, size_t array_len, int flags)
+{
+    return kastore_oputs(self, key, (void *) array, array_len, KAS_FLOAT64, flags);
+}
+
+void
+kastore_print_state(kastore_t *self, FILE *out)
+{
+    kaitem_t *item;
+    size_t j;
+
+    fprintf(out, "============================\n");
+    fprintf(out, "kastore state\n");
+    fprintf(out, "file_version = %d.%d\n", self->file_version[0], self->file_version[1]);
+    fprintf(out, "mode  = %d\n", self->mode);
+    fprintf(out, "flags = %d\n", self->flags);
+    fprintf(out, "num_items = %zu\n", self->num_items);
+    fprintf(out, "file_size = %zu\n", self->file_size);
+    fprintf(out, "own_file  = %d\n", !!(self->flags & OWN_FILE));
+    fprintf(out, "file = '%p'\n", (void *) self->file);
+    fprintf(out, "============================\n");
+    for (j = 0; j < self->num_items; j++) {
+        item = self->items + j;
+        fprintf(out,
+            "%.*s: type=%d, key_start=%zu, key_len=%zu, key=%p, "
+            "array_start=%zu, array_len=%zu, array=%p\n",
+            (int) item->key_len, item->key, item->type, item->key_start, item->key_len,
+            (void *) item->key, item->array_start, item->array_len,
+            (void *) item->array);
+    }
+    fprintf(out, "============================\n");
+}

--- a/subprojects/kastore/kastore.h
+++ b/subprojects/kastore/kastore.h
@@ -1,0 +1,571 @@
+/**
+ * @file kastore.h
+ * @brief Public API for kastore.
+ *
+ * This is the API documentation for kastore.
+ */
+#ifndef KASTORE_H
+#define KASTORE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __GNUC__
+#define KAS_WARN_UNUSED __attribute__((warn_unused_result))
+#define KAS_UNUSED(x) KAS_UNUSED_##x __attribute__((__unused__))
+#else
+#define KAS_WARN_UNUSED
+#define KAS_UNUSED(x) KAS_UNUSED_##x
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+
+/** @} */
+
+/**
+@defgroup ERROR_GROUP Error return values.
+@{
+*/
+// clang-format off
+/**
+Generic error thrown when no other message can be generated.
+*/
+#define KAS_ERR_GENERIC                               -1
+/**
+An error occured during IO.
+*/
+#define KAS_ERR_IO                                    -2
+/**
+An unrecognised mode string was passed to open().
+*/
+#define KAS_ERR_BAD_MODE                              -3
+/**
+Out-of-memory condition.
+*/
+#define KAS_ERR_NO_MEMORY                             -4
+/**
+Attempt to read an unknown file format.
+*/
+#define KAS_ERR_BAD_FILE_FORMAT                       -5
+/**
+The file is in kastore format, but the version is too old for this
+version of the library to read.
+*/
+#define KAS_ERR_VERSION_TOO_OLD                       -6
+/**
+The file is in kastore format, but the version is too new for this
+version of the library to read.
+*/
+#define KAS_ERR_VERSION_TOO_NEW                       -7
+/**
+An unknown type key was specified.
+*/
+#define KAS_ERR_BAD_TYPE                              -8
+/**
+A zero-length key was specified.
+*/
+#define KAS_ERR_EMPTY_KEY                             -9
+/**
+A duplicate key was specified.
+*/
+#define KAS_ERR_DUPLICATE_KEY                         -10
+/**
+The requested key does not exist in the store.
+*/
+#define KAS_ERR_KEY_NOT_FOUND                         -11
+/**
+The requestion function cannot be called in the current mode.
+*/
+#define KAS_ERR_ILLEGAL_OPERATION                     -12
+/**
+The requested type does not match the type of the stored values.
+*/
+#define KAS_ERR_TYPE_MISMATCH                         -13
+/**
+End of file was reached while reading data.
+*/
+#define KAS_ERR_EOF                                   -14
+/**
+Unknown flags were provided to open.
+*/
+#define KAS_ERR_BAD_FLAGS                             -15
+/** @} */
+
+/* Flags for open */
+#define KAS_READ_ALL            1
+
+
+/**
+@defgroup TYPE_GROUP Data types.
+@{
+*/
+#define KAS_INT8                0
+#define KAS_UINT8               1
+#define KAS_INT16               2
+#define KAS_UINT16              3
+#define KAS_INT32               4
+#define KAS_UINT32              5
+#define KAS_INT64               6
+#define KAS_UINT64              7
+#define KAS_FLOAT32             8
+#define KAS_FLOAT64             9
+/** @} */
+
+#define KAS_NUM_TYPES           10
+
+#define KAS_READ                1
+#define KAS_WRITE               2
+
+/**
+@defgroup FILE_VERSION_GROUP File version macros.
+@{
+*/
+/**
+The file version major number. Incremented when any breaking changes are made
+to the file format.
+*/
+#define KAS_FILE_VERSION_MAJOR  1
+/**
+The file version minor number. Incremented when non-breaking backward-compatible
+changes are made to the file format.
+*/
+#define KAS_FILE_VERSION_MINOR  0
+/** @} */
+
+/**
+@defgroup API_VERSION_GROUP API version macros.
+@{
+*/
+/**
+The library major version. Incremented when breaking changes to the API or ABI are
+introduced. This includes any changes to the signatures of functions and the
+sizes and types of externally visible structs.
+*/
+#define KAS_VERSION_MAJOR   2
+/**
+The library minor version. Incremented when non-breaking backward-compatible changes
+to the API or ABI are introduced, i.e., the addition of a new function.
+*/
+#define KAS_VERSION_MINOR   0
+/**
+The library patch version. Incremented when any changes not relevant to the
+to the API or ABI are introduced, i.e., internal refactors of bugfixes.
+*/
+#define KAS_VERSION_PATCH   0
+/** @} */
+
+#define KAS_HEADER_SIZE             64
+#define KAS_ITEM_DESCRIPTOR_SIZE    64
+#define KAS_MAGIC                   "\211KAS\r\n\032\n"
+#define KAS_ARRAY_ALIGN             8
+// clang-format on
+
+typedef struct {
+    int type;
+    size_t key_len;
+    size_t array_len;
+    char *key;
+    void *array;
+    size_t key_start;
+    size_t array_start;
+} kaitem_t;
+
+/**
+@brief A file-backed store of key-array values.
+*/
+typedef struct {
+    int flags;
+    int mode;
+    int file_version[2];
+    size_t num_items;
+    kaitem_t *items;
+    FILE *file;
+    size_t file_size;
+    long file_offset;
+    char *read_buffer;
+} kastore_t;
+
+/**
+@brief Library version information.
+*/
+typedef struct {
+    /** @brief The major version number. */
+    int major;
+    /** @brief The minor version number. */
+    int minor;
+    /** @brief The patch version number. */
+    int patch;
+} kas_version_t;
+
+/**
+@brief Open a store from a given file in read ("r"), write ("w") or
+append ("a") mode.
+
+@rst
+In read mode, a store can be queried using the :ref:`get functions
+<sec_c_api_get>` and any attempts to write to the store will return an error.
+In write and append mode, the store can written to using the :ref:`put
+functions <sec_c_api_put>` and any attempt to read will return an error.
+
+After :c:func:`kastore_open` has been called on a particular store,
+:c:func:`kastore_close` must be called to avoid leaking memory. This must also
+be done when :c:func:`kastore_open` returns an error.
+
+When opened in read-mode, the default is to read key/array values from file
+on demand. This is useful when a subset of the data is required and we don't
+wish to read the entire file. If the entire file is to be read, the
+``KAS_READ_ALL`` flag may be specified to improve performance.
+
+**Flags**
+
+KAS_READ_ALL
+    If this option is specified, read the entire file at
+    open time. This will give slightly better performance as the file can
+    be read sequentially in a single pass.
+
+@endrst
+
+@param self A pointer to a kastore object.
+@param filename The file path to open.
+@param mode The open mode: can be read ("r"), write ("w") or append ("a").
+@param flags The open flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_open(kastore_t *self, const char *filename, const char *mode, int flags);
+
+/**
+@brief Open a store from a given FILE pointer.
+
+@rst
+Behaviour, mode and flags follow that of :c:func:`kastore_open`,
+except append mode is not supported.
+The ``file`` argument must be opened in an appropriate mode (e.g. "r"
+for a kastore in "r" mode).  Files open with other modes will result
+in KAS_ERR_IO being returned when read/write operations are attempted.
+
+The FILE will not be closed when :c:func:`kastore_close` is called.
+If the KAS_READ_ALL flag is supplied, no ``seek`` operations will be
+performed on the FILE and so streams such as stdin, FIFOs etc are
+supported. The FILE pointer will be positioned exactly at the end
+of the kastore encoded bytes once reading is completed, and reading
+multiple stores from the same FILE sequentially is fully supported.
+@endrst
+
+@param self A pointer to a kastore object.
+@param file The FILE* to read/write the store from/to.
+@param mode The open mode: can be read ("r") or write ("w").
+@param flags The open flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_openf(kastore_t *self, FILE *file, const char *mode, int flags);
+
+/**
+@brief Close an opened store, freeing all resources.
+
+Any store that has been opened must be closed to avoid memory leaks
+(including cases in which errors have occured). It is not an error to
+call ``kastore_close`` multiple times on the same object, but
+``kastore_open`` must be called before ``kastore_close``.
+
+@param self A pointer to a kastore object.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_close(kastore_t *self);
+
+/**
+@brief Return 1 if the store contains the specified key and 0 if it does not.
+
+@rst
+Queries the store for the specified key and returns 1 if it exists. If the
+key does not exist, 0 is returned. If an error occurs (for example, if querying
+the store while it is in write-mode), a negative value is returned.
+
+For keys that are standard NULL terminated strings, the :c:func:`kastore_containss`
+function may be more convenient.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@param key_len The length of the key.
+@return Return 1 if the key is present and 0 if it does not. If an error occurs,
+    return a negative value.
+*/
+int kastore_contains(kastore_t *self, const char *key, size_t key_len);
+
+/**
+@brief Return 1 if the store contains the specified NULL terminated key
+and 0 if it does not.
+
+@rst
+Queries the store for the specified key, which must be a NULL terminated string,
+and returns 1 if it exists. If the
+key does not exist, 0 is returned. If an error occurs (for example, if querying
+the store while it is in write-mode), a negative value is returned.
+the array in the specified destination pointers.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@return Return 1 if the key is present and 0 if it does not. If an error occurs,
+    return a negative value.
+*/
+int kastore_containss(kastore_t *self, const char *key);
+
+/**
+@brief Get the array for the specified key.
+
+@rst
+Queries the store for the specified key and stores pointers to the memory for
+the corresponding array, the number of elements in this array and the type of
+the array in the specified destination pointers. This is the most general form
+of ``get`` query in kastore, as non NULL-terminated strings can be used as
+keys and the resulting array is returned in a generic pointer. When standard C
+strings are used as keys and the type of the array is known, it is more
+convenient to use the :ref:`typed variants <sec_c_api_typed_get>` of this function.
+
+The returned array points to memory that is internally managed by the store
+and must not be freed or modified. The pointer is guaranteed to be valid
+until :c:func:`kastore_close` is called.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@param key_len The length of the key.
+@param array The destination pointer for the array.
+@param array_len The destination pointer for the number of elements
+in the array.
+@param type The destination pointer for the type code of the array.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_get(kastore_t *self, const char *key, size_t key_len, void **array,
+    size_t *array_len, int *type);
+
+/**
+@brief Get the array for the specified NULL-terminated key.
+
+@rst
+As for :c:func:`kastore_get()` except the key is a NULL-terminated string.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@param array The destination pointer for the array.
+@param array_len The destination pointer for the number of elements
+in the array.
+@param type The destination pointer for the type code of the array.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_gets(
+    kastore_t *self, const char *key, void **array, size_t *array_len, int *type);
+
+/**
+@defgroup TYPED_GETS_GROUP Typed get functions.
+@{
+*/
+
+int kastore_gets_int8(
+    kastore_t *self, const char *key, int8_t **array, size_t *array_len);
+int kastore_gets_uint8(
+    kastore_t *self, const char *key, uint8_t **array, size_t *array_len);
+int kastore_gets_int16(
+    kastore_t *self, const char *key, int16_t **array, size_t *array_len);
+int kastore_gets_uint16(
+    kastore_t *self, const char *key, uint16_t **array, size_t *array_len);
+int kastore_gets_int32(
+    kastore_t *self, const char *key, int32_t **array, size_t *array_len);
+int kastore_gets_uint32(
+    kastore_t *self, const char *key, uint32_t **array, size_t *array_len);
+int kastore_gets_int64(
+    kastore_t *self, const char *key, int64_t **array, size_t *array_len);
+int kastore_gets_uint64(
+    kastore_t *self, const char *key, uint64_t **array, size_t *array_len);
+int kastore_gets_float32(
+    kastore_t *self, const char *key, float **array, size_t *array_len);
+int kastore_gets_float64(
+    kastore_t *self, const char *key, double **array, size_t *array_len);
+
+/** @} */
+
+/**
+@brief Insert the specified key-array pair into the store.
+
+@rst
+A key with the specified length is inserted into the store and associated with
+an array of the specified type and number of elements. The contents of the
+specified key and array are copied. Keys can be any sequence of bytes but must
+be at least one byte long and be unique. There is no restriction on the
+contents of arrays. This is the most general form of ``put`` operation in
+kastore; when the type of the array is known and the keys are standard C
+strings, it is usually more convenient to use the :ref:`typed variants
+<sec_c_api_typed_put>` of this function.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@param key_len The length of the key.
+@param array The array.
+@param array_len The number of elements in the array.
+@param type The type of the array.
+@param flags The insertion flags. Currently unused.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_put(kastore_t *self, const char *key, size_t key_len, const void *array,
+    size_t array_len, int type, int flags);
+/**
+@brief Insert the specified NULL terminated key and array pair into the store.
+
+@rst
+As for :c:func:`kastore_put` except the key must be NULL-terminated C string.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@param array The array.
+@param array_len The number of elements in the array.
+@param type The type of the array.
+@param flags The insertion flags. Currently unused.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_puts(kastore_t *self, const char *key, const void *array, size_t array_len,
+    int type, int flags);
+
+/**
+ @defgroup TYPED_PUTS_GROUP Typed put functions.
+ @{
+ */
+
+int kastore_puts_int8(
+    kastore_t *self, const char *key, const int8_t *array, size_t array_len, int flags);
+int kastore_puts_uint8(
+    kastore_t *self, const char *key, const uint8_t *array, size_t array_len, int flags);
+int kastore_puts_int16(
+    kastore_t *self, const char *key, const int16_t *array, size_t array_len, int flags);
+int kastore_puts_uint16(kastore_t *self, const char *key, const uint16_t *array,
+    size_t array_len, int flags);
+int kastore_puts_int32(
+    kastore_t *self, const char *key, const int32_t *array, size_t array_len, int flags);
+int kastore_puts_uint32(kastore_t *self, const char *key, const uint32_t *array,
+    size_t array_len, int flags);
+int kastore_puts_int64(
+    kastore_t *self, const char *key, const int64_t *array, size_t array_len, int flags);
+int kastore_puts_uint64(kastore_t *self, const char *key, const uint64_t *array,
+    size_t array_len, int flags);
+int kastore_puts_float32(
+    kastore_t *self, const char *key, const float *array, size_t array_len, int flags);
+int kastore_puts_float64(
+    kastore_t *self, const char *key, const double *array, size_t array_len, int flags);
+
+/** @} */
+
+/**
+@brief Insert the specified key-array pair into the store, transferring ownership
+of the malloced array buffer to the store (own-put).
+
+@rst
+A key with the specified length is inserted into the store and associated with
+an array of the specified type and number of elements. The contents of the
+specified key is copied, but the array buffer is taken directly and freed when
+the store is closed. The array buffer must be a pointer returned by ``malloc``
+or ``calloc``. Ownership of the buffer is not taken unless the function returns
+successfully.
+
+Apart from taking ownership of the array buffer, the semantics of this
+function are identical to :c:func:`kastore_put`.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@param key_len The length of the key.
+@param array The array. Must be a pointer returned by malloc/calloc.
+@param array_len The number of elements in the array.
+@param type The type of the array.
+@param flags The insertion flags. Currently unused.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_oput(kastore_t *self, const char *key, size_t key_len, void *array,
+    size_t array_len, int type, int flags);
+/**
+@brief Insert the specified NULL terminated key and array pair into the store,
+transferring ownership of the malloced array buffer to the store (own-put).
+
+@rst
+As for :c:func:`kastore_oput` except the key must be NULL-terminated C string.
+@endrst
+
+@param self A pointer to a kastore object.
+@param key The key.
+@param array The array. Must be a pointer returned by malloc/calloc.
+@param array_len The number of elements in the array.
+@param type The type of the array.
+@param flags The insertion flags. Currently unused.
+@return Return 0 on success or a negative value on failure.
+*/
+int kastore_oputs(kastore_t *self, const char *key, void *array, size_t array_len,
+    int type, int flags);
+
+/**
+ @defgroup TYPED_OPUTS_GROUP Typed own-and-put functions.
+ @{
+ */
+
+int kastore_oputs_int8(
+    kastore_t *self, const char *key, int8_t *array, size_t array_len, int flags);
+int kastore_oputs_uint8(
+    kastore_t *self, const char *key, uint8_t *array, size_t array_len, int flags);
+int kastore_oputs_int16(
+    kastore_t *self, const char *key, int16_t *array, size_t array_len, int flags);
+int kastore_oputs_uint16(
+    kastore_t *self, const char *key, uint16_t *array, size_t array_len, int flags);
+int kastore_oputs_int32(
+    kastore_t *self, const char *key, int32_t *array, size_t array_len, int flags);
+int kastore_oputs_uint32(
+    kastore_t *self, const char *key, uint32_t *array, size_t array_len, int flags);
+int kastore_oputs_int64(
+    kastore_t *self, const char *key, int64_t *array, size_t array_len, int flags);
+int kastore_oputs_uint64(
+    kastore_t *self, const char *key, uint64_t *array, size_t array_len, int flags);
+int kastore_oputs_float32(
+    kastore_t *self, const char *key, float *array, size_t array_len, int flags);
+int kastore_oputs_float64(
+    kastore_t *self, const char *key, double *array, size_t array_len, int flags);
+
+/** @} */
+
+void kastore_print_state(kastore_t *self, FILE *out);
+
+/**
+@brief Returns a description of the specified error code.
+
+@param err The error code.
+@return String describing the error code.
+*/
+const char *kas_strerror(int err);
+
+/**
+@brief Returns the API version.
+
+@rst
+The API follows the `semver convention <https://semver.org/>`_, where the
+major, minor and patch numbers have specific meanings. The versioning
+scheme here also takes into account ABI compatability.
+@endrst
+*/
+kas_version_t kas_version(void);
+
+#define kas_safe_free(pointer)                                                          \
+    do {                                                                                \
+        if (pointer != NULL) {                                                          \
+            free(pointer);                                                              \
+            pointer = NULL;                                                             \
+        }                                                                               \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/subprojects/tskit/tskit.h
+++ b/subprojects/tskit/tskit.h
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file tskit.h
+ * @brief Tskit API.
+ */
+#ifndef __TSKIT_H__
+#define __TSKIT_H__
+
+#include <tskit/core.h>
+#include <tskit/trees.h>
+#include <tskit/genotypes.h>
+#include <tskit/convert.h>
+#include <tskit/stats.h>
+#include <tskit/haplotype_matching.h>
+
+#endif

--- a/subprojects/tskit/tskit/convert.c
+++ b/subprojects/tskit/tskit/convert.c
@@ -1,0 +1,188 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2015-2017 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <tskit/convert.h>
+
+/* ======================================================== *
+ * Newick output.
+ * ======================================================== */
+
+/* This infrastructure is left-over from an earlier more complex version
+ * of this algorithm that worked over a tree sequence and cached the newick
+ * subtrees, updating according to diffs. It's unclear whether this complexity
+ * was of any real-world use, since newick output for large trees is pretty
+ * pointless. */
+
+typedef struct {
+    size_t precision;
+    tsk_flags_t options;
+    char *newick;
+    tsk_id_t *traversal_stack;
+    const tsk_tree_t *tree;
+} tsk_newick_converter_t;
+
+static int
+tsk_newick_converter_run(
+    tsk_newick_converter_t *self, tsk_id_t root, size_t buffer_size, char *buffer)
+{
+    int ret = TSK_ERR_GENERIC;
+    const tsk_tree_t *tree = self->tree;
+    tsk_id_t *stack = self->traversal_stack;
+    const double *time = self->tree->tree_sequence->tables->nodes.time;
+    int stack_top = 0;
+    int label;
+    size_t s = 0;
+    int r;
+    tsk_id_t u, v, w, root_parent;
+    double branch_length;
+
+    if (root < 0 || root >= (tsk_id_t) self->tree->num_nodes) {
+        ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+        goto out;
+    }
+    if (buffer == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    root_parent = tree->parent[root];
+    stack[0] = root;
+    u = root_parent;
+    while (stack_top >= 0) {
+        v = stack[stack_top];
+        if (tree->left_child[v] != TSK_NULL && v != u) {
+            if (s >= buffer_size) {
+                ret = TSK_ERR_BUFFER_OVERFLOW;
+                goto out;
+            }
+            buffer[s] = '(';
+            s++;
+            for (w = tree->right_child[v]; w != TSK_NULL; w = tree->left_sib[w]) {
+                stack_top++;
+                stack[stack_top] = w;
+            }
+        } else {
+            u = tree->parent[v];
+            stack_top--;
+            if (tree->left_child[v] == TSK_NULL) {
+                if (s >= buffer_size) {
+                    ret = TSK_ERR_BUFFER_OVERFLOW;
+                    goto out;
+                }
+                /* We do this for ms-compatability. This should be a configurable option
+                 * via the flags attribute */
+                label = v + 1;
+                r = snprintf(buffer + s, buffer_size - s, "%d", label);
+                if (r < 0) {
+                    ret = TSK_ERR_IO;
+                    goto out;
+                }
+                s += (size_t) r;
+                if (s >= buffer_size) {
+                    ret = TSK_ERR_BUFFER_OVERFLOW;
+                    goto out;
+                }
+            }
+            if (u != root_parent) {
+                branch_length = (time[u] - time[v]);
+                r = snprintf(buffer + s, buffer_size - s, ":%.*f", (int) self->precision,
+                    branch_length);
+                if (r < 0) {
+                    ret = TSK_ERR_IO;
+                    goto out;
+                }
+                s += (size_t) r;
+                if (s >= buffer_size) {
+                    ret = TSK_ERR_BUFFER_OVERFLOW;
+                    goto out;
+                }
+                if (v == tree->right_child[u]) {
+                    buffer[s] = ')';
+                } else {
+                    buffer[s] = ',';
+                }
+                s++;
+            }
+        }
+    }
+    if ((s + 1) >= buffer_size) {
+        ret = TSK_ERR_BUFFER_OVERFLOW;
+        goto out;
+    }
+    buffer[s] = ';';
+    buffer[s + 1] = '\0';
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+tsk_newick_converter_init(tsk_newick_converter_t *self, const tsk_tree_t *tree,
+    size_t precision, tsk_flags_t options)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_newick_converter_t));
+    self->precision = precision;
+    self->options = options;
+    self->tree = tree;
+    self->traversal_stack = malloc(tsk_treeseq_get_num_nodes(self->tree->tree_sequence)
+                                   * sizeof(*self->traversal_stack));
+    if (self->traversal_stack == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_newick_converter_free(tsk_newick_converter_t *self)
+{
+    tsk_safe_free(self->traversal_stack);
+    return 0;
+}
+
+int
+tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
+    tsk_flags_t options, size_t buffer_size, char *buffer)
+{
+    int ret = 0;
+    tsk_newick_converter_t nc;
+
+    ret = tsk_newick_converter_init(&nc, tree, precision, options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_newick_converter_run(&nc, root, buffer_size, buffer);
+out:
+    tsk_newick_converter_free(&nc);
+    return ret;
+}

--- a/subprojects/tskit/tskit/convert.h
+++ b/subprojects/tskit/tskit/convert.h
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2015-2017 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef TSK_CONVERT_H
+#define TSK_CONVERT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <tskit/trees.h>
+
+int tsk_convert_newick(const tsk_tree_t *tree, tsk_id_t root, size_t precision,
+    tsk_flags_t options, size_t buffer_size, char *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/subprojects/tskit/tskit/core.c
+++ b/subprojects/tskit/tskit/core.c
@@ -1,0 +1,687 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2015-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <math.h>
+
+#include <kastore.h>
+#include <tskit/core.h>
+
+#define UUID_NUM_BYTES 16
+
+#if defined(_WIN32)
+
+#include <windows.h>
+#include <wincrypt.h>
+
+static int TSK_WARN_UNUSED
+get_random_bytes(uint8_t *buf)
+{
+    /* Based on CPython's code in bootstrap_hash.c */
+    int ret = TSK_ERR_GENERATE_UUID;
+    HCRYPTPROV hCryptProv = NULL;
+
+    if (!CryptAcquireContext(
+            &hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
+        goto out;
+    }
+    if (!CryptGenRandom(hCryptProv, (DWORD) UUID_NUM_BYTES, buf)) {
+        goto out;
+    }
+    if (!CryptReleaseContext(hCryptProv, 0)) {
+        hCryptProv = NULL;
+        goto out;
+    }
+    hCryptProv = NULL;
+    ret = 0;
+out:
+    if (hCryptProv != NULL) {
+        CryptReleaseContext(hCryptProv, 0);
+    }
+    return ret;
+}
+
+#else
+
+/* Assuming the existance of /dev/urandom on Unix platforms */
+static int TSK_WARN_UNUSED
+get_random_bytes(uint8_t *buf)
+{
+    int ret = TSK_ERR_GENERATE_UUID;
+    FILE *f = fopen("/dev/urandom", "r");
+
+    if (f == NULL) {
+        goto out;
+    }
+    if (fread(buf, UUID_NUM_BYTES, 1, f) != 1) {
+        goto out;
+    }
+    if (fclose(f) != 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+#endif
+
+/* Generate a new UUID4 using a system-generated source of randomness.
+ * Note that this function writes a NULL terminator to the end of this
+ * string, so that the total length of the buffer must be 37 bytes.
+ */
+int
+tsk_generate_uuid(char *dest, int TSK_UNUSED(flags))
+{
+    int ret = 0;
+    uint8_t buf[UUID_NUM_BYTES];
+    const char *pattern
+        = "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x";
+
+    ret = get_random_bytes(buf);
+    if (ret != 0) {
+        goto out;
+    }
+    if (snprintf(dest, TSK_UUID_SIZE + 1, pattern, buf[0], buf[1], buf[2], buf[3],
+            buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10], buf[11], buf[12],
+            buf[13], buf[14], buf[15])
+        < 0) {
+        ret = TSK_ERR_GENERATE_UUID;
+        goto out;
+    }
+out:
+    return ret;
+}
+static const char *
+tsk_strerror_internal(int err)
+{
+    const char *ret = "Unknown error";
+
+    switch (err) {
+        case 0:
+            ret = "Normal exit condition. This is not an error!";
+            break;
+
+        /* General errors */
+        case TSK_ERR_GENERIC:
+            ret = "Generic error; please file a bug report";
+            break;
+        case TSK_ERR_NO_MEMORY:
+            ret = "Out of memory";
+            break;
+        case TSK_ERR_IO:
+            if (errno != 0) {
+                ret = strerror(errno);
+            } else {
+                ret = "Unspecified IO error";
+            }
+            break;
+        case TSK_ERR_BAD_PARAM_VALUE:
+            ret = "Bad parameter value provided";
+            break;
+        case TSK_ERR_BUFFER_OVERFLOW:
+            ret = "Supplied buffer is too small";
+            break;
+        case TSK_ERR_UNSUPPORTED_OPERATION:
+            ret = "Operation cannot be performed in current configuration";
+            break;
+        case TSK_ERR_GENERATE_UUID:
+            ret = "Error generating UUID";
+            break;
+        case TSK_ERR_EOF:
+            ret = "End of file";
+            break;
+
+        /* File format errors */
+        case TSK_ERR_FILE_FORMAT:
+            ret = "File format error";
+            break;
+        case TSK_ERR_FILE_VERSION_TOO_OLD:
+            ret = "tskit file version too old. Please upgrade using the "
+                  "'tskit upgrade' command";
+            break;
+        case TSK_ERR_FILE_VERSION_TOO_NEW:
+            ret = "tskit file version is too new for this instance. "
+                  "Please upgrade tskit to the latest version";
+            break;
+        case TSK_ERR_REQUIRED_COL_NOT_FOUND:
+            ret = "A required column was not found in the file.";
+            break;
+        case TSK_ERR_BOTH_COLUMNS_REQUIRED:
+            ret = "Both columns in a related pair must be provided";
+            break;
+
+        /* Out of bounds errors */
+        case TSK_ERR_BAD_OFFSET:
+            ret = "Bad offset provided in input array";
+            break;
+        case TSK_ERR_OUT_OF_BOUNDS:
+            ret = "Object reference out of bounds";
+            break;
+        case TSK_ERR_NODE_OUT_OF_BOUNDS:
+            ret = "Node out of bounds";
+            break;
+        case TSK_ERR_EDGE_OUT_OF_BOUNDS:
+            ret = "Edge out of bounds";
+            break;
+        case TSK_ERR_POPULATION_OUT_OF_BOUNDS:
+            ret = "Population out of bounds";
+            break;
+        case TSK_ERR_SITE_OUT_OF_BOUNDS:
+            ret = "Site out of bounds";
+            break;
+        case TSK_ERR_MUTATION_OUT_OF_BOUNDS:
+            ret = "Mutation out of bounds";
+            break;
+        case TSK_ERR_MIGRATION_OUT_OF_BOUNDS:
+            ret = "Migration out of bounds";
+            break;
+        case TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS:
+            ret = "Individual out of bounds";
+            break;
+        case TSK_ERR_PROVENANCE_OUT_OF_BOUNDS:
+            ret = "Provenance out of bounds";
+            break;
+        case TSK_ERR_TIME_NONFINITE:
+            ret = "Times must be finite";
+            break;
+        case TSK_ERR_GENOME_COORDS_NONFINITE:
+            ret = "Genome coordinates must be finite numbers";
+            break;
+
+        /* Edge errors */
+        case TSK_ERR_NULL_PARENT:
+            ret = "Edge in parent is null";
+            break;
+        case TSK_ERR_NULL_CHILD:
+            ret = "Edge in parent is null";
+            break;
+        case TSK_ERR_EDGES_NOT_SORTED_PARENT_TIME:
+            ret = "Edges must be listed in (time[parent], child, left) order;"
+                  " time[parent] order violated";
+            break;
+        case TSK_ERR_EDGES_NONCONTIGUOUS_PARENTS:
+            ret = "All edges for a given parent must be contiguous";
+            break;
+        case TSK_ERR_EDGES_NOT_SORTED_CHILD:
+            ret = "Edges must be listed in (time[parent], child, left) order;"
+                  " child order violated";
+            break;
+        case TSK_ERR_EDGES_NOT_SORTED_LEFT:
+            ret = "Edges must be listed in (time[parent], child, left) order;"
+                  " left order violated";
+            break;
+        case TSK_ERR_BAD_NODE_TIME_ORDERING:
+            ret = "time[parent] must be greater than time[child]";
+            break;
+        case TSK_ERR_BAD_EDGE_INTERVAL:
+            ret = "Bad edge interval where right <= left";
+            break;
+        case TSK_ERR_DUPLICATE_EDGES:
+            ret = "Duplicate edges provided";
+            break;
+        case TSK_ERR_RIGHT_GREATER_SEQ_LENGTH:
+            ret = "Right coordinate > sequence length";
+            break;
+        case TSK_ERR_LEFT_LESS_ZERO:
+            ret = "Left coordinate must be >= 0";
+            break;
+        case TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN:
+            ret = "Bad edges: contradictory children for a given parent over "
+                  "an interval";
+            break;
+        case TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA:
+            ret = "Can't squash, flush, simplify or link ancestors with edges that have "
+                  "non-empty metadata";
+            break;
+
+        /* Site errors */
+        case TSK_ERR_UNSORTED_SITES:
+            ret = "Sites must be provided in strictly increasing position order";
+            break;
+        case TSK_ERR_DUPLICATE_SITE_POSITION:
+            ret = "Duplicate site positions";
+            break;
+        case TSK_ERR_BAD_SITE_POSITION:
+            ret = "Site positions must be between 0 and sequence_length";
+            break;
+
+        /* Mutation errors */
+        case TSK_ERR_MUTATION_PARENT_DIFFERENT_SITE:
+            ret = "Specified parent mutation is at a different site";
+            break;
+        case TSK_ERR_MUTATION_PARENT_EQUAL:
+            ret = "Parent mutation refers to itself";
+            break;
+        case TSK_ERR_MUTATION_PARENT_AFTER_CHILD:
+            ret = "Parent mutation ID must be < current ID";
+            break;
+        case TSK_ERR_INCONSISTENT_MUTATIONS:
+            ret = "Inconsistent mutations: state already equal to derived state";
+            break;
+        case TSK_ERR_UNSORTED_MUTATIONS:
+            ret = "Mutations must be provided in non-decreasing site order and "
+                  "non-increasing time order within each site";
+            break;
+        case TSK_ERR_MUTATION_TIME_YOUNGER_THAN_NODE:
+            ret = "A mutation's time must be >= the node time, or be marked as "
+                  "'unknown'";
+            break;
+        case TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_MUTATION:
+            ret = "A mutation's time must be <= the parent mutation time (if known), or "
+                  "be marked as 'unknown'";
+            break;
+        case TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_NODE:
+            ret = "A mutation's time must be < the parent node of the edge on which it "
+                  "occurs, or be marked as 'unknown'";
+            break;
+        case TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN:
+            ret = "Mutation times must either be all marked 'unknown', or all be known "
+                  "values for any single site.";
+            break;
+
+        /* Sample errors */
+        case TSK_ERR_DUPLICATE_SAMPLE:
+            ret = "Duplicate sample value";
+            break;
+        case TSK_ERR_BAD_SAMPLES:
+            ret = "Bad sample configuration provided";
+            break;
+
+        /* Table errors */
+        case TSK_ERR_BAD_TABLE_POSITION:
+            ret = "Bad table position provided to truncate/reset";
+            break;
+        case TSK_ERR_BAD_SEQUENCE_LENGTH:
+            ret = "Sequence length must be > 0";
+            break;
+        case TSK_ERR_TABLES_NOT_INDEXED:
+            ret = "Table collection must be indexed";
+            break;
+        case TSK_ERR_TABLE_OVERFLOW:
+            ret = "Table too large; cannot allocate more than 2**31 rows.";
+            break;
+        case TSK_ERR_COLUMN_OVERFLOW:
+            ret = "Table column too large; cannot be more than 2**32 bytes.";
+            break;
+        case TSK_ERR_TREE_OVERFLOW:
+            ret = "Too many trees; cannot be more than 2**31.";
+            break;
+        case TSK_ERR_METADATA_DISABLED:
+            ret = "Metadata is disabled for this table, so cannot be set";
+            break;
+
+        /* Limitations */
+        case TSK_ERR_ONLY_INFINITE_SITES:
+            ret = "Only infinite sites mutations are supported for this operation";
+            break;
+        case TSK_ERR_SIMPLIFY_MIGRATIONS_NOT_SUPPORTED:
+            ret = "Migrations not currently supported by simplify";
+            break;
+        case TSK_ERR_SORT_MIGRATIONS_NOT_SUPPORTED:
+            ret = "Migrations not currently supported by sort";
+            break;
+        case TSK_ERR_MIGRATIONS_NOT_SUPPORTED:
+            ret = "Migrations not currently supported by this operation";
+            break;
+        case TSK_ERR_SORT_OFFSET_NOT_SUPPORTED:
+            ret = "Sort offsets for sites and mutations must be either 0 "
+                  "or the length of the respective tables. Intermediate values "
+                  "are not supported";
+            break;
+        case TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED:
+            ret = "Only binary mutations are supported for this operation";
+            break;
+        case TSK_ERR_UNION_NOT_SUPPORTED:
+            ret = "Union is not supported for cases where there is non-shared"
+                  "history older than the shared history of the two Table Collections";
+            break;
+
+        /* Stats errors */
+        case TSK_ERR_BAD_NUM_WINDOWS:
+            ret = "Must have at least one window, [0, L]";
+            break;
+        case TSK_ERR_BAD_WINDOWS:
+            ret = "Windows must be increasing list [0, ..., L]";
+            break;
+        case TSK_ERR_MULTIPLE_STAT_MODES:
+            ret = "Cannot specify more than one stats mode.";
+            break;
+        case TSK_ERR_BAD_STATE_DIMS:
+            ret = "Must have state dimension >= 1";
+            break;
+        case TSK_ERR_BAD_RESULT_DIMS:
+            ret = "Must have result dimension >= 1";
+            break;
+        case TSK_ERR_INSUFFICIENT_SAMPLE_SETS:
+            ret = "Insufficient sample sets provided.";
+            break;
+        case TSK_ERR_INSUFFICIENT_INDEX_TUPLES:
+            ret = "Insufficient sample set index tuples provided.";
+            break;
+        case TSK_ERR_BAD_SAMPLE_SET_INDEX:
+            ret = "Sample set index out of bounds";
+            break;
+        case TSK_ERR_EMPTY_SAMPLE_SET:
+            ret = "Samples cannot be empty";
+            break;
+        case TSK_ERR_UNSUPPORTED_STAT_MODE:
+            ret = "Requested statistics mode not supported for this method.";
+            break;
+
+        /* Mutation mapping errors */
+        case TSK_ERR_GENOTYPES_ALL_MISSING:
+            ret = "Must provide at least one non-missing genotype.";
+            break;
+        case TSK_ERR_BAD_GENOTYPE:
+            ret = "Bad genotype value provided";
+            break;
+
+        /* Genotype decoding errors */
+        case TSK_ERR_TOO_MANY_ALLELES:
+            ret = "Cannot have more than 127 alleles";
+            break;
+        case TSK_ERR_ZERO_ALLELES:
+            ret = "Must have at least one allele when specifying an allele map";
+            break;
+        case TSK_ERR_MUST_IMPUTE_NON_SAMPLES:
+            ret = "Cannot generate genotypes for non-samples when isolated nodes are "
+                  "considered as missing";
+            break;
+        case TSK_ERR_ALLELE_NOT_FOUND:
+            ret = "An allele was not found in the user-specified allele map";
+            break;
+
+        /* Distance metric errors */
+        case TSK_ERR_SAMPLE_SIZE_MISMATCH:
+            ret = "Cannot compare trees with different numbers of samples.";
+            break;
+        case TSK_ERR_SAMPLES_NOT_EQUAL:
+            ret = "Samples must be identical in trees to compare.";
+            break;
+        case TSK_ERR_MULTIPLE_ROOTS:
+            ret = "Trees with multiple roots not supported.";
+            break;
+        case TSK_ERR_UNARY_NODES:
+            ret = "Unsimplified trees with unary nodes are not supported.";
+            break;
+        case TSK_ERR_SEQUENCE_LENGTH_MISMATCH:
+            ret = "Sequence lengths must be identical to compare.";
+            break;
+        case TSK_ERR_NO_SAMPLE_LISTS:
+            ret = "The sample_lists option must be enabled to perform this operation.";
+            break;
+
+        /* Haplotype matching errors */
+        case TSK_ERR_NULL_VITERBI_MATRIX:
+            ret = "Viterbi matrix has not filled.";
+            break;
+        case TSK_ERR_MATCH_IMPOSSIBLE:
+            ret = "No matching haplotype exists with current parameters";
+            break;
+        case TSK_ERR_BAD_COMPRESSED_MATRIX_NODE:
+            ret = "The compressed matrix contains a node that subtends no samples";
+            break;
+        case TSK_ERR_TOO_MANY_VALUES:
+            ret = "Too many values to compress";
+            break;
+
+        /* Union errors */
+        case TSK_ERR_UNION_BAD_MAP:
+            ret = "Node map contains an entry of a node not present in this table "
+                  "collection.";
+            break;
+        case TSK_ERR_UNION_DIFF_HISTORIES:
+            // histories could be equivalent, because subset does not reorder
+            // edges (if not sorted) or mutations.
+            ret = "Shared portions of the tree sequences are not equal.";
+            break;
+
+        /* IBD errors */
+        case TSK_ERR_NO_SAMPLE_PAIRS:
+            ret = "There are no possible sample pairs.";
+            break;
+
+        case TSK_ERR_DUPLICATE_SAMPLE_PAIRS:
+            ret = "There are duplicate sample pairs.";
+            break;
+    }
+    return ret;
+}
+
+int
+tsk_set_kas_error(int err)
+{
+    if (err == KAS_ERR_IO) {
+        /* If we've detected an IO error, report it as TSK_ERR_IO so that we have
+         * a consistent error code covering these situtations */
+        return TSK_ERR_IO;
+    } else {
+        /* Flip this bit. As the error is negative, this sets the bit to 0 */
+        return err ^ (1 << TSK_KAS_ERR_BIT);
+    }
+}
+
+bool
+tsk_is_kas_error(int err)
+{
+    return !(err & (1 << TSK_KAS_ERR_BIT));
+}
+
+const char *
+tsk_strerror(int err)
+{
+    if (err != 0 && tsk_is_kas_error(err)) {
+        err ^= (1 << TSK_KAS_ERR_BIT);
+        return kas_strerror(err);
+    } else {
+        return tsk_strerror_internal(err);
+    }
+}
+
+void
+__tsk_safe_free(void **ptr)
+{
+    if (ptr != NULL) {
+        if (*ptr != NULL) {
+            free(*ptr);
+            *ptr = NULL;
+        }
+    }
+}
+
+/* Block allocator. Simple allocator when we lots of chunks of memory
+ * and don't need to free them individually.
+ */
+
+void
+tsk_blkalloc_print_state(tsk_blkalloc_t *self, FILE *out)
+{
+    fprintf(out, "Block allocator%p::\n", (void *) self);
+    fprintf(out, "\ttop = %d\n", (int) self->top);
+    fprintf(out, "\tchunk_size = %d\n", (int) self->chunk_size);
+    fprintf(out, "\tnum_chunks = %d\n", (int) self->num_chunks);
+    fprintf(out, "\ttotal_allocated = %d\n", (int) self->total_allocated);
+    fprintf(out, "\ttotal_size = %d\n", (int) self->total_size);
+}
+
+int TSK_WARN_UNUSED
+tsk_blkalloc_reset(tsk_blkalloc_t *self)
+{
+    int ret = 0;
+
+    self->top = 0;
+    self->current_chunk = 0;
+    self->total_allocated = 0;
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_blkalloc_init(tsk_blkalloc_t *self, size_t chunk_size)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_blkalloc_t));
+    if (chunk_size < 1) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    self->chunk_size = chunk_size;
+    self->top = 0;
+    self->current_chunk = 0;
+    self->total_allocated = 0;
+    self->total_size = 0;
+    self->num_chunks = 0;
+    self->mem_chunks = malloc(sizeof(char *));
+    if (self->mem_chunks == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    self->mem_chunks[0] = malloc(chunk_size);
+    if (self->mem_chunks[0] == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    self->num_chunks = 1;
+    self->total_size = chunk_size + sizeof(void *);
+out:
+    return ret;
+}
+
+void *TSK_WARN_UNUSED
+tsk_blkalloc_get(tsk_blkalloc_t *self, size_t size)
+{
+    void *ret = NULL;
+    void *p;
+
+    if (size > self->chunk_size) {
+        goto out;
+    }
+    if ((self->top + size) > self->chunk_size) {
+        if (self->current_chunk == (self->num_chunks - 1)) {
+            p = realloc(self->mem_chunks, (self->num_chunks + 1) * sizeof(void *));
+            if (p == NULL) {
+                goto out;
+            }
+            self->mem_chunks = p;
+            p = malloc(self->chunk_size);
+            if (p == NULL) {
+                goto out;
+            }
+            self->mem_chunks[self->num_chunks] = p;
+            self->num_chunks++;
+            self->total_size += self->chunk_size + sizeof(void *);
+        }
+        self->current_chunk++;
+        self->top = 0;
+    }
+    ret = self->mem_chunks[self->current_chunk] + self->top;
+    self->top += size;
+    self->total_allocated += size;
+out:
+    return ret;
+}
+
+void
+tsk_blkalloc_free(tsk_blkalloc_t *self)
+{
+    size_t j;
+
+    for (j = 0; j < self->num_chunks; j++) {
+        if (self->mem_chunks[j] != NULL) {
+            free(self->mem_chunks[j]);
+        }
+    }
+    if (self->mem_chunks != NULL) {
+        free(self->mem_chunks);
+    }
+}
+
+/* Mirrors the semantics of numpy's searchsorted function. Uses binary
+ * search to find the index of the closest value in the array. */
+size_t
+tsk_search_sorted(const double *restrict array, size_t size, double value)
+{
+    int64_t upper = (int64_t) size;
+    int64_t lower = 0;
+    int64_t offset = 0;
+    int64_t mid;
+
+    if (upper == 0) {
+        return 0;
+    }
+
+    while (upper - lower > 1) {
+        mid = (upper + lower) / 2;
+        if (value >= array[mid]) {
+            lower = mid;
+        } else {
+            upper = mid;
+        }
+    }
+    offset = (int64_t)(array[lower] < value);
+    return (size_t)(lower + offset);
+}
+
+/* Rounds the specified double to the closest multiple of 10**-num_digits. If
+ * num_digits > 22, return value without changes. This is intended for use with
+ * small positive numbers; behaviour with large inputs has not been considered.
+ *
+ * Based on double_round from the Python standard library
+ * https://github.com/python/cpython/blob/master/Objects/floatobject.c#L985
+ */
+double
+tsk_round(double x, unsigned int ndigits)
+{
+    double pow1, y, z;
+
+    z = x;
+    if (ndigits < 22) {
+        pow1 = pow(10.0, (double) ndigits);
+        y = x * pow1;
+        z = round(y);
+        if (fabs(y - z) == 0.5) {
+            /* halfway between two integers; use round-half-even */
+            z = 2.0 * round(y / 2.0);
+        }
+        z = z / pow1;
+    }
+    return z;
+}
+
+/* As NANs are not equal, use this function to check for equality to TSK_UNKNOWN_TIME */
+bool
+tsk_is_unknown_time(double val)
+{
+    union {
+        uint64_t i;
+        double f;
+    } nan_union;
+    nan_union.f = val;
+    return nan_union.i == TSK_UNKNOWN_TIME_HEX;
+}

--- a/subprojects/tskit/tskit/core.h
+++ b/subprojects/tskit/tskit/core.h
@@ -1,0 +1,409 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 Tskit Developers
+ * Copyright (c) 2015-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file core.h
+ * @brief Core utilities used in all of tskit.
+ */
+#ifndef __TSK_CORE_H__
+#define __TSK_CORE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <limits.h>
+
+#if defined(_TSK_WORKAROUND_FALSE_CLANG_WARNING) && defined(__clang__)
+/* Work around bug in clang >= 6.0, https://github.com/tskit-dev/tskit/issues/721
+ * (note: fixed in clang January 2019)
+ * This workaround does some nasty fiddling with builtins and is only intended to
+ * be used within the library. To turn it on, make sure
+ * _TSK_WORKAROUND_FALSE_CLANG_WARNING is defined before including any tskit
+ * headers.
+ */
+#if __has_builtin(__builtin_isnan)
+#undef isnan
+#define isnan __builtin_isnan
+#else
+abort();
+#endif
+#if __has_builtin(__builtin_isfinite)
+#undef isfinite
+#define isfinite __builtin_isfinite
+#else
+abort();
+#endif
+#endif
+
+#ifdef __GNUC__
+#define TSK_WARN_UNUSED __attribute__((warn_unused_result))
+#define TSK_UNUSED(x) TSK_UNUSED_##x __attribute__((__unused__))
+#else
+#define TSK_WARN_UNUSED
+#define TSK_UNUSED(x) TSK_UNUSED_##x
+/* Don't bother with restrict for MSVC */
+#define restrict
+#endif
+
+/* We assume CHAR_BIT == 8 when loading strings from 8-bit byte arrays */
+#if CHAR_BIT != 8
+#error CHAR_BIT MUST EQUAL 8
+#endif
+
+/* This sets up TSK_DBL_DECIMAL_DIG, which can then be used as a
+ * precision specifier when writing out doubles, if you want sufficient
+ * decimal digits to be written to guarantee a lossless round-trip
+ * after being read back in.  Usage:
+ *
+ *     printf("%.*g", TSK_DBL_DECIMAL_DIG, foo);
+ *
+ * See https://stackoverflow.com/a/19897395/2752221
+ */
+#ifdef DBL_DECIMAL_DIG
+#define TSK_DBL_DECIMAL_DIG (DBL_DECIMAL_DIG)
+#else
+#define TSK_DBL_DECIMAL_DIG (DBL_DIG + 3)
+#endif
+
+/* We define a specific NAN value for default mutation time which indicates
+ * the time is unknown. We use a specific value so that if mutation time is set to
+ * a NAN from a computation we can reject it. This specific value is a non-signalling
+ * NAN with the last six fraction bytes set to the ascii of "tskit!"
+ */
+#define TSK_UNKNOWN_TIME_HEX 0x7FF874736B697421ULL
+static inline double
+__tsk_nan_f(void)
+{
+    const union {
+        uint64_t i;
+        double f;
+    } nan_union = { .i = TSK_UNKNOWN_TIME_HEX };
+    return nan_union.f;
+}
+#define TSK_UNKNOWN_TIME __tsk_nan_f()
+
+// clang-format off
+/**
+@defgroup API_VERSION_GROUP API version macros.
+@{
+*/
+/**
+The library major version. Incremented when breaking changes to the API or ABI are
+introduced. This includes any changes to the signatures of functions and the
+sizes and types of externally visible structs.
+*/
+#define TSK_VERSION_MAJOR   0
+/**
+The library major version. Incremented when non-breaking backward-compatible changes
+to the API or ABI are introduced, i.e., the addition of a new function.
+*/
+#define TSK_VERSION_MINOR   99
+/**
+The library patch version. Incremented when any changes not relevant to the
+to the API or ABI are introduced, i.e., internal refactors of bugfixes.
+*/
+#define TSK_VERSION_PATCH   9
+/** @} */
+
+/* Node flags */
+#define TSK_NODE_IS_SAMPLE 1u
+
+/* The null ID */
+#define TSK_NULL ((tsk_id_t) -1)
+
+/* Missing data in an array of genotypes */
+#define TSK_MISSING_DATA    (-1)
+
+#define TSK_FILE_FORMAT_NAME          "tskit.trees"
+#define TSK_FILE_FORMAT_NAME_LENGTH   11
+#define TSK_FILE_FORMAT_VERSION_MAJOR 12
+#define TSK_FILE_FORMAT_VERSION_MINOR 3
+
+/**
+@defgroup GENERAL_ERROR_GROUP General errors.
+@{
+*/
+
+/**
+Generic error thrown when no other message can be generated.
+*/
+#define TSK_ERR_GENERIC                                             -1
+/**
+Memory could not be allocated.
+*/
+#define TSK_ERR_NO_MEMORY                                           -2
+/**
+An IO error occured.
+*/
+#define TSK_ERR_IO                                                  -3
+#define TSK_ERR_BAD_PARAM_VALUE                                     -4
+#define TSK_ERR_BUFFER_OVERFLOW                                     -5
+#define TSK_ERR_UNSUPPORTED_OPERATION                               -6
+#define TSK_ERR_GENERATE_UUID                                       -7
+/**
+The file stream ended after reading zero bytes.
+*/
+#define TSK_ERR_EOF                                                 -8
+/** @} */
+
+/**
+@defgroup FILE_FORMAT_ERROR_GROUP File format errors.
+@{
+*/
+
+/**
+A file could not be read because it is in the wrong format
+*/
+#define TSK_ERR_FILE_FORMAT                                         -100
+/**
+The file is in tskit format, but the version is too old for the
+library to read. The file should be upgraded to the latest version
+using the ``tskit upgrade`` command line utility.
+*/
+#define TSK_ERR_FILE_VERSION_TOO_OLD                                -101
+/**
+The file is in tskit format, but the version is too new for the
+library to read. To read the file you must upgrade the version
+of tskit.
+*/
+#define TSK_ERR_FILE_VERSION_TOO_NEW                                -102
+/** @} */
+
+/**
+A column that is a required member of a table was not found in
+the file.
+*/
+#define TSK_ERR_REQUIRED_COL_NOT_FOUND                              -103
+
+/**
+One of a pair of columns that must be specified together was
+not found in the file.
+*/
+#define TSK_ERR_BOTH_COLUMNS_REQUIRED                               -104
+
+/* Out of bounds errors */
+#define TSK_ERR_BAD_OFFSET                                          -200
+#define TSK_ERR_OUT_OF_BOUNDS                                       -201
+#define TSK_ERR_NODE_OUT_OF_BOUNDS                                  -202
+#define TSK_ERR_EDGE_OUT_OF_BOUNDS                                  -203
+#define TSK_ERR_POPULATION_OUT_OF_BOUNDS                            -204
+#define TSK_ERR_SITE_OUT_OF_BOUNDS                                  -205
+#define TSK_ERR_MUTATION_OUT_OF_BOUNDS                              -206
+#define TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS                            -207
+#define TSK_ERR_MIGRATION_OUT_OF_BOUNDS                             -208
+#define TSK_ERR_PROVENANCE_OUT_OF_BOUNDS                            -209
+#define TSK_ERR_TIME_NONFINITE                                      -210
+#define TSK_ERR_GENOME_COORDS_NONFINITE                             -211
+
+/* Edge errors */
+#define TSK_ERR_NULL_PARENT                                         -300
+#define TSK_ERR_NULL_CHILD                                          -301
+#define TSK_ERR_EDGES_NOT_SORTED_PARENT_TIME                        -302
+#define TSK_ERR_EDGES_NONCONTIGUOUS_PARENTS                         -303
+#define TSK_ERR_EDGES_NOT_SORTED_CHILD                              -304
+#define TSK_ERR_EDGES_NOT_SORTED_LEFT                               -305
+#define TSK_ERR_BAD_NODE_TIME_ORDERING                              -306
+#define TSK_ERR_BAD_EDGE_INTERVAL                                   -307
+#define TSK_ERR_DUPLICATE_EDGES                                     -308
+#define TSK_ERR_RIGHT_GREATER_SEQ_LENGTH                            -309
+#define TSK_ERR_LEFT_LESS_ZERO                                      -310
+#define TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN                    -311
+#define TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA                    -312
+
+/* Site errors */
+#define TSK_ERR_UNSORTED_SITES                                      -400
+#define TSK_ERR_DUPLICATE_SITE_POSITION                             -401
+#define TSK_ERR_BAD_SITE_POSITION                                   -402
+
+/* Mutation errors */
+#define TSK_ERR_MUTATION_PARENT_DIFFERENT_SITE                      -500
+#define TSK_ERR_MUTATION_PARENT_EQUAL                               -501
+#define TSK_ERR_MUTATION_PARENT_AFTER_CHILD                         -502
+#define TSK_ERR_INCONSISTENT_MUTATIONS                              -503
+#define TSK_ERR_UNSORTED_MUTATIONS                                  -505
+#define TSK_ERR_NON_SINGLE_CHAR_MUTATION                            -506
+#define TSK_ERR_MUTATION_TIME_YOUNGER_THAN_NODE                     -507
+#define TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_MUTATION            -508
+#define TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_NODE                -509
+#define TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN            -510
+
+/* Sample errors */
+#define TSK_ERR_DUPLICATE_SAMPLE                                    -600
+#define TSK_ERR_BAD_SAMPLES                                         -601
+
+/* Table errors */
+#define TSK_ERR_BAD_TABLE_POSITION                                  -700
+#define TSK_ERR_BAD_SEQUENCE_LENGTH                                 -701
+#define TSK_ERR_TABLES_NOT_INDEXED                                  -702
+#define TSK_ERR_TABLE_OVERFLOW                                      -703
+#define TSK_ERR_COLUMN_OVERFLOW                                     -704
+#define TSK_ERR_TREE_OVERFLOW                                       -705
+#define TSK_ERR_METADATA_DISABLED                                   -706
+
+/* Limitations */
+#define TSK_ERR_ONLY_INFINITE_SITES                                 -800
+#define TSK_ERR_SIMPLIFY_MIGRATIONS_NOT_SUPPORTED                   -801
+#define TSK_ERR_SORT_MIGRATIONS_NOT_SUPPORTED                       -802
+#define TSK_ERR_SORT_OFFSET_NOT_SUPPORTED                           -803
+#define TSK_ERR_NONBINARY_MUTATIONS_UNSUPPORTED                     -804
+#define TSK_ERR_MIGRATIONS_NOT_SUPPORTED                            -805
+#define TSK_ERR_UNION_NOT_SUPPORTED                                 -806
+
+/* Stats errors */
+#define TSK_ERR_BAD_NUM_WINDOWS                                     -900
+#define TSK_ERR_BAD_WINDOWS                                         -901
+#define TSK_ERR_MULTIPLE_STAT_MODES                                 -902
+#define TSK_ERR_BAD_STATE_DIMS                                      -903
+#define TSK_ERR_BAD_RESULT_DIMS                                     -904
+#define TSK_ERR_INSUFFICIENT_SAMPLE_SETS                            -905
+#define TSK_ERR_INSUFFICIENT_INDEX_TUPLES                           -906
+#define TSK_ERR_BAD_SAMPLE_SET_INDEX                                -907
+#define TSK_ERR_EMPTY_SAMPLE_SET                                    -908
+#define TSK_ERR_UNSUPPORTED_STAT_MODE                               -909
+
+/* Mutation mapping errors */
+#define TSK_ERR_GENOTYPES_ALL_MISSING                              -1000
+#define TSK_ERR_BAD_GENOTYPE                                       -1001
+
+/* Genotype decoding errors */
+#define TSK_ERR_MUST_IMPUTE_NON_SAMPLES                            -1100
+#define TSK_ERR_ALLELE_NOT_FOUND                                   -1101
+#define TSK_ERR_TOO_MANY_ALLELES                                   -1102
+#define TSK_ERR_ZERO_ALLELES                                       -1103
+
+/* Distance metric errors */
+#define TSK_ERR_SAMPLE_SIZE_MISMATCH                               -1200
+#define TSK_ERR_SAMPLES_NOT_EQUAL                                  -1201
+#define TSK_ERR_MULTIPLE_ROOTS                                     -1202
+#define TSK_ERR_UNARY_NODES                                        -1203
+#define TSK_ERR_SEQUENCE_LENGTH_MISMATCH                           -1204
+#define TSK_ERR_NO_SAMPLE_LISTS                                    -1205
+
+/* Haplotype matching errors */
+#define TSK_ERR_NULL_VITERBI_MATRIX                                -1300
+#define TSK_ERR_MATCH_IMPOSSIBLE                                   -1301
+#define TSK_ERR_BAD_COMPRESSED_MATRIX_NODE                         -1302
+#define TSK_ERR_TOO_MANY_VALUES                                    -1303
+
+/* Union errors */
+#define TSK_ERR_UNION_BAD_MAP                                      -1400
+#define TSK_ERR_UNION_DIFF_HISTORIES                               -1401
+
+/* IBD errors */
+#define TSK_ERR_NO_SAMPLE_PAIRS                                    -1500
+#define TSK_ERR_DUPLICATE_SAMPLE_PAIRS                             -1501
+
+// clang-format on
+
+/* This bit is 0 for any errors originating from kastore */
+#define TSK_KAS_ERR_BIT 14
+
+int tsk_set_kas_error(int err);
+bool tsk_is_kas_error(int err);
+
+/**
+@brief Return a description of the specified error.
+
+The memory for the returned string is handled by the library and should
+not be freed by client code.
+
+@param err A tskit error code.
+@return A description of the error.
+*/
+const char *tsk_strerror(int err);
+
+#ifndef TSK_BUG_ASSERT_MESSAGE
+#define TSK_BUG_ASSERT_MESSAGE                                                          \
+    "If you are using tskit directly please open an issue on"                           \
+    " GitHub, ideally with a reproducible example."                                     \
+    " (https://github.com/tskit-dev/tskit/issues) If you are"                           \
+    " using software that uses tskit, please report an issue"                           \
+    " to that software's issue tracker, at least initially."
+#endif
+
+/**
+We often wish to assert a condition that is unexpected, but using the normal `assert`
+means compiling without NDEBUG. This macro still asserts when NDEBUG is defined.
+If you are using this macro in your own software then please set TSK_BUG_ASSERT_MESSAGE
+to point users to your issue tracker.
+*/
+#define tsk_bug_assert(condition)                                                       \
+    do {                                                                                \
+        if (!(condition)) {                                                             \
+            fprintf(stderr, "Bug detected in %s at line %d. %s\n", __FILE__, __LINE__,  \
+                TSK_BUG_ASSERT_MESSAGE);                                                \
+            abort();                                                                    \
+        }                                                                               \
+    } while (0)
+
+void __tsk_safe_free(void **ptr);
+#define tsk_safe_free(pointer) __tsk_safe_free((void **) &(pointer))
+
+#define TSK_MAX(a, b) ((a) > (b) ? (a) : (b))
+#define TSK_MIN(a, b) ((a) < (b) ? (a) : (b))
+
+/* This is a simple allocator that is optimised to efficiently allocate a
+ * large number of small objects without large numbers of calls to malloc.
+ * The allocator mallocs memory in chunks of a configurable size. When
+ * responding to calls to get(), it will return a chunk of this memory.
+ * This memory cannot be subsequently handed back to the allocator. However,
+ * all memory allocated by the allocator can be returned at once by calling
+ * reset.
+ */
+
+typedef struct {
+    size_t chunk_size; /* number of bytes per chunk */
+    size_t top;        /* the offset of the next available byte in the current chunk */
+    size_t current_chunk;   /* the index of the chunk currently being used */
+    size_t total_size;      /* the total number of bytes allocated + overhead. */
+    size_t total_allocated; /* the total number of bytes allocated. */
+    size_t num_chunks;      /* the number of memory chunks. */
+    char **mem_chunks;      /* the memory chunks */
+} tsk_blkalloc_t;
+
+extern void tsk_blkalloc_print_state(tsk_blkalloc_t *self, FILE *out);
+extern int tsk_blkalloc_reset(tsk_blkalloc_t *self);
+extern int tsk_blkalloc_init(tsk_blkalloc_t *self, size_t chunk_size);
+extern void *tsk_blkalloc_get(tsk_blkalloc_t *self, size_t size);
+extern void tsk_blkalloc_free(tsk_blkalloc_t *self);
+
+size_t tsk_search_sorted(const double *array, size_t size, double value);
+double tsk_round(double x, unsigned int ndigits);
+
+bool tsk_is_unknown_time(double val);
+
+#define TSK_UUID_SIZE 36
+int tsk_generate_uuid(char *dest, int flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/subprojects/tskit/tskit/genotypes.c
+++ b/subprojects/tskit/tskit/genotypes.c
@@ -1,0 +1,664 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2016-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <tskit/genotypes.h>
+
+/* ======================================================== *
+ * Variant generator
+ * ======================================================== */
+
+void
+tsk_vargen_print_state(const tsk_vargen_t *self, FILE *out)
+{
+    tsk_size_t j;
+
+    fprintf(out, "tsk_vargen state\n");
+    fprintf(out, "tree_index = %d\n", self->tree.index);
+    fprintf(out, "tree_site_index = %d\n", (int) self->tree_site_index);
+    fprintf(out, "user_alleles = %d\n", self->user_alleles);
+    fprintf(out, "num_alleles = %d\n", self->variant.num_alleles);
+    for (j = 0; j < self->variant.num_alleles; j++) {
+        fprintf(out, "\tlen = %d, '%.*s'\n", self->variant.allele_lengths[j],
+            self->variant.allele_lengths[j], self->variant.alleles[j]);
+    }
+    fprintf(out, "num_samples = %d\n", (int) self->num_samples);
+    for (j = 0; j < tsk_treeseq_get_num_nodes(self->tree_sequence); j++) {
+        fprintf(out, "\t%d -> %d\n", (int) j, (int) self->sample_index_map[j]);
+    }
+}
+
+static int
+tsk_vargen_next_tree(tsk_vargen_t *self)
+{
+    int ret = 0;
+
+    ret = tsk_tree_next(&self->tree);
+    if (ret == 0) {
+        self->finished = 1;
+    } else if (ret < 0) {
+        goto out;
+    }
+    self->tree_site_index = 0;
+out:
+    return ret;
+}
+
+/* Copy the fixed allele mapping specified by the user into local
+ * memory. */
+static int
+tsk_vargen_copy_alleles(tsk_vargen_t *self, const char **alleles)
+{
+    int ret = 0;
+    tsk_size_t j;
+    size_t total_len, allele_len, offset;
+
+    self->variant.num_alleles = self->variant.max_alleles;
+
+    total_len = 0;
+    for (j = 0; j < self->variant.num_alleles; j++) {
+        allele_len = strlen(alleles[j]);
+        self->variant.allele_lengths[j] = (tsk_size_t) allele_len;
+        total_len += allele_len;
+    }
+    self->user_alleles_mem = malloc(total_len * sizeof(char *));
+    if (self->user_alleles_mem == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    offset = 0;
+    for (j = 0; j < self->variant.num_alleles; j++) {
+        strcpy(self->user_alleles_mem + offset, alleles[j]);
+        self->variant.alleles[j] = self->user_alleles_mem + offset;
+        offset += self->variant.allele_lengths[j];
+    }
+out:
+    return ret;
+}
+
+static int
+vargen_init_samples_and_index_map(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
+    const tsk_id_t *samples, size_t num_samples, size_t num_samples_alloc,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    const tsk_flags_t *flags = tree_sequence->tables->nodes.flags;
+    size_t j, num_nodes;
+    bool impute_missing = !!(options & TSK_ISOLATED_NOT_MISSING);
+    tsk_id_t u;
+
+    num_nodes = tsk_treeseq_get_num_nodes(tree_sequence);
+    self->alt_samples = malloc(num_samples_alloc * sizeof(*samples));
+    self->alt_sample_index_map = malloc(num_nodes * sizeof(*self->alt_sample_index_map));
+    if (self->alt_samples == NULL || self->alt_sample_index_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(self->alt_samples, samples, num_samples * sizeof(*samples));
+    memset(self->alt_sample_index_map, 0xff,
+        num_nodes * sizeof(*self->alt_sample_index_map));
+    /* Create the reverse mapping */
+    for (j = 0; j < num_samples; j++) {
+        u = samples[j];
+        if (u < 0 || u >= (tsk_id_t) num_nodes) {
+            ret = TSK_ERR_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (self->alt_sample_index_map[u] != TSK_NULL) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        /* We can only detect missing data for samples */
+        if (!impute_missing && !(flags[u] & TSK_NODE_IS_SAMPLE)) {
+            ret = TSK_ERR_MUST_IMPUTE_NON_SAMPLES;
+            goto out;
+        }
+        self->alt_sample_index_map[samples[j]] = (tsk_id_t) j;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
+    const tsk_id_t *samples, size_t num_samples, const char **alleles,
+    tsk_flags_t options)
+{
+    int ret = TSK_ERR_NO_MEMORY;
+    tsk_flags_t tree_options;
+    size_t num_samples_alloc, max_alleles_limit;
+    tsk_size_t max_alleles;
+
+    tsk_bug_assert(tree_sequence != NULL);
+    memset(self, 0, sizeof(tsk_vargen_t));
+
+    if (samples == NULL) {
+        self->num_samples = tsk_treeseq_get_num_samples(tree_sequence);
+        self->sample_index_map = tsk_treeseq_get_sample_index_map(tree_sequence);
+        num_samples_alloc = self->num_samples;
+    } else {
+        /* Take a copy of the samples for simplicity */
+        /* We can have num_samples = 0 here, so guard against malloc(0) */
+        num_samples_alloc = num_samples + 1;
+        ret = vargen_init_samples_and_index_map(
+            self, tree_sequence, samples, num_samples, num_samples_alloc, options);
+        if (ret != 0) {
+            goto out;
+        }
+        self->num_samples = num_samples;
+        self->sample_index_map = self->alt_sample_index_map;
+    }
+    self->num_sites = tsk_treeseq_get_num_sites(tree_sequence);
+    self->tree_sequence = tree_sequence;
+    self->options = options;
+    if (self->options & TSK_16_BIT_GENOTYPES) {
+        self->variant.genotypes.i16
+            = malloc(num_samples_alloc * sizeof(*self->variant.genotypes.i16));
+        max_alleles_limit = INT16_MAX;
+    } else {
+        self->variant.genotypes.i8
+            = malloc(num_samples_alloc * sizeof(*self->variant.genotypes.i8));
+        max_alleles_limit = INT8_MAX;
+    }
+
+    if (alleles == NULL) {
+        self->user_alleles = false;
+        max_alleles = 4; /* Arbitrary --- we'll rarely have more than this */
+    } else {
+        self->user_alleles = true;
+        /* Count the input alleles. The end is designated by the NULL sentinel. */
+        for (max_alleles = 0; alleles[max_alleles] != NULL; max_alleles++)
+            ;
+        if (max_alleles > max_alleles_limit) {
+            ret = TSK_ERR_TOO_MANY_ALLELES;
+            goto out;
+        }
+        if (max_alleles == 0) {
+            ret = TSK_ERR_ZERO_ALLELES;
+            goto out;
+        }
+    }
+    self->variant.max_alleles = max_alleles;
+    self->variant.alleles = calloc(max_alleles, sizeof(*self->variant.alleles));
+    self->variant.allele_lengths
+        = malloc(max_alleles * sizeof(*self->variant.allele_lengths));
+    /* Because genotypes is a union we can check the pointer */
+    if (self->variant.genotypes.i8 == NULL || self->variant.alleles == NULL
+        || self->variant.allele_lengths == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    if (self->user_alleles) {
+        ret = tsk_vargen_copy_alleles(self, alleles);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    /* When a list of samples is given, we use the traversal based algorithm
+     * and turn off the sample list tracking in the tree */
+    tree_options = 0;
+    if (self->alt_samples == NULL) {
+        tree_options = TSK_SAMPLE_LISTS;
+    } else {
+        self->traversal_stack = malloc(
+            tsk_treeseq_get_num_nodes(tree_sequence) * sizeof(*self->traversal_stack));
+        if (self->traversal_stack == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+    }
+
+    ret = tsk_tree_init(&self->tree, tree_sequence, tree_options);
+    if (ret != 0) {
+        goto out;
+    }
+    self->finished = 0;
+    self->tree_site_index = 0;
+    ret = tsk_tree_first(&self->tree);
+    if (ret < 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+int
+tsk_vargen_free(tsk_vargen_t *self)
+{
+    tsk_tree_free(&self->tree);
+    tsk_safe_free(self->variant.genotypes.i8);
+    tsk_safe_free(self->variant.alleles);
+    tsk_safe_free(self->variant.allele_lengths);
+    tsk_safe_free(self->user_alleles_mem);
+    tsk_safe_free(self->alt_samples);
+    tsk_safe_free(self->alt_sample_index_map);
+    tsk_safe_free(self->traversal_stack);
+    return 0;
+}
+
+static int
+tsk_vargen_expand_alleles(tsk_vargen_t *self)
+{
+    int ret = 0;
+    tsk_variant_t *var = &self->variant;
+    void *p;
+    tsk_size_t hard_limit = INT8_MAX;
+
+    if (self->options & TSK_16_BIT_GENOTYPES) {
+        hard_limit = INT16_MAX;
+    }
+    if (var->max_alleles == hard_limit) {
+        ret = TSK_ERR_TOO_MANY_ALLELES;
+        goto out;
+    }
+    var->max_alleles = TSK_MIN(hard_limit, var->max_alleles * 2);
+    p = realloc(var->alleles, var->max_alleles * sizeof(*var->alleles));
+    if (p == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    var->alleles = p;
+    p = realloc(var->allele_lengths, var->max_alleles * sizeof(*var->allele_lengths));
+    if (p == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    var->allele_lengths = p;
+out:
+    return ret;
+}
+
+/* The following pair of functions are identical except one handles 8 bit
+ * genotypes and the other handles 16 bit genotypes. This is done for performance
+ * reasons as this is a key function and for common alleles can entail
+ * iterating over millions of samples. The compiler hints are included for the
+ * same reason.
+ */
+static int TSK_WARN_UNUSED
+tsk_vargen_update_genotypes_i8_sample_list(
+    tsk_vargen_t *self, tsk_id_t node, tsk_id_t derived)
+{
+    int8_t *restrict genotypes = self->variant.genotypes.i8;
+    const tsk_id_t *restrict list_left = self->tree.left_sample;
+    const tsk_id_t *restrict list_right = self->tree.right_sample;
+    const tsk_id_t *restrict list_next = self->tree.next_sample;
+    tsk_id_t index, stop;
+    int ret = 0;
+
+    tsk_bug_assert(derived < INT8_MAX);
+
+    index = list_left[node];
+    if (index != TSK_NULL) {
+        stop = list_right[node];
+        while (true) {
+            if (genotypes[index] == (int8_t) derived) {
+                ret = TSK_ERR_INCONSISTENT_MUTATIONS;
+                goto out;
+            }
+            ret += genotypes[index] == TSK_MISSING_DATA;
+            genotypes[index] = (int8_t) derived;
+            if (index == stop) {
+                break;
+            }
+            index = list_next[index];
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_vargen_update_genotypes_i16_sample_list(
+    tsk_vargen_t *self, tsk_id_t node, tsk_id_t derived)
+{
+    int16_t *restrict genotypes = self->variant.genotypes.i16;
+    const tsk_id_t *restrict list_left = self->tree.left_sample;
+    const tsk_id_t *restrict list_right = self->tree.right_sample;
+    const tsk_id_t *restrict list_next = self->tree.next_sample;
+    tsk_id_t index, stop;
+    int ret = 0;
+
+    tsk_bug_assert(derived < INT16_MAX);
+
+    index = list_left[node];
+    if (index != TSK_NULL) {
+        stop = list_right[node];
+        while (true) {
+            if (genotypes[index] == (int16_t) derived) {
+                ret = TSK_ERR_INCONSISTENT_MUTATIONS;
+                goto out;
+            }
+            ret += genotypes[index] == TSK_MISSING_DATA;
+            genotypes[index] = (int16_t) derived;
+            if (index == stop) {
+                break;
+            }
+            index = list_next[index];
+        }
+    }
+out:
+    return ret;
+}
+
+/* The following functions implement the genotype setting by traversing
+ * down the tree to the samples. We're not so worried about performance here
+ * because this should only be used when we have a very small number of samples,
+ * and so we use a visit function to avoid duplicating code.
+ */
+
+typedef int (*visit_func_t)(tsk_vargen_t *, tsk_id_t, tsk_id_t);
+
+static int TSK_WARN_UNUSED
+tsk_vargen_traverse(
+    tsk_vargen_t *self, tsk_id_t node, tsk_id_t derived, visit_func_t visit)
+{
+    int ret = 0;
+    tsk_id_t *restrict stack = self->traversal_stack;
+    const tsk_id_t *restrict left_child = self->tree.left_child;
+    const tsk_id_t *restrict right_sib = self->tree.right_sib;
+    const tsk_id_t *restrict sample_index_map = self->sample_index_map;
+    tsk_id_t u, v, sample_index;
+    int stack_top;
+    int no_longer_missing = 0;
+
+    stack_top = 0;
+    stack[0] = node;
+    while (stack_top >= 0) {
+        u = stack[stack_top];
+        sample_index = sample_index_map[u];
+        if (sample_index != TSK_NULL) {
+            ret = visit(self, sample_index, derived);
+            if (ret < 0) {
+                goto out;
+            }
+            no_longer_missing += ret;
+        }
+        stack_top--;
+        for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
+            stack_top++;
+            stack[stack_top] = v;
+        }
+    }
+    ret = no_longer_missing;
+out:
+    return ret;
+}
+
+static int
+tsk_vargen_visit_i8(tsk_vargen_t *self, tsk_id_t sample_index, tsk_id_t derived)
+{
+    int ret = 0;
+    int8_t *restrict genotypes = self->variant.genotypes.i8;
+
+    tsk_bug_assert(derived < INT8_MAX);
+    tsk_bug_assert(sample_index != -1);
+    if (genotypes[sample_index] == (int8_t) derived) {
+        ret = TSK_ERR_INCONSISTENT_MUTATIONS;
+        goto out;
+    }
+    ret = genotypes[sample_index] == TSK_MISSING_DATA;
+    genotypes[sample_index] = (int8_t) derived;
+out:
+    return ret;
+}
+
+static int
+tsk_vargen_visit_i16(tsk_vargen_t *self, tsk_id_t sample_index, tsk_id_t derived)
+{
+    int ret = 0;
+    int16_t *restrict genotypes = self->variant.genotypes.i16;
+
+    tsk_bug_assert(derived < INT16_MAX);
+    tsk_bug_assert(sample_index != -1);
+    if (genotypes[sample_index] == (int16_t) derived) {
+        ret = TSK_ERR_INCONSISTENT_MUTATIONS;
+        goto out;
+    }
+    ret = genotypes[sample_index] == TSK_MISSING_DATA;
+    genotypes[sample_index] = (int16_t) derived;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_vargen_update_genotypes_i8_traversal(
+    tsk_vargen_t *self, tsk_id_t node, tsk_id_t derived)
+{
+    return tsk_vargen_traverse(self, node, derived, tsk_vargen_visit_i8);
+}
+
+static int TSK_WARN_UNUSED
+tsk_vargen_update_genotypes_i16_traversal(
+    tsk_vargen_t *self, tsk_id_t node, tsk_id_t derived)
+{
+    return tsk_vargen_traverse(self, node, derived, tsk_vargen_visit_i16);
+}
+
+static tsk_size_t
+tsk_vargen_mark_missing_i16(tsk_vargen_t *self)
+{
+    tsk_size_t num_missing = 0;
+    const tsk_id_t *restrict left_child = self->tree.left_child;
+    const tsk_id_t *restrict right_sib = self->tree.right_sib;
+    const tsk_id_t *restrict sample_index_map = self->sample_index_map;
+    int16_t *restrict genotypes = self->variant.genotypes.i16;
+    tsk_id_t root, sample_index;
+
+    for (root = self->tree.left_root; root != TSK_NULL; root = right_sib[root]) {
+        if (left_child[root] == TSK_NULL) {
+            sample_index = sample_index_map[root];
+            if (sample_index != TSK_NULL) {
+                genotypes[sample_index] = TSK_MISSING_DATA;
+                num_missing++;
+            }
+        }
+    }
+    return num_missing;
+}
+
+static tsk_size_t
+tsk_vargen_mark_missing_i8(tsk_vargen_t *self)
+{
+    tsk_size_t num_missing = 0;
+    const tsk_id_t *restrict left_child = self->tree.left_child;
+    const tsk_id_t *restrict right_sib = self->tree.right_sib;
+    const tsk_id_t *restrict sample_index_map = self->sample_index_map;
+    int8_t *restrict genotypes = self->variant.genotypes.i8;
+    tsk_id_t root, sample_index;
+
+    for (root = self->tree.left_root; root != TSK_NULL; root = right_sib[root]) {
+        if (left_child[root] == TSK_NULL) {
+            sample_index = sample_index_map[root];
+            if (sample_index != TSK_NULL) {
+                genotypes[sample_index] = TSK_MISSING_DATA;
+                num_missing++;
+            }
+        }
+    }
+    return num_missing;
+}
+
+static tsk_id_t
+tsk_vargen_get_allele_index(tsk_vargen_t *self, const char *allele, tsk_size_t length)
+{
+    tsk_id_t ret = -1;
+    tsk_size_t j;
+    const tsk_variant_t *var = &self->variant;
+
+    for (j = 0; j < var->num_alleles; j++) {
+        if (length == var->allele_lengths[j]
+            && memcmp(allele, var->alleles[j], length) == 0) {
+            ret = (tsk_id_t) j;
+            break;
+        }
+    }
+    return ret;
+}
+
+static int
+tsk_vargen_update_site(tsk_vargen_t *self)
+{
+    int ret = 0;
+    tsk_id_t allele_index;
+    tsk_size_t j, num_missing;
+    int no_longer_missing;
+    tsk_variant_t *var = &self->variant;
+    const tsk_site_t *site = var->site;
+    tsk_mutation_t mutation;
+    bool genotypes16 = !!(self->options & TSK_16_BIT_GENOTYPES);
+    bool impute_missing = !!(self->options & TSK_ISOLATED_NOT_MISSING);
+    bool by_traversal = self->alt_samples != NULL;
+    int (*update_genotypes)(tsk_vargen_t *, tsk_id_t, tsk_id_t);
+    tsk_size_t (*mark_missing)(tsk_vargen_t *);
+
+    /* For now we use a traversal method to find genotypes when we have a
+     * specified set of samples, but we should provide the option to do it
+     * via tracked_samples in the tree also. There will be a tradeoff: if
+     * we only have a small number of samples, it's probably better to
+     * do it by traversal. For large sets of samples though, it may be
+     * better to use the sample list infrastructure. */
+    if (genotypes16) {
+        mark_missing = tsk_vargen_mark_missing_i16;
+        update_genotypes = tsk_vargen_update_genotypes_i16_sample_list;
+        if (by_traversal) {
+            update_genotypes = tsk_vargen_update_genotypes_i16_traversal;
+        }
+    } else {
+        mark_missing = tsk_vargen_mark_missing_i8;
+        update_genotypes = tsk_vargen_update_genotypes_i8_sample_list;
+        if (by_traversal) {
+            update_genotypes = tsk_vargen_update_genotypes_i8_traversal;
+        }
+    }
+    if (self->user_alleles) {
+        allele_index = tsk_vargen_get_allele_index(
+            self, site->ancestral_state, site->ancestral_state_length);
+        if (allele_index == -1) {
+            ret = TSK_ERR_ALLELE_NOT_FOUND;
+            goto out;
+        }
+    } else {
+        /* Ancestral state is always allele 0 */
+        var->alleles[0] = site->ancestral_state;
+        var->allele_lengths[0] = site->ancestral_state_length;
+        var->num_alleles = 1;
+        allele_index = 0;
+    }
+
+    /* The algorithm for generating the allelic state of every sample works by
+     * examining each mutation in order, and setting the state for all the
+     * samples under the mutation's node. For complex sites where there is
+     * more than one mutation, we depend on the ordering of mutations being
+     * correct. Specifically, any mutation that is above another mutation in
+     * the tree must be visited first. This is enforced using the mutation.parent
+     * field, where we require that a mutation's parent must appear before it
+     * in the list of mutations. This guarantees the correctness of this algorithm.
+     */
+    if (genotypes16) {
+        for (j = 0; j < self->num_samples; j++) {
+            self->variant.genotypes.i16[j] = (int16_t) allele_index;
+        }
+    } else {
+        for (j = 0; j < self->num_samples; j++) {
+            self->variant.genotypes.i8[j] = (int8_t) allele_index;
+        }
+    }
+    /* We mark missing data *before* updating the genotypes because
+     * mutations directly over samples should not be missing */
+    num_missing = 0;
+    if (!impute_missing) {
+        num_missing = mark_missing(self);
+    }
+    for (j = 0; j < site->mutations_length; j++) {
+        mutation = site->mutations[j];
+        /* Compute the allele index for this derived state value. */
+        allele_index = tsk_vargen_get_allele_index(
+            self, mutation.derived_state, mutation.derived_state_length);
+        if (allele_index == -1) {
+            if (self->user_alleles) {
+                ret = TSK_ERR_ALLELE_NOT_FOUND;
+                goto out;
+            }
+            if (var->num_alleles == var->max_alleles) {
+                ret = tsk_vargen_expand_alleles(self);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+            allele_index = (tsk_id_t) var->num_alleles;
+            var->alleles[allele_index] = mutation.derived_state;
+            var->allele_lengths[allele_index] = mutation.derived_state_length;
+            var->num_alleles++;
+        }
+
+        no_longer_missing = update_genotypes(self, mutation.node, allele_index);
+        if (no_longer_missing < 0) {
+            ret = no_longer_missing;
+            goto out;
+        }
+        /* Update genotypes returns the number of missing values marked
+         * not-missing */
+        num_missing -= (tsk_size_t) no_longer_missing;
+    }
+    var->has_missing_data = num_missing > 0;
+out:
+    return ret;
+}
+
+int
+tsk_vargen_next(tsk_vargen_t *self, tsk_variant_t **variant)
+{
+    int ret = 0;
+
+    bool not_done = true;
+
+    if (!self->finished) {
+        while (not_done && self->tree_site_index == self->tree.sites_length) {
+            ret = tsk_vargen_next_tree(self);
+            if (ret < 0) {
+                goto out;
+            }
+            not_done = ret == 1;
+        }
+        if (not_done) {
+            self->variant.site = &self->tree.sites[self->tree_site_index];
+            ret = tsk_vargen_update_site(self);
+            if (ret != 0) {
+                goto out;
+            }
+            self->tree_site_index++;
+            *variant = &self->variant;
+            ret = 1;
+        }
+    }
+out:
+    return ret;
+}

--- a/subprojects/tskit/tskit/genotypes.h
+++ b/subprojects/tskit/tskit/genotypes.h
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2016-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef TSK_GENOTYPES_H
+#define TSK_GENOTYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <tskit/trees.h>
+
+#define TSK_16_BIT_GENOTYPES (1 << 0)
+#define TSK_ISOLATED_NOT_MISSING (1 << 1)
+
+typedef struct {
+    const tsk_site_t *site;
+    const char **alleles;
+    tsk_size_t *allele_lengths;
+    tsk_size_t num_alleles;
+    tsk_size_t max_alleles;
+    bool has_missing_data;
+    union {
+        int8_t *i8;
+        int16_t *i16;
+    } genotypes;
+} tsk_variant_t;
+
+typedef struct {
+    size_t num_samples;
+    size_t num_sites;
+    const tsk_treeseq_t *tree_sequence;
+    const tsk_id_t *sample_index_map;
+    tsk_id_t *alt_samples;
+    tsk_id_t *alt_sample_index_map;
+    bool user_alleles;
+    char *user_alleles_mem;
+    size_t tree_site_index;
+    int finished;
+    tsk_id_t *traversal_stack;
+    tsk_tree_t tree;
+    tsk_flags_t options;
+    tsk_variant_t variant;
+} tsk_vargen_t;
+
+int tsk_vargen_init(tsk_vargen_t *self, const tsk_treeseq_t *tree_sequence,
+    const tsk_id_t *samples, size_t num_samples, const char **alleles,
+    tsk_flags_t options);
+int tsk_vargen_next(tsk_vargen_t *self, tsk_variant_t **variant);
+int tsk_vargen_free(tsk_vargen_t *self);
+void tsk_vargen_print_state(const tsk_vargen_t *self, FILE *out);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/subprojects/tskit/tskit/haplotype_matching.c
+++ b/subprojects/tskit/tskit/haplotype_matching.c
@@ -1,0 +1,1595 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 Tskit Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+#include <float.h>
+
+#include <tskit/haplotype_matching.h>
+
+const char *_zero_one_alleles[] = { "0", "1", NULL };
+const char *_acgt_alleles[] = { "A", "C", "G", "T", NULL };
+
+static int
+cmp_double(const void *a, const void *b)
+{
+    const double *ia = (const double *) a;
+    const double *ib = (const double *) b;
+    return (*ia > *ib) - (*ia < *ib);
+}
+
+static int
+cmp_argsort(const void *a, const void *b)
+{
+    const tsk_argsort_t *ia = (const tsk_argsort_t *) a;
+    const tsk_argsort_t *ib = (const tsk_argsort_t *) b;
+    int ret = (ia->value > ib->value) - (ia->value < ib->value);
+    /* Break any ties using the index to ensure consistency */
+    if (ret == 0) {
+        ret = (ia->index > ib->index) - (ia->index < ib->index);
+    }
+    return ret;
+}
+
+static void
+tsk_ls_hmm_check_state(tsk_ls_hmm_t *self)
+{
+    tsk_id_t *T_index = self->transition_index;
+    tsk_value_transition_t *T = self->transitions;
+    tsk_id_t j;
+
+    for (j = 0; j < (tsk_id_t) self->num_transitions; j++) {
+        if (T[j].tree_node != TSK_NULL) {
+            tsk_bug_assert(T_index[T[j].tree_node] == j);
+        }
+    }
+    /* tsk_bug_assert(self->num_transitions <= self->num_samples); */
+
+    if (self->num_transitions > 0) {
+        for (j = 0; j < (tsk_id_t) self->num_nodes; j++) {
+            if (T_index[j] != TSK_NULL) {
+                tsk_bug_assert(T[T_index[j]].tree_node == j);
+            }
+            tsk_bug_assert(self->tree.parent[j] == self->parent[j]);
+        }
+    }
+}
+
+void
+tsk_ls_hmm_print_state(tsk_ls_hmm_t *self, FILE *out)
+{
+    tsk_size_t j, l;
+
+    fprintf(out, "tree_sequence   = %p\n", (void *) self->tree_sequence);
+    fprintf(out, "num_sites       = %d\n", self->num_sites);
+    fprintf(out, "num_samples     = %d\n", self->num_samples);
+    fprintf(out, "num_values      = %d\n", (int) self->num_values);
+    fprintf(out, "max_values      = %d\n", (int) self->max_values);
+    fprintf(out, "num_fitch_words = %d\n", (int) self->num_fitch_words);
+
+    fprintf(out, "sites::\n");
+    for (l = 0; l < self->num_sites; l++) {
+        fprintf(out, "%d\t%d\t[", l, self->num_alleles[l]);
+        for (j = 0; j < self->num_alleles[l]; j++) {
+            fprintf(out, "%s,", self->alleles[l][j]);
+        }
+        fprintf(out, "]\n");
+    }
+    fprintf(out, "transitions::%d\n", (int) self->num_transitions);
+    for (j = 0; j < self->num_transitions; j++) {
+        fprintf(out, "tree_node=%d\tvalue=%.14f\tvalue_index=%d\n",
+            self->transitions[j].tree_node, self->transitions[j].value,
+            self->transitions[j].value_index);
+    }
+    if (self->num_transitions > 0) {
+        fprintf(out, "tree::%d\n", (int) self->num_nodes);
+        for (j = 0; j < self->num_nodes; j++) {
+            fprintf(out, "%d\tparent=%d\ttransition=%d\n", j, self->parent[j],
+                self->transition_index[j]);
+        }
+    }
+    tsk_ls_hmm_check_state(self);
+}
+
+int TSK_WARN_UNUSED
+tsk_ls_hmm_init(tsk_ls_hmm_t *self, tsk_treeseq_t *tree_sequence,
+    double *recombination_rate, double *mutation_rate, tsk_flags_t options)
+{
+    int ret = TSK_ERR_GENERIC;
+    tsk_size_t l;
+
+    memset(self, 0, sizeof(tsk_ls_hmm_t));
+    self->tree_sequence = tree_sequence;
+    self->precision = 6; /* Seems like a safe value, but probably not ideal for perf */
+    self->num_sites = tsk_treeseq_get_num_sites(tree_sequence);
+    self->num_samples = tsk_treeseq_get_num_samples(tree_sequence);
+    self->num_alleles = malloc(self->num_sites * sizeof(*self->num_alleles));
+    self->num_nodes = tsk_treeseq_get_num_nodes(tree_sequence);
+    self->parent = malloc(self->num_nodes * sizeof(*self->parent));
+    self->allelic_state = malloc(self->num_nodes * sizeof(*self->allelic_state));
+    self->transition_index = malloc(self->num_nodes * sizeof(*self->transition_index));
+    self->transition_stack = malloc(self->num_nodes * sizeof(*self->transition_stack));
+    /* We can't have more than 2 * num_samples transitions, so we use this as the
+     * upper bound. Because of the implementation, we'll also have to worry about
+     * the extra mutations at the first site, which in worst case involves all
+     * mutations. We can definitely save some memory here if we want to.*/
+    self->max_transitions
+        = 2 * self->num_samples + tsk_treeseq_get_num_mutations(tree_sequence);
+    /* FIXME Arbitrarily doubling this after hitting problems */
+    self->max_transitions *= 2;
+    self->transitions = malloc(self->max_transitions * sizeof(*self->transitions));
+    self->transitions_copy = malloc(self->max_transitions * sizeof(*self->transitions));
+    self->num_transition_samples
+        = malloc(self->max_transitions * sizeof(*self->num_transition_samples));
+    self->transition_parent
+        = malloc(self->max_transitions * sizeof(*self->transition_parent));
+    self->transition_time_order
+        = malloc(self->max_transitions * sizeof(*self->transition_time_order));
+    self->values = malloc(self->max_transitions * sizeof(*self->values));
+    self->recombination_rate
+        = malloc(self->num_sites * sizeof(*self->recombination_rate));
+    self->mutation_rate = malloc(self->num_sites * sizeof(*self->mutation_rate));
+    self->alleles = calloc(self->num_sites, sizeof(*self->alleles));
+    if (self->num_alleles == NULL || self->parent == NULL || self->allelic_state == NULL
+        || self->transition_index == NULL || self->transition_stack == NULL
+        || self->transitions == NULL || self->transitions_copy == NULL
+        || self->num_transition_samples == NULL || self->transition_parent == NULL
+        || self->transition_time_order == NULL || self->values == NULL
+        || self->recombination_rate == NULL || self->mutation_rate == NULL
+        || self->alleles == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    for (l = 0; l < self->num_sites; l++) {
+        /* TODO check these inputs */
+        self->recombination_rate[l] = recombination_rate[l];
+        self->mutation_rate[l] = mutation_rate[l];
+        if (options & TSK_ALLELES_ACGT) {
+            self->num_alleles[l] = 4;
+            self->alleles[l] = _acgt_alleles;
+        } else {
+            /* Default to the 0/1 alleles */
+            self->num_alleles[l] = 2;
+            self->alleles[l] = _zero_one_alleles;
+        }
+    }
+    ret = tsk_tree_init(&self->tree, self->tree_sequence, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    self->num_values = 0;
+    self->max_values = 0;
+    ret = 0;
+out:
+    return ret;
+}
+
+int
+tsk_ls_hmm_set_precision(tsk_ls_hmm_t *self, unsigned int precision)
+{
+    self->precision = precision;
+    return 0;
+}
+
+int
+tsk_ls_hmm_free(tsk_ls_hmm_t *self)
+{
+    tsk_tree_free(&self->tree);
+    tsk_diff_iter_free(&self->diffs);
+    tsk_safe_free(self->recombination_rate);
+    tsk_safe_free(self->mutation_rate);
+    tsk_safe_free(self->recombination_rate);
+    tsk_safe_free(self->alleles);
+    tsk_safe_free(self->num_alleles);
+    tsk_safe_free(self->parent);
+    tsk_safe_free(self->allelic_state);
+    tsk_safe_free(self->transition_index);
+    tsk_safe_free(self->transition_stack);
+    tsk_safe_free(self->transitions);
+    tsk_safe_free(self->transitions_copy);
+    tsk_safe_free(self->transition_time_order);
+    tsk_safe_free(self->values);
+    tsk_safe_free(self->num_transition_samples);
+    tsk_safe_free(self->transition_parent);
+    tsk_safe_free(self->fitch_sets);
+    return 0;
+}
+
+static int
+tsk_ls_hmm_reset(tsk_ls_hmm_t *self)
+{
+    int ret = 0;
+    double n = self->num_samples;
+    tsk_size_t j;
+    tsk_id_t u;
+    const tsk_id_t *samples;
+    tsk_size_t N = self->num_nodes;
+
+    memset(self->parent, 0xff, N * sizeof(*self->parent));
+    memset(self->transition_index, 0xff, N * sizeof(*self->transition_index));
+    memset(self->allelic_state, 0xff, N * sizeof(*self->allelic_state));
+    memset(self->transitions, 0, self->max_transitions * sizeof(*self->transitions));
+    memset(self->num_transition_samples, 0,
+        self->max_transitions * sizeof(*self->num_transition_samples));
+    memset(self->transition_parent, 0xff,
+        self->max_transitions * sizeof(*self->transition_parent));
+
+    /* This is safe because we've already zero'd out the memory. */
+    tsk_diff_iter_free(&self->diffs);
+    ret = tsk_diff_iter_init(&self->diffs, self->tree_sequence, false);
+    if (ret != 0) {
+        goto out;
+    }
+    samples = tsk_treeseq_get_samples(self->tree_sequence);
+    for (j = 0; j < self->num_samples; j++) {
+        u = samples[j];
+        self->transitions[j].tree_node = u;
+        self->transitions[j].value = 1.0 / n;
+        self->transition_index[u] = (tsk_id_t) j;
+    }
+    self->num_transitions = self->num_samples;
+out:
+    return ret;
+}
+
+/* After we have moved on to a new tree we can have transitions still associated
+ * with the old roots, which are now disconnected. Remove. */
+static int
+tsk_ls_hmm_remove_dead_roots(tsk_ls_hmm_t *self)
+{
+    tsk_id_t *restrict T_index = self->transition_index;
+    tsk_value_transition_t *restrict T = self->transitions;
+    const tsk_id_t *restrict right_sib = self->tree.right_sib;
+    const tsk_id_t left_root = self->tree.left_root;
+    const tsk_id_t *restrict parent = self->parent;
+    tsk_id_t root, u;
+    size_t j;
+    const tsk_id_t root_marker = -2;
+
+    for (root = left_root; root != TSK_NULL; root = right_sib[root]) {
+        if (T_index[root] != TSK_NULL) {
+            /* Use the value_index slot as a marker. We don't use this between
+             * iterations, so it's safe to appropriate here */
+            T[T_index[root]].value_index = root_marker;
+        }
+    }
+    for (j = 0; j < self->num_transitions; j++) {
+        u = T[j].tree_node;
+        if (u != TSK_NULL) {
+            if (parent[u] == TSK_NULL && T[j].value_index != root_marker) {
+                T_index[u] = TSK_NULL;
+                T[j].tree_node = TSK_NULL;
+            }
+            T[j].value_index = -1;
+        }
+    }
+    return 0;
+}
+
+static int
+tsk_ls_hmm_update_tree(tsk_ls_hmm_t *self)
+{
+    int ret = 0;
+    tsk_id_t *restrict parent = self->parent;
+    tsk_id_t *restrict T_index = self->transition_index;
+    tsk_value_transition_t *restrict T = self->transitions;
+    tsk_edge_list_node_t *record;
+    tsk_edge_list_t records_out, records_in;
+    tsk_edge_t edge;
+    double left, right;
+    tsk_id_t u;
+    tsk_value_transition_t *vt;
+
+    ret = tsk_diff_iter_next(&self->diffs, &left, &right, &records_out, &records_in);
+    if (ret < 0) {
+        goto out;
+    }
+
+    for (record = records_out.head; record != NULL; record = record->next) {
+        u = record->edge.child;
+        if (T_index[u] == TSK_NULL) {
+            /* Ensure the subtree we're detaching has a transition at the root */
+            while (T_index[u] == TSK_NULL) {
+                u = parent[u];
+                tsk_bug_assert(u != TSK_NULL);
+            }
+            tsk_bug_assert(self->num_transitions < self->max_transitions);
+            T_index[record->edge.child] = (tsk_id_t) self->num_transitions;
+            T[self->num_transitions].tree_node = record->edge.child;
+            T[self->num_transitions].value = T[T_index[u]].value;
+            self->num_transitions++;
+        }
+        parent[record->edge.child] = TSK_NULL;
+    }
+
+    for (record = records_in.head; record != NULL; record = record->next) {
+        edge = record->edge;
+        parent[edge.child] = edge.parent;
+        u = edge.parent;
+        if (parent[edge.parent] == TSK_NULL) {
+            /* Grafting onto a new root. */
+            if (T_index[record->edge.parent] == TSK_NULL) {
+                T_index[edge.parent] = (tsk_id_t) self->num_transitions;
+                tsk_bug_assert(self->num_transitions < self->max_transitions);
+                T[self->num_transitions].tree_node = edge.parent;
+                T[self->num_transitions].value = T[T_index[edge.child]].value;
+                self->num_transitions++;
+            }
+        } else {
+            /* Grafting into an existing subtree. */
+            while (T_index[u] == TSK_NULL) {
+                u = parent[u];
+            }
+            tsk_bug_assert(u != TSK_NULL);
+        }
+        tsk_bug_assert(T_index[u] != -1 && T_index[edge.child] != -1);
+        if (T[T_index[u]].value == T[T_index[edge.child]].value) {
+            vt = &T[T_index[edge.child]];
+            /* Mark the value transition as unusued */
+            vt->value = -1;
+            vt->tree_node = TSK_NULL;
+            T_index[edge.child] = TSK_NULL;
+        }
+    }
+
+    ret = tsk_ls_hmm_remove_dead_roots(self);
+out:
+    return ret;
+}
+
+static int
+tsk_ls_hmm_get_allele_index(tsk_ls_hmm_t *self, tsk_id_t site, const char *allele_state,
+    const size_t allele_length)
+{
+    int ret = TSK_ERR_ALLELE_NOT_FOUND;
+    const char **alleles = self->alleles[site];
+    const tsk_id_t num_alleles = self->num_alleles[site];
+
+    tsk_id_t j;
+
+    for (j = 0; j < num_alleles; j++) {
+        if (strlen(alleles[j]) != allele_length) {
+            break;
+        }
+        if (strncmp(alleles[j], allele_state, allele_length) == 0) {
+            ret = j;
+            break;
+        }
+    }
+    return ret;
+}
+
+static int
+tsk_ls_hmm_update_probabilities(
+    tsk_ls_hmm_t *self, const tsk_site_t *site, int8_t haplotype_state)
+{
+    int ret = 0;
+    tsk_id_t root;
+    tsk_tree_t *tree = &self->tree;
+    tsk_id_t *restrict parent = self->parent;
+    tsk_id_t *restrict T_index = self->transition_index;
+    tsk_value_transition_t *restrict T = self->transitions;
+    int8_t *restrict allelic_state = self->allelic_state;
+    tsk_mutation_t mut;
+    tsk_id_t j, u, v;
+    double x;
+    bool match;
+
+    /* Set the allelic states */
+    ret = tsk_ls_hmm_get_allele_index(
+        self, site->id, site->ancestral_state, site->ancestral_state_length);
+    if (ret < 0) {
+        goto out;
+    }
+    for (root = tree->left_root; root != TSK_NULL; root = tree->right_sib[root]) {
+        allelic_state[root] = (int8_t) ret;
+    }
+
+    for (j = 0; j < (tsk_id_t) site->mutations_length; j++) {
+        mut = site->mutations[j];
+        ret = tsk_ls_hmm_get_allele_index(
+            self, site->id, mut.derived_state, mut.derived_state_length);
+        if (ret < 0) {
+            goto out;
+        }
+        u = mut.node;
+        allelic_state[u] = (int8_t) ret;
+        if (T_index[u] == TSK_NULL) {
+            while (T_index[u] == TSK_NULL) {
+                u = parent[u];
+            }
+            tsk_bug_assert(self->num_transitions < self->max_transitions);
+            T_index[mut.node] = (tsk_id_t) self->num_transitions;
+            T[self->num_transitions].tree_node = mut.node;
+            T[self->num_transitions].value = T[T_index[u]].value;
+            self->num_transitions++;
+        }
+    }
+
+    for (j = 0; j < (tsk_id_t) self->num_transitions; j++) {
+        u = T[j].tree_node;
+        if (u != TSK_NULL) {
+            /* Get the allelic_state at u. */
+            v = u;
+            while (allelic_state[v] == TSK_MISSING_DATA) {
+                v = parent[v];
+                tsk_bug_assert(v != -1);
+            }
+            match = haplotype_state == TSK_MISSING_DATA
+                    || haplotype_state == allelic_state[v];
+            ret = self->next_probability(self, site->id, T[j].value, match, u, &x);
+            if (ret != 0) {
+                goto out;
+            }
+            T[j].value = x;
+        }
+    }
+
+    /* Unset the allelic states */
+    for (root = tree->left_root; root != TSK_NULL; root = tree->right_sib[root]) {
+        allelic_state[root] = TSK_MISSING_DATA;
+    }
+    for (j = 0; j < (tsk_id_t) site->mutations_length; j++) {
+        mut = site->mutations[j];
+        allelic_state[mut.node] = TSK_MISSING_DATA;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+tsk_ls_hmm_discretise_values(tsk_ls_hmm_t *self)
+{
+    int ret = 0;
+    tsk_value_transition_t *T = self->transitions;
+    double *values = self->values;
+    size_t j, k, num_values;
+
+    num_values = 0;
+    for (j = 0; j < self->num_transitions; j++) {
+        if (T[j].tree_node != TSK_NULL) {
+            values[num_values] = T[j].value;
+            num_values++;
+        }
+    }
+    tsk_bug_assert(num_values > 0);
+
+    qsort(values, num_values, sizeof(double), cmp_double);
+
+    k = 0;
+    for (j = 1; j < num_values; j++) {
+        if (values[j] != values[k]) {
+            k++;
+            values[k] = values[j];
+        }
+    }
+    num_values = k + 1;
+    self->num_values = num_values;
+    for (j = 0; j < self->num_transitions; j++) {
+        if (T[j].tree_node != TSK_NULL) {
+            T[j].value_index
+                = (tsk_id_t) tsk_search_sorted(values, num_values, T[j].value);
+            tsk_bug_assert(T[j].value == self->values[T[j].value_index]);
+        }
+    }
+    return ret;
+}
+
+/*
+ * TODO We also have this function in tree.s where it's used in the Fitch
+ * calculations (which are slightly different). It would be good to bring
+ * these together, or at least avoid having the same function in two
+ * files. Keeping it as it is for now so that it can be inlined, since
+ * it's perf-sensitive. */
+
+static inline tsk_id_t
+get_smallest_set_bit(uint64_t v)
+{
+    /* This is an inefficient implementation, there are several better
+     * approaches. On GCC we can use
+     * return (uint8_t) (__builtin_ffsll((long long) v) - 1);
+     */
+    uint64_t t = 1;
+    tsk_id_t r = 0;
+    tsk_bug_assert(v != 0);
+
+    while ((v & t) == 0) {
+        t <<= 1;
+        r++;
+    }
+    return r;
+}
+
+static inline tsk_id_t
+get_smallest_element(const uint64_t *restrict A, size_t u, size_t num_words)
+{
+    size_t base = (size_t) u * num_words;
+    const uint64_t *restrict a = A + base;
+    tsk_id_t j = 0;
+
+    while (a[j] == 0) {
+        j++;
+        tsk_bug_assert(j < (tsk_id_t) num_words);
+    }
+    return j * 64 + get_smallest_set_bit(a[j]);
+}
+
+#define MAX_FITCH_WORDS 256
+/* static variables are zero-initialised by default. */
+static const uint64_t zero_block[MAX_FITCH_WORDS];
+
+static inline bool
+all_zero(const uint64_t *restrict A, size_t u, size_t num_words)
+{
+    if (num_words == 1) {
+        return A[u] == 0;
+    } else {
+        return memcmp(zero_block, A + u * num_words, num_words * sizeof(*A)) == 0;
+    }
+}
+
+static inline bool
+element_in(const uint64_t *restrict A, size_t u, const tsk_id_t state, size_t num_words)
+{
+    size_t index = ((size_t) u) * num_words + (size_t)(state / 64);
+    return (A[index] & (1ULL << (state % 64))) != 0;
+}
+static inline void
+set_fitch(uint64_t *restrict A, const tsk_id_t u, const size_t num_words, tsk_id_t state)
+{
+    size_t index = ((size_t) u) * num_words + (size_t)(state / 64);
+    tsk_bug_assert(((size_t) state) / 64 < num_words);
+    A[index] |= 1ULL << (state % 64);
+}
+
+static void
+compute_fitch_1(uint64_t *restrict A, const tsk_id_t *restrict left_child,
+    const tsk_id_t *restrict right_sib, const tsk_id_t u, const tsk_id_t parent_state)
+{
+    tsk_id_t v;
+    uint64_t a_union = 0;
+    uint64_t a_inter = UINT64_MAX;
+    uint64_t child;
+
+    for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
+        child = A[v];
+        /* If the set for a given child is empty, then we know it inherits
+         * directly from the parent state and must be a singleton set. */
+        if (child == 0) {
+            child = 1ULL << parent_state;
+        }
+        a_union |= child;
+        a_inter &= child;
+    }
+    A[u] = a_inter;
+    if (a_inter == 0) {
+        A[u] = a_union;
+    }
+}
+
+static void
+compute_fitch_2(uint64_t *restrict A, const tsk_id_t *restrict left_child,
+    const tsk_id_t *restrict right_sib, const tsk_id_t u, const tsk_id_t parent_state)
+{
+    tsk_id_t v;
+    uint64_t a_union[2] = { 0, 0 };
+    uint64_t a_inter[2] = { UINT64_MAX, UINT64_MAX };
+    uint64_t child[2];
+    const tsk_id_t state_index = parent_state / 64;
+    const uint64_t state_word = 1ULL << (parent_state % 64);
+
+    for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
+        child[0] = A[2 * v];
+        child[1] = A[2 * v + 1];
+        /* If the set for a given child is empty, then we know it inherits
+         * directly from the parent state and must be a singleton set. */
+        if (child[0] == 0 && child[1] == 0) {
+            child[state_index] = state_word;
+        }
+        /* printf("\tFITCH child %d = %d: %d\n", v, (int) child, (int) A[v]); */
+        a_union[0] |= child[0];
+        a_union[1] |= child[1];
+        a_inter[0] &= child[0];
+        a_inter[1] &= child[1];
+    }
+    A[2 * u] = a_inter[0];
+    A[2 * u + 1] = a_inter[1];
+    if (a_inter[0] == 0 && a_inter[1] == 0) {
+        A[2 * u] = a_union[0];
+        A[2 * u + 1] = a_union[1];
+    }
+}
+
+static void
+compute_fitch_general(uint64_t *restrict A, const tsk_id_t *restrict left_child,
+    const tsk_id_t *restrict right_sib, const tsk_id_t u, const tsk_id_t parent_state,
+    const size_t num_words)
+{
+    tsk_id_t v;
+    uint64_t a_union[MAX_FITCH_WORDS];
+    uint64_t a_inter[MAX_FITCH_WORDS];
+    uint64_t child[MAX_FITCH_WORDS];
+    uint64_t *src;
+    size_t base;
+    bool child_all_zero, inter_all_zero;
+    const tsk_id_t state_index = parent_state / 64;
+    const uint64_t state_word = 1ULL << (parent_state % 64);
+    int j;
+
+    tsk_bug_assert(num_words <= MAX_FITCH_WORDS);
+
+    memset(a_union, 0, num_words * sizeof(*a_union));
+    memset(a_inter, 0xff, num_words * sizeof(*a_inter));
+    for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
+        child_all_zero = true;
+        base = ((size_t) v) * num_words;
+        for (j = 0; j < (int) num_words; j++) {
+            child[j] = A[base + (size_t) j];
+            child_all_zero = child_all_zero && (child[j] == 0);
+        }
+        /* If the set for a given child is empty, then we know it inherits
+         * directly from the parent state and must be a singleton set. */
+        if (child_all_zero) {
+            child[state_index] = state_word;
+        }
+        for (j = 0; j < (int) num_words; j++) {
+            a_union[j] |= child[j];
+            a_inter[j] &= child[j];
+        }
+    }
+    inter_all_zero = true;
+    for (j = 0; j < (int) num_words; j++) {
+        inter_all_zero = inter_all_zero && (a_inter[j] == 0);
+    }
+
+    src = a_inter;
+    if (inter_all_zero) {
+        src = a_union;
+    }
+    for (j = 0; j < (int) num_words; j++) {
+        A[((size_t) u) * num_words + (size_t) j] = src[j];
+    }
+}
+
+static void
+compute_fitch(uint64_t *restrict A, const tsk_id_t *restrict left_child,
+    const tsk_id_t *restrict right_sib, const tsk_id_t u, const tsk_id_t parent_state,
+    const size_t num_words)
+{
+    if (num_words == 1) {
+        compute_fitch_1(A, left_child, right_sib, u, parent_state);
+    } else if (num_words == 2) {
+        compute_fitch_2(A, left_child, right_sib, u, parent_state);
+    } else {
+        compute_fitch_general(A, left_child, right_sib, u, parent_state, num_words);
+    }
+}
+
+static int
+tsk_ls_hmm_setup_fitch_sets(tsk_ls_hmm_t *self)
+{
+    int ret = 0;
+
+    /* We expect that most of the time there will be one word per fitch set,
+     * but there will be times when we need more than one word. This approach
+     * lets us expand the memory if we need to, but when the number of
+     * values goes back below 64 we revert to using one word per set. We
+     * could in principle release back the memory as well, but it doesn't seem
+     * worth the bother. */
+    self->num_fitch_words = (self->num_values / 64) + 1;
+    if (self->num_fitch_words > MAX_FITCH_WORDS) {
+        ret = TSK_ERR_TOO_MANY_VALUES;
+        goto out;
+    }
+    if (self->num_values >= self->max_values) {
+        self->max_values = self->num_fitch_words * 64;
+        tsk_safe_free(self->fitch_sets);
+        self->fitch_sets
+            = calloc(self->num_nodes * self->num_fitch_words, sizeof(*self->fitch_sets));
+        if (self->fitch_sets == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_ls_hmm_build_fitch_sets(tsk_ls_hmm_t *self)
+{
+    int ret = 0;
+    const double *restrict node_time = self->tree_sequence->tables->nodes.time;
+    const tsk_id_t *restrict left_child = self->tree.left_child;
+    const tsk_id_t *restrict right_sib = self->tree.right_sib;
+    const tsk_id_t *restrict parent = self->parent;
+    const tsk_value_transition_t *restrict T = self->transitions;
+    const tsk_id_t *restrict T_index = self->transition_index;
+    tsk_argsort_t *restrict order = self->transition_time_order;
+    const size_t num_fitch_words = self->num_fitch_words;
+    uint64_t *restrict A = self->fitch_sets;
+    size_t j;
+    tsk_id_t u, v, state, parent_state;
+
+    /* argsort the transitions by node time so we can visit them in the
+     * correct order */
+    for (j = 0; j < self->num_transitions; j++) {
+        order[j].index = j;
+        order[j].value = DBL_MAX;
+        if (T[j].tree_node != TSK_NULL) {
+            order[j].value = node_time[T[j].tree_node];
+        }
+    }
+    qsort(order, self->num_transitions, sizeof(*order), cmp_argsort);
+
+    for (j = 0; j < self->num_transitions; j++) {
+        u = T[order[j].index].tree_node;
+        if (u != TSK_NULL) {
+            state = T[order[j].index].value_index;
+            if (left_child[u] == TSK_NULL) {
+                /* leaf node */
+                set_fitch(A, u, num_fitch_words, state);
+            } else {
+                compute_fitch(A, left_child, right_sib, u, state, num_fitch_words);
+            }
+            v = parent[u];
+            if (v != TSK_NULL) {
+                while (T_index[v] == TSK_NULL) {
+                    v = parent[v];
+                    tsk_bug_assert(v != TSK_NULL);
+                }
+                parent_state = T[T_index[v]].value_index;
+                v = parent[u];
+                while (T_index[v] == TSK_NULL) {
+                    compute_fitch(
+                        A, left_child, right_sib, v, parent_state, num_fitch_words);
+                    v = parent[v];
+                    tsk_bug_assert(v != TSK_NULL);
+                }
+            }
+        }
+    }
+    return ret;
+}
+
+static int
+tsk_ls_hmm_redistribute_transitions(tsk_ls_hmm_t *self)
+{
+    int ret = 0;
+    const tsk_id_t *restrict left_child = self->tree.left_child;
+    const tsk_id_t *restrict right_sib = self->tree.right_sib;
+    const tsk_id_t *restrict parent = self->parent;
+    tsk_id_t *restrict T_index = self->transition_index;
+    tsk_id_t *restrict T_parent = self->transition_parent;
+    tsk_value_transition_t *restrict T = self->transitions;
+    tsk_value_transition_t *restrict T_old = self->transitions_copy;
+    tsk_transition_stack_t *stack = self->transition_stack;
+    uint64_t *restrict A = self->fitch_sets;
+    const size_t num_fitch_words = self->num_fitch_words;
+    tsk_transition_stack_t s, child_s;
+    tsk_id_t root, u, v;
+    int stack_top = 0;
+    size_t j, old_num_transitions;
+
+    memcpy(T_old, T, self->num_transitions * sizeof(*T));
+    old_num_transitions = self->num_transitions;
+    self->num_transitions = 0;
+
+    for (root = self->tree.left_root; root != TSK_NULL; root = right_sib[root]) {
+        stack[0].tree_node = root;
+        stack[0].old_state = T_old[T_index[root]].value_index;
+        /* tsk_bug_assert(self->num_fitch_words == 1); */
+        stack[0].new_state = get_smallest_element(A, (size_t) root, num_fitch_words);
+        stack[0].transition_parent = 0;
+        stack_top = 0;
+
+        tsk_bug_assert(self->num_transitions < self->max_transitions);
+        T_parent[self->num_transitions] = TSK_NULL;
+        T[self->num_transitions].tree_node = stack[0].tree_node;
+        T[self->num_transitions].value_index = stack[0].new_state;
+        self->num_transitions++;
+
+        while (stack_top >= 0) {
+            s = stack[stack_top];
+            stack_top--;
+            for (v = left_child[s.tree_node]; v != TSK_NULL; v = right_sib[v]) {
+                child_s = s;
+                child_s.tree_node = v;
+                if (T_index[v] != TSK_NULL) {
+                    child_s.old_state = T_old[T_index[v]].value_index;
+                }
+                if (!all_zero(A, (size_t) v, num_fitch_words)) {
+                    if (!element_in(A, (size_t) v, s.new_state, num_fitch_words)) {
+                        child_s.new_state
+                            = get_smallest_element(A, (size_t) v, num_fitch_words);
+                        child_s.transition_parent = (tsk_id_t) self->num_transitions;
+                        /* Add a new transition */
+                        tsk_bug_assert(self->num_transitions < self->max_transitions);
+                        T_parent[self->num_transitions] = s.transition_parent;
+                        T[self->num_transitions].tree_node = v;
+                        T[self->num_transitions].value_index = child_s.new_state;
+                        self->num_transitions++;
+                    }
+                    stack_top++;
+                    stack[stack_top] = child_s;
+                } else {
+                    /* Node that we didn't visit when moving up the tree */
+                    if (s.old_state != s.new_state) {
+                        tsk_bug_assert(self->num_transitions < self->max_transitions);
+                        T_parent[self->num_transitions] = s.transition_parent;
+                        T[self->num_transitions].tree_node = v;
+                        T[self->num_transitions].value_index = s.old_state;
+                        self->num_transitions++;
+                    }
+                }
+            }
+        }
+    }
+
+    /* Unset the old T_index pointers and Fitch sets. */
+    for (j = 0; j < old_num_transitions; j++) {
+        u = T_old[j].tree_node;
+        if (u != TSK_NULL) {
+            T_index[u] = TSK_NULL;
+            while (u != TSK_NULL && !all_zero(A, (size_t) u, num_fitch_words)) {
+                memset(A + ((size_t) u) * num_fitch_words, 0,
+                    num_fitch_words * sizeof(uint64_t));
+                u = parent[u];
+            }
+        }
+    }
+    /* Set the new pointers for transition nodes and the values.*/
+    for (j = 0; j < self->num_transitions; j++) {
+        T_index[T[j].tree_node] = (tsk_id_t) j;
+        T[j].value = self->values[T[j].value_index];
+    }
+    return ret;
+}
+
+static int
+tsk_ls_hmm_compress(tsk_ls_hmm_t *self)
+{
+    int ret = 0;
+
+    ret = tsk_ls_hmm_discretise_values(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_ls_hmm_setup_fitch_sets(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_ls_hmm_build_fitch_sets(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_ls_hmm_redistribute_transitions(self);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_ls_hmm_process_site(
+    tsk_ls_hmm_t *self, const tsk_site_t *site, int8_t haplotype_state)
+{
+    int ret = 0;
+    double x, normalisation_factor;
+    tsk_compressed_matrix_t *output = (tsk_compressed_matrix_t *) self->output;
+    tsk_value_transition_t *restrict T = self->transitions;
+    const unsigned int precision = (unsigned int) self->precision;
+    tsk_size_t j;
+
+    ret = tsk_ls_hmm_update_probabilities(self, site, haplotype_state);
+    if (ret != 0) {
+        goto out;
+    }
+    /* See notes in the Python implementation on why we don't want to compress
+     * here, but rather should be doing it after rounding. */
+    ret = tsk_ls_hmm_compress(self);
+    if (ret != 0) {
+        goto out;
+    }
+    tsk_bug_assert(self->num_transitions <= self->num_samples);
+    normalisation_factor = self->compute_normalisation_factor(self);
+
+    if (normalisation_factor == 0) {
+        ret = TSK_ERR_MATCH_IMPOSSIBLE;
+        goto out;
+    }
+    for (j = 0; j < self->num_transitions; j++) {
+        tsk_bug_assert(T[j].tree_node != TSK_NULL);
+        x = T[j].value / normalisation_factor;
+        T[j].value = tsk_round(x, precision);
+    }
+
+    ret = tsk_compressed_matrix_store_site(
+        output, site->id, normalisation_factor, (tsk_size_t) self->num_transitions, T);
+out:
+    return ret;
+}
+
+int
+tsk_ls_hmm_run(tsk_ls_hmm_t *self, int8_t *haplotype,
+    int (*next_probability)(tsk_ls_hmm_t *, tsk_id_t, double, bool, tsk_id_t, double *),
+    double (*compute_normalisation_factor)(struct _tsk_ls_hmm_t *), void *output)
+{
+    int ret = 0;
+    int t_ret;
+    const tsk_site_t *sites;
+    tsk_size_t j, num_sites;
+
+    self->next_probability = next_probability;
+    self->compute_normalisation_factor = compute_normalisation_factor;
+    self->output = output;
+
+    ret = tsk_ls_hmm_reset(self);
+    if (ret != 0) {
+        goto out;
+    }
+
+    for (t_ret = tsk_tree_first(&self->tree); t_ret == 1;
+         t_ret = tsk_tree_next(&self->tree)) {
+        ret = tsk_ls_hmm_update_tree(self);
+        if (ret != 0) {
+            goto out;
+        }
+        /* tsk_ls_hmm_check_state(self); */
+        ret = tsk_tree_get_sites(&self->tree, &sites, &num_sites);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_sites; j++) {
+            ret = tsk_ls_hmm_process_site(self, &sites[j], haplotype[sites[j].id]);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+    }
+    /* Set to zero so we can print and check the state OK. */
+    self->num_transitions = 0;
+    if (t_ret != 0) {
+        ret = t_ret;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+/****************************************************************
+ * Forward Algorithm
+ ****************************************************************/
+
+static double
+tsk_ls_hmm_compute_normalisation_factor_forward(tsk_ls_hmm_t *self)
+{
+    tsk_id_t *restrict N = self->num_transition_samples;
+    tsk_value_transition_t *restrict T = self->transitions;
+    const tsk_id_t *restrict T_parent = self->transition_parent;
+    const tsk_id_t *restrict num_samples = self->tree.num_samples;
+    const tsk_id_t num_transitions = (tsk_id_t) self->num_transitions;
+    double normalisation_factor;
+    tsk_id_t j;
+
+    /* Compute the number of samples directly inheriting from each transition */
+    for (j = 0; j < num_transitions; j++) {
+        tsk_bug_assert(T[j].tree_node != TSK_NULL);
+        N[j] = num_samples[T[j].tree_node];
+    }
+    for (j = 0; j < num_transitions; j++) {
+        if (T_parent[j] != TSK_NULL) {
+            N[T_parent[j]] -= N[j];
+        }
+    }
+
+    /* Compute the normalising constant used to avoid underflow */
+    normalisation_factor = 0;
+    for (j = 0; j < num_transitions; j++) {
+        normalisation_factor += N[j] * T[j].value;
+    }
+    return normalisation_factor;
+}
+
+static int
+tsk_ls_hmm_next_probability_forward(tsk_ls_hmm_t *self, tsk_id_t site_id, double p_last,
+    bool is_match, tsk_id_t TSK_UNUSED(node), double *result)
+{
+    const double rho = self->recombination_rate[site_id];
+    const double mu = self->mutation_rate[site_id];
+    const double n = self->num_samples;
+    const double num_alleles = self->num_alleles[site_id];
+    double p_t, p_e;
+
+    p_t = p_last * (1 - rho) + rho / n;
+    p_e = mu;
+    if (is_match) {
+        p_e = 1 - (num_alleles - 1) * mu;
+    }
+    *result = p_t * p_e;
+    return 0;
+}
+
+int
+tsk_ls_hmm_forward(tsk_ls_hmm_t *self, int8_t *haplotype,
+    tsk_compressed_matrix_t *output, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_compressed_matrix_init(output, self->tree_sequence, 0, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    } else {
+        if (output->tree_sequence != self->tree_sequence) {
+            ret = TSK_ERR_BAD_PARAM_VALUE;
+            goto out;
+        }
+        ret = tsk_compressed_matrix_clear(output);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_ls_hmm_run(self, haplotype, tsk_ls_hmm_next_probability_forward,
+        tsk_ls_hmm_compute_normalisation_factor_forward, output);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+/****************************************************************
+ * Viterbi Algorithm
+ ****************************************************************/
+
+static double
+tsk_ls_hmm_compute_normalisation_factor_viterbi(tsk_ls_hmm_t *self)
+{
+    tsk_value_transition_t *restrict T = self->transitions;
+    const tsk_id_t num_transitions = (tsk_id_t) self->num_transitions;
+    tsk_value_transition_t max_vt;
+    tsk_id_t j;
+
+    max_vt.value = -1;
+    max_vt.tree_node = 0; /* keep compiler happy */
+    tsk_bug_assert(num_transitions > 0);
+    for (j = 0; j < num_transitions; j++) {
+        tsk_bug_assert(T[j].tree_node != TSK_NULL);
+        if (T[j].value > max_vt.value) {
+            max_vt = T[j];
+        }
+    }
+    return max_vt.value;
+}
+
+static int
+tsk_ls_hmm_next_probability_viterbi(tsk_ls_hmm_t *self, tsk_id_t site, double p_last,
+    bool is_match, tsk_id_t node, double *result)
+{
+    const double rho = self->recombination_rate[site];
+    const double mu = self->mutation_rate[site];
+    const double num_alleles = self->num_alleles[site];
+    const double n = self->num_samples;
+    double p_recomb, p_no_recomb, p_t, p_e;
+    bool recombination_required = false;
+
+    p_no_recomb = p_last * (1 - rho + rho / n);
+    p_recomb = rho / n;
+    if (p_no_recomb > p_recomb) {
+        p_t = p_no_recomb;
+    } else {
+        p_t = p_recomb;
+        recombination_required = true;
+    }
+    p_e = mu;
+    if (is_match) {
+        p_e = 1 - (num_alleles - 1) * mu;
+    }
+    *result = p_t * p_e;
+    return tsk_viterbi_matrix_add_recombination_required(
+        self->output, site, node, recombination_required);
+}
+
+int
+tsk_ls_hmm_viterbi(tsk_ls_hmm_t *self, int8_t *haplotype, tsk_viterbi_matrix_t *output,
+    tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_viterbi_matrix_init(output, self->tree_sequence, 0, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    } else {
+        if (output->matrix.tree_sequence != self->tree_sequence) {
+            ret = TSK_ERR_BAD_PARAM_VALUE;
+            goto out;
+        }
+        ret = tsk_viterbi_matrix_clear(output);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_ls_hmm_run(self, haplotype, tsk_ls_hmm_next_probability_viterbi,
+        tsk_ls_hmm_compute_normalisation_factor_viterbi, output);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+/****************************************************************
+ * Compressed matrix
+ ****************************************************************/
+
+int
+tsk_compressed_matrix_init(tsk_compressed_matrix_t *self, tsk_treeseq_t *tree_sequence,
+    size_t block_size, tsk_flags_t options)
+{
+    int ret = 0;
+    size_t num_sites;
+
+    memset(self, 0, sizeof(*self));
+    self->tree_sequence = tree_sequence;
+    self->options = options;
+    self->num_sites = tsk_treeseq_get_num_sites(tree_sequence);
+    self->num_samples = tsk_treeseq_get_num_samples(tree_sequence);
+    /* Avoid malloc(0) */
+    num_sites = TSK_MAX(self->num_sites, 1);
+    self->num_transitions = malloc(num_sites * sizeof(*self->num_transitions));
+    self->normalisation_factor = malloc(num_sites * sizeof(*self->normalisation_factor));
+    self->values = malloc(num_sites * sizeof(*self->values));
+    self->nodes = malloc(num_sites * sizeof(*self->nodes));
+    if (self->num_transitions == NULL || self->values == NULL || self->nodes == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    if (block_size == 0) {
+        block_size = 1 << 20;
+    }
+    ret = tsk_blkalloc_init(&self->memory, block_size);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_compressed_matrix_clear(self);
+out:
+    return ret;
+}
+
+int
+tsk_compressed_matrix_free(tsk_compressed_matrix_t *self)
+{
+    tsk_blkalloc_free(&self->memory);
+    tsk_safe_free(self->num_transitions);
+    tsk_safe_free(self->normalisation_factor);
+    tsk_safe_free(self->values);
+    tsk_safe_free(self->nodes);
+    return 0;
+}
+
+int
+tsk_compressed_matrix_clear(tsk_compressed_matrix_t *self)
+{
+    tsk_blkalloc_reset(&self->memory);
+    memset(self->num_transitions, 0, self->num_sites * sizeof(*self->num_transitions));
+    memset(self->normalisation_factor, 0,
+        self->num_sites * sizeof(*self->normalisation_factor));
+    return 0;
+}
+
+void
+tsk_compressed_matrix_print_state(tsk_compressed_matrix_t *self, FILE *out)
+{
+    tsk_size_t l, j;
+
+    fprintf(out, "Compressed matrix for %p\n", (void *) self->tree_sequence);
+    fprintf(out, "num_sites = %d\n", self->num_sites);
+    fprintf(out, "num_samples = %d\n", self->num_samples);
+    for (l = 0; l < self->num_sites; l++) {
+        fprintf(out, "%d\ts=%f\tv=%d [", l, self->normalisation_factor[l],
+            self->num_transitions[l]);
+        for (j = 0; j < self->num_transitions[l]; j++) {
+            fprintf(out, "(%d, %f)", self->nodes[l][j], self->values[l][j]);
+            if (j < self->num_transitions[l] - 1) {
+                fprintf(out, ",");
+            } else {
+                fprintf(out, "]\n");
+            }
+        }
+    }
+    fprintf(out, "Memory:\n");
+    tsk_blkalloc_print_state(&self->memory, out);
+}
+
+int
+tsk_compressed_matrix_store_site(tsk_compressed_matrix_t *self, tsk_id_t site,
+    double normalisation_factor, tsk_size_t num_transitions,
+    const tsk_value_transition_t *transitions)
+{
+    int ret = 0;
+    tsk_size_t j;
+
+    if (site < 0 || site >= (tsk_id_t) self->num_sites) {
+        ret = TSK_ERR_OUT_OF_BOUNDS;
+        goto out;
+    }
+
+    self->num_transitions[site] = num_transitions;
+    self->normalisation_factor[site] = normalisation_factor;
+    self->nodes[site]
+        = tsk_blkalloc_get(&self->memory, num_transitions * sizeof(tsk_id_t));
+    self->values[site]
+        = tsk_blkalloc_get(&self->memory, num_transitions * sizeof(double));
+    if (self->nodes[site] == NULL || self->values[site] == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    for (j = 0; j < num_transitions; j++) {
+        self->values[site][j] = transitions[j].value;
+        self->nodes[site][j] = transitions[j].tree_node;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_compressed_matrix_decode_site(tsk_compressed_matrix_t *self, const tsk_tree_t *tree,
+    const tsk_id_t site, double *values)
+{
+    int ret = 0;
+    const tsk_id_t *restrict list_left = tree->left_sample;
+    const tsk_id_t *restrict list_right = tree->right_sample;
+    const tsk_id_t *restrict list_next = tree->next_sample;
+    const tsk_id_t num_nodes = (tsk_id_t) tsk_treeseq_get_num_nodes(self->tree_sequence);
+    tsk_size_t j;
+    tsk_id_t node, index, stop;
+    double value;
+
+    for (j = 0; j < self->num_transitions[site]; j++) {
+        node = self->nodes[site][j];
+        if (node < 0 || node >= num_nodes) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        value = self->values[site][j];
+        index = list_left[node];
+        if (index == TSK_NULL) {
+            /* It's an error if there are nodes that don't subtend any samples */
+            ret = TSK_ERR_BAD_COMPRESSED_MATRIX_NODE;
+            goto out;
+        }
+        stop = list_right[node];
+        while (true) {
+            values[index] = value;
+            if (index == stop) {
+                break;
+            }
+            index = list_next[index];
+        }
+    }
+out:
+    return ret;
+}
+
+int
+tsk_compressed_matrix_decode(tsk_compressed_matrix_t *self, double *values)
+{
+    int ret = 0;
+    int t_ret;
+    tsk_tree_t tree;
+    tsk_size_t j, num_tree_sites;
+    const tsk_site_t *sites = NULL;
+    tsk_id_t site_id;
+    double *site_array;
+
+    ret = tsk_tree_init(&tree, self->tree_sequence, TSK_SAMPLE_LISTS);
+    if (ret != 0) {
+        goto out;
+    }
+
+    for (t_ret = tsk_tree_first(&tree); t_ret == 1; t_ret = tsk_tree_next(&tree)) {
+        ret = tsk_tree_get_sites(&tree, &sites, &num_tree_sites);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_tree_sites; j++) {
+            site_id = sites[j].id;
+            site_array = values + ((size_t) site_id) * self->num_samples;
+            if (self->num_transitions[site_id] == 0) {
+                memset(site_array, 0, self->num_samples * sizeof(site_array));
+            } else {
+                ret = tsk_compressed_matrix_decode_site(
+                    self, &tree, site_id, site_array);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        }
+    }
+    if (t_ret < 0) {
+        ret = t_ret;
+        goto out;
+    }
+out:
+    tsk_tree_free(&tree);
+    return ret;
+}
+
+/****************************************************************
+ * Viterbi matrix
+ ****************************************************************/
+
+static int
+tsk_viterbi_matrix_expand_recomb_records(tsk_viterbi_matrix_t *self)
+{
+    int ret = 0;
+    tsk_recomb_required_record *tmp
+        = realloc(self->recombination_required, self->max_recomb_records * sizeof(*tmp));
+
+    if (tmp == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    self->recombination_required = tmp;
+out:
+    return ret;
+}
+
+int
+tsk_viterbi_matrix_init(tsk_viterbi_matrix_t *self, tsk_treeseq_t *tree_sequence,
+    size_t block_size, tsk_flags_t options)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(*self));
+    if (block_size == 0) {
+        block_size = 1 << 20; /* 1MiB */
+    }
+    ret = tsk_compressed_matrix_init(&self->matrix, tree_sequence, block_size, options);
+    if (ret != 0) {
+        goto out;
+    }
+
+    self->max_recomb_records
+        = TSK_MAX(1, block_size / sizeof(tsk_recomb_required_record));
+    ret = tsk_viterbi_matrix_expand_recomb_records(self);
+    if (ret != 0) {
+        goto out;
+    }
+    /* Add the sentinel at the start to simplify traceback */
+    self->recombination_required[0].site = -1;
+
+    ret = tsk_viterbi_matrix_clear(self);
+out:
+    return ret;
+}
+
+int
+tsk_viterbi_matrix_free(tsk_viterbi_matrix_t *self)
+{
+    tsk_compressed_matrix_free(&self->matrix);
+    tsk_safe_free(self->recombination_required);
+    return 0;
+}
+
+int
+tsk_viterbi_matrix_clear(tsk_viterbi_matrix_t *self)
+{
+    self->num_recomb_records = 1;
+    tsk_compressed_matrix_clear(&self->matrix);
+    return 0;
+}
+
+void
+tsk_viterbi_matrix_print_state(tsk_viterbi_matrix_t *self, FILE *out)
+{
+    tsk_id_t l, j;
+
+    fprintf(out, "viterbi_matrix\n");
+    fprintf(out, "num_recomb_records = %d\n", (int) self->num_recomb_records);
+    fprintf(out, "max_recomb_records = %d\n", (int) self->max_recomb_records);
+
+    j = 1;
+    for (l = 0; l < (tsk_id_t) self->matrix.num_sites; l++) {
+        fprintf(out, "%d\t[", l);
+        while (j < (tsk_id_t) self->num_recomb_records
+               && self->recombination_required[j].site == l) {
+            fprintf(out, "(%d, %d) ", self->recombination_required[j].node,
+                self->recombination_required[j].required);
+            j++;
+        }
+        fprintf(out, "]\n");
+    }
+    tsk_compressed_matrix_print_state(&self->matrix, out);
+}
+
+TSK_WARN_UNUSED int
+tsk_viterbi_matrix_add_recombination_required(
+    tsk_viterbi_matrix_t *self, tsk_id_t site, tsk_id_t node, bool required)
+{
+    int ret = 0;
+    tsk_recomb_required_record *record;
+
+    if (self->num_recomb_records == self->max_recomb_records) {
+        self->max_recomb_records *= 2;
+        ret = tsk_viterbi_matrix_expand_recomb_records(self);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    record = self->recombination_required + self->num_recomb_records;
+    record->site = site;
+    record->node = node;
+    record->required = required;
+    self->num_recomb_records++;
+out:
+    return ret;
+}
+
+static tsk_id_t
+tsk_viterbi_matrix_choose_sample(
+    tsk_viterbi_matrix_t *self, tsk_id_t site, tsk_tree_t *tree)
+{
+    tsk_id_t ret;
+    tsk_id_t u = TSK_NULL;
+    const tsk_flags_t *node_flags = self->matrix.tree_sequence->tables->nodes.flags;
+    const tsk_size_t num_transitions = self->matrix.num_transitions[site];
+    const tsk_id_t *transition_nodes = self->matrix.nodes[site];
+    const double *transition_values = self->matrix.values[site];
+    double max_value = -1;
+    tsk_size_t j;
+    tsk_id_t v;
+    bool found;
+
+    if (num_transitions == 0) {
+        ret = TSK_ERR_NULL_VITERBI_MATRIX;
+        goto out;
+    }
+    for (j = 0; j < num_transitions; j++) {
+        if (max_value < transition_values[j]) {
+            u = transition_nodes[j];
+            max_value = transition_values[j];
+        }
+    }
+    tsk_bug_assert(u != TSK_NULL);
+
+    while (!(node_flags[u] & TSK_NODE_IS_SAMPLE)) {
+        found = false;
+        for (v = tree->left_child[u]; v != TSK_NULL; v = tree->right_sib[v]) {
+            /* Choose the first child that is not in the list of transition nodes */
+            for (j = 0; j < num_transitions; j++) {
+                if (transition_nodes[j] == v) {
+                    break;
+                }
+            }
+            if (j == num_transitions) {
+                u = v;
+                found = true;
+                break;
+            }
+        }
+        /* TODO: should remove this once we're sure this is robust */
+        tsk_bug_assert(found);
+    }
+    ret = u;
+out:
+    return ret;
+}
+
+int
+tsk_viterbi_matrix_traceback(
+    tsk_viterbi_matrix_t *self, tsk_id_t *path, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_site_t site;
+    tsk_id_t u, site_id, current_node;
+    tsk_recomb_required_record *rr_record, *rr_record_tmp;
+    const tsk_id_t num_sites = (tsk_id_t) self->matrix.num_sites;
+    const tsk_id_t num_nodes
+        = (tsk_id_t) tsk_treeseq_get_num_nodes(self->matrix.tree_sequence);
+    tsk_tree_t tree;
+    tsk_id_t *recombination_tree
+        = malloc((size_t) num_nodes * sizeof(*recombination_tree));
+
+    ret = tsk_tree_init(&tree, self->matrix.tree_sequence, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    if (recombination_tree == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    /* Initialise the path an recombination_tree to contain TSK_NULL */
+    memset(path, 0xff, ((size_t) num_sites) * sizeof(*path));
+    memset(recombination_tree, 0xff, ((size_t) num_nodes) * sizeof(*path));
+
+    current_node = TSK_NULL;
+    rr_record = &self->recombination_required[self->num_recomb_records - 1];
+    ret = tsk_tree_last(&tree);
+    if (ret < 0) {
+        goto out;
+    }
+
+    for (site_id = num_sites - 1; site_id >= 0; site_id--) {
+        ret = tsk_treeseq_get_site(self->matrix.tree_sequence, site_id, &site);
+        if (ret != 0) {
+            goto out;
+        }
+        while (tree.left > site.position) {
+            ret = tsk_tree_prev(&tree);
+            if (ret < 0) {
+                goto out;
+            }
+        }
+        tsk_bug_assert(tree.left <= site.position);
+        tsk_bug_assert(site.position < tree.right);
+
+        /* Fill in the recombination tree */
+        rr_record_tmp = rr_record;
+        while (rr_record->site == site.id) {
+            recombination_tree[rr_record->node] = rr_record->required;
+            rr_record--;
+        }
+        if (current_node == TSK_NULL) {
+            current_node = tsk_viterbi_matrix_choose_sample(self, site.id, &tree);
+            if (current_node < 0) {
+                ret = current_node;
+                goto out;
+            }
+        }
+        path[site.id] = current_node;
+        /* Now traverse up the tree from the current node. The
+         * first marked node tells us whether we need to recombine */
+        u = current_node;
+        while (u != TSK_NULL && recombination_tree[u] == TSK_NULL) {
+            u = tree.parent[u];
+        }
+        tsk_bug_assert(u != TSK_NULL);
+        if (recombination_tree[u] == 1) {
+            /* Switch at the next site */
+            current_node = TSK_NULL;
+        }
+
+        /* Reset in the recombination tree */
+        rr_record = rr_record_tmp;
+        while (rr_record->site == site.id) {
+            recombination_tree[rr_record->node] = TSK_NULL;
+            rr_record--;
+        }
+    }
+    ret = 0;
+out:
+    tsk_tree_free(&tree);
+    tsk_safe_free(recombination_tree);
+    return ret;
+}

--- a/subprojects/tskit/tskit/haplotype_matching.h
+++ b/subprojects/tskit/tskit/haplotype_matching.h
@@ -1,0 +1,169 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 Tskit Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef TSK_HAPLOTYPE_MATCHING_H
+#define TSK_HAPLOTYPE_MATCHING_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <tskit/trees.h>
+
+/* Seems like we might use this somewhere else as well, so putting it into the middle
+ * of the flags space */
+#define TSK_ALLELES_ACGT (1 << 16)
+
+typedef struct {
+    tsk_id_t tree_node;
+    tsk_id_t value_index;
+    double value;
+} tsk_value_transition_t;
+
+typedef struct {
+    size_t index;
+    double value;
+} tsk_argsort_t;
+
+typedef struct {
+    tsk_id_t tree_node;
+    tsk_id_t old_state;
+    tsk_id_t new_state;
+    tsk_id_t transition_parent;
+} tsk_transition_stack_t;
+
+typedef struct {
+    double normalisation_factor;
+    double *value;
+    tsk_id_t *node;
+    tsk_size_t num_values;
+} tsk_site_probability_t;
+
+typedef struct {
+    tsk_treeseq_t *tree_sequence;
+    tsk_flags_t options;
+    tsk_size_t num_sites;
+    tsk_size_t num_samples;
+    double *normalisation_factor;
+    tsk_size_t *num_transitions;
+    double **values;
+    tsk_id_t **nodes;
+    tsk_blkalloc_t memory;
+} tsk_compressed_matrix_t;
+
+typedef struct {
+    tsk_id_t site;
+    tsk_id_t node;
+    bool required;
+} tsk_recomb_required_record;
+
+typedef struct {
+    tsk_compressed_matrix_t matrix;
+    tsk_recomb_required_record *recombination_required;
+    size_t num_recomb_records;
+    size_t max_recomb_records;
+} tsk_viterbi_matrix_t;
+
+typedef struct _tsk_ls_hmm_t {
+    /* input */
+    tsk_treeseq_t *tree_sequence;
+    double *recombination_rate;
+    double *mutation_rate;
+    const char ***alleles;
+    unsigned int precision;
+    uint8_t *num_alleles;
+    tsk_size_t num_samples;
+    tsk_size_t num_sites;
+    tsk_size_t num_nodes;
+    /* state */
+    tsk_tree_t tree;
+    tsk_diff_iter_t diffs;
+    tsk_id_t *parent;
+    /* The probability value transitions on the tree */
+    tsk_value_transition_t *transitions;
+    tsk_value_transition_t *transitions_copy;
+    /* Stack used when distributing transitions on the tree */
+    tsk_transition_stack_t *transition_stack;
+    /* Map of node_id to index in the transitions list */
+    tsk_id_t *transition_index;
+    /* Buffer used to argsort the transitions by node time */
+    tsk_argsort_t *transition_time_order;
+    size_t num_transitions;
+    size_t max_transitions;
+    /* The distinct values in the transitions */
+    double *values;
+    size_t num_values;
+    size_t max_values;
+    /* Number of machine words per node fitch set. */
+    size_t num_fitch_words;
+    uint64_t *fitch_sets;
+    /* The parent transition; used during compression */
+    tsk_id_t *transition_parent;
+    /* The number of samples directly subtended by a transition */
+    tsk_id_t *num_transition_samples;
+    int8_t *allelic_state;
+    /* Algorithms set these values before they are run */
+    int (*next_probability)(
+        struct _tsk_ls_hmm_t *, tsk_id_t, double, bool, tsk_id_t, double *);
+    double (*compute_normalisation_factor)(struct _tsk_ls_hmm_t *);
+    void *output;
+} tsk_ls_hmm_t;
+
+int tsk_ls_hmm_init(tsk_ls_hmm_t *self, tsk_treeseq_t *tree_sequence,
+    double *recombination_rate, double *mutation_rate, tsk_flags_t options);
+int tsk_ls_hmm_set_precision(tsk_ls_hmm_t *self, unsigned int precision);
+int tsk_ls_hmm_free(tsk_ls_hmm_t *self);
+void tsk_ls_hmm_print_state(tsk_ls_hmm_t *self, FILE *out);
+int tsk_ls_hmm_forward(tsk_ls_hmm_t *self, int8_t *haplotype,
+    tsk_compressed_matrix_t *output, tsk_flags_t options);
+int tsk_ls_hmm_viterbi(tsk_ls_hmm_t *self, int8_t *haplotype,
+    tsk_viterbi_matrix_t *output, tsk_flags_t options);
+int tsk_ls_hmm_run(tsk_ls_hmm_t *self, int8_t *haplotype,
+    int (*next_probability)(tsk_ls_hmm_t *, tsk_id_t, double, bool, tsk_id_t, double *),
+    double (*compute_normalisation_factor)(struct _tsk_ls_hmm_t *), void *output);
+
+int tsk_compressed_matrix_init(tsk_compressed_matrix_t *self,
+    tsk_treeseq_t *tree_sequence, size_t block_size, tsk_flags_t options);
+int tsk_compressed_matrix_free(tsk_compressed_matrix_t *self);
+int tsk_compressed_matrix_clear(tsk_compressed_matrix_t *self);
+void tsk_compressed_matrix_print_state(tsk_compressed_matrix_t *self, FILE *out);
+int tsk_compressed_matrix_store_site(tsk_compressed_matrix_t *self, tsk_id_t site,
+    double normalisation_factor, tsk_size_t num_transitions,
+    const tsk_value_transition_t *transitions);
+int tsk_compressed_matrix_decode(tsk_compressed_matrix_t *self, double *values);
+
+int tsk_viterbi_matrix_init(tsk_viterbi_matrix_t *self, tsk_treeseq_t *tree_sequence,
+    size_t block_size, tsk_flags_t options);
+int tsk_viterbi_matrix_free(tsk_viterbi_matrix_t *self);
+int tsk_viterbi_matrix_clear(tsk_viterbi_matrix_t *self);
+void tsk_viterbi_matrix_print_state(tsk_viterbi_matrix_t *self, FILE *out);
+int tsk_viterbi_matrix_add_recombination_required(
+    tsk_viterbi_matrix_t *self, tsk_id_t site, tsk_id_t node, bool required);
+int tsk_viterbi_matrix_traceback(
+    tsk_viterbi_matrix_t *self, tsk_id_t *path, tsk_flags_t options);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/subprojects/tskit/tskit/stats.c
+++ b/subprojects/tskit/tskit/stats.c
@@ -1,0 +1,475 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2016-2017 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <tskit/stats.h>
+
+static void
+tsk_ld_calc_check_state(const tsk_ld_calc_t *self)
+{
+    uint32_t u;
+    uint32_t num_nodes = (uint32_t) tsk_treeseq_get_num_nodes(self->tree_sequence);
+    tsk_tree_t *tA = self->outer_tree;
+    tsk_tree_t *tB = self->inner_tree;
+
+    tsk_bug_assert(tA->index == tB->index);
+
+    /* The inner tree's mark values should all be zero. */
+    for (u = 0; u < num_nodes; u++) {
+        tsk_bug_assert(tA->marked[u] == 0);
+        tsk_bug_assert(tB->marked[u] == 0);
+    }
+}
+
+void
+tsk_ld_calc_print_state(const tsk_ld_calc_t *self, FILE *out)
+{
+    fprintf(out, "tree_sequence = %p\n", (const void *) self->tree_sequence);
+    fprintf(out, "outer tree index = %d\n", (int) self->outer_tree->index);
+    fprintf(out, "outer tree interval = (%f, %f)\n", self->outer_tree->left,
+        self->outer_tree->right);
+    fprintf(out, "inner tree index = %d\n", (int) self->inner_tree->index);
+    fprintf(out, "inner tree interval = (%f, %f)\n", self->inner_tree->left,
+        self->inner_tree->right);
+    tsk_ld_calc_check_state(self);
+}
+
+int TSK_WARN_UNUSED
+tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence)
+{
+    int ret = TSK_ERR_GENERIC;
+
+    memset(self, 0, sizeof(tsk_ld_calc_t));
+    self->tree_sequence = tree_sequence;
+    self->num_sites = tsk_treeseq_get_num_sites(tree_sequence);
+    self->outer_tree = malloc(sizeof(tsk_tree_t));
+    self->inner_tree = malloc(sizeof(tsk_tree_t));
+    if (self->outer_tree == NULL || self->inner_tree == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    ret = tsk_tree_init(self->outer_tree, self->tree_sequence, TSK_SAMPLE_LISTS);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_tree_init(self->inner_tree, self->tree_sequence, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_tree_first(self->outer_tree);
+    if (ret < 0) {
+        goto out;
+    }
+    ret = tsk_tree_first(self->inner_tree);
+    if (ret < 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+int
+tsk_ld_calc_free(tsk_ld_calc_t *self)
+{
+    if (self->inner_tree != NULL) {
+        tsk_tree_free(self->inner_tree);
+        free(self->inner_tree);
+    }
+    if (self->outer_tree != NULL) {
+        tsk_tree_free(self->outer_tree);
+        free(self->outer_tree);
+    }
+    return 0;
+}
+
+/* Position the two trees so that the specified site is within their
+ * interval.
+ */
+static int TSK_WARN_UNUSED
+tsk_ld_calc_position_trees(tsk_ld_calc_t *self, tsk_id_t site_index)
+{
+    int ret = TSK_ERR_GENERIC;
+    tsk_site_t mut;
+    double x;
+    tsk_tree_t *tA = self->outer_tree;
+    tsk_tree_t *tB = self->inner_tree;
+
+    ret = tsk_treeseq_get_site(self->tree_sequence, site_index, &mut);
+    if (ret != 0) {
+        goto out;
+    }
+    x = mut.position;
+    tsk_bug_assert(tA->index == tB->index);
+    while (x >= tA->right) {
+        ret = tsk_tree_next(tA);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+        ret = tsk_tree_next(tB);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+    }
+    while (x < tA->left) {
+        ret = tsk_tree_prev(tA);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+        ret = tsk_tree_prev(tB);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+    }
+    ret = 0;
+    tsk_bug_assert(x >= tA->left && x < tB->right);
+    tsk_bug_assert(tA->index == tB->index);
+out:
+    return ret;
+}
+
+static double
+tsk_ld_calc_overlap_within_tree(tsk_ld_calc_t *self, tsk_site_t sA, tsk_site_t sB)
+{
+    const tsk_tree_t *t = self->inner_tree;
+    const tsk_node_table_t *nodes = &self->tree_sequence->tables->nodes;
+    tsk_id_t u, v, nAB;
+
+    tsk_bug_assert(sA.mutations_length == 1);
+    tsk_bug_assert(sB.mutations_length == 1);
+    u = sA.mutations[0].node;
+    v = sB.mutations[0].node;
+    if (nodes->time[u] > nodes->time[v]) {
+        v = sA.mutations[0].node;
+        u = sB.mutations[0].node;
+    }
+    while (u != v && u != TSK_NULL) {
+        u = t->parent[u];
+    }
+    nAB = 0;
+    if (u == v) {
+        nAB = TSK_MIN(
+            t->num_samples[sA.mutations[0].node], t->num_samples[sB.mutations[0].node]);
+    }
+    return (double) nAB;
+}
+
+static inline int TSK_WARN_UNUSED
+tsk_ld_calc_set_tracked_samples(tsk_ld_calc_t *self, tsk_site_t sA)
+{
+    int ret = 0;
+
+    tsk_bug_assert(sA.mutations_length == 1);
+    ret = tsk_tree_set_tracked_samples_from_sample_list(
+        self->inner_tree, self->outer_tree, sA.mutations[0].node);
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_ld_calc_get_r2_array_forward(tsk_ld_calc_t *self, tsk_id_t source_index,
+    tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values)
+{
+    int ret = TSK_ERR_GENERIC;
+    tsk_site_t sA, sB;
+    double fA, fB, fAB, D;
+    int tracked_samples_set = 0;
+    tsk_tree_t *tA, *tB;
+    double n = (double) tsk_treeseq_get_num_samples(self->tree_sequence);
+    tsk_id_t j;
+    double nAB;
+
+    tA = self->outer_tree;
+    tB = self->inner_tree;
+    ret = tsk_treeseq_get_site(self->tree_sequence, source_index, &sA);
+    if (ret != 0) {
+        goto out;
+    }
+    if (sA.mutations_length > 1) {
+        ret = TSK_ERR_ONLY_INFINITE_SITES;
+        goto out;
+    }
+    fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
+    tsk_bug_assert(fA > 0);
+    tB->mark = 1;
+    for (j = 0; j < (tsk_id_t) max_sites; j++) {
+        if (source_index + j + 1 >= (tsk_id_t) self->num_sites) {
+            break;
+        }
+        ret = tsk_treeseq_get_site(self->tree_sequence, (source_index + j + 1), &sB);
+        if (ret != 0) {
+            goto out;
+        }
+        if (sB.mutations_length > 1) {
+            ret = TSK_ERR_ONLY_INFINITE_SITES;
+            goto out;
+        }
+        if (sB.position - sA.position > max_distance) {
+            break;
+        }
+        while (sB.position >= tB->right) {
+            ret = tsk_tree_next(tB);
+            if (ret < 0) {
+                goto out;
+            }
+            tsk_bug_assert(ret == 1);
+        }
+        fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
+        tsk_bug_assert(fB > 0);
+        if (sB.position < tA->right) {
+            nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
+        } else {
+            if (!tracked_samples_set && tB->marked[sA.mutations[0].node] == 1) {
+                tracked_samples_set = 1;
+                ret = tsk_ld_calc_set_tracked_samples(self, sA);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+            if (tracked_samples_set) {
+                nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];
+            } else {
+                nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
+            }
+        }
+        fAB = nAB / n;
+        D = fAB - fA * fB;
+        r2[j] = D * D / (fA * fB * (1 - fA) * (1 - fB));
+    }
+
+    /* Now rewind back the inner iterator and unmark all nodes that
+     * were set to 1 as we moved forward. */
+    tB->mark = 0;
+    while (tB->index > tA->index) {
+        ret = tsk_tree_prev(tB);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+    }
+    *num_r2_values = (tsk_size_t) j;
+    ret = 0;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_ld_calc_get_r2_array_reverse(tsk_ld_calc_t *self, tsk_id_t source_index,
+    tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values)
+{
+    int ret = TSK_ERR_GENERIC;
+    tsk_site_t sA, sB;
+    double fA, fB, fAB, D;
+    int tracked_samples_set = 0;
+    tsk_tree_t *tA, *tB;
+    double n = (double) tsk_treeseq_get_num_samples(self->tree_sequence);
+    double nAB;
+    tsk_id_t j, site_index;
+
+    tA = self->outer_tree;
+    tB = self->inner_tree;
+    ret = tsk_treeseq_get_site(self->tree_sequence, source_index, &sA);
+    if (ret != 0) {
+        goto out;
+    }
+    if (sA.mutations_length > 1) {
+        ret = TSK_ERR_ONLY_INFINITE_SITES;
+        goto out;
+    }
+    fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
+    tsk_bug_assert(fA > 0);
+    tB->mark = 1;
+    for (j = 0; j < (tsk_id_t) max_sites; j++) {
+        site_index = source_index - j - 1;
+        if (site_index < 0) {
+            break;
+        }
+        ret = tsk_treeseq_get_site(self->tree_sequence, site_index, &sB);
+        if (ret != 0) {
+            goto out;
+        }
+        if (sB.mutations_length > 1) {
+            ret = TSK_ERR_ONLY_INFINITE_SITES;
+            goto out;
+        }
+        if (sA.position - sB.position > max_distance) {
+            break;
+        }
+        while (sB.position < tB->left) {
+            ret = tsk_tree_prev(tB);
+            if (ret < 0) {
+                goto out;
+            }
+            tsk_bug_assert(ret == 1);
+        }
+        fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
+        tsk_bug_assert(fB > 0);
+        if (sB.position >= tA->left) {
+            nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
+        } else {
+            if (!tracked_samples_set && tB->marked[sA.mutations[0].node] == 1) {
+                tracked_samples_set = 1;
+                ret = tsk_ld_calc_set_tracked_samples(self, sA);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+            if (tracked_samples_set) {
+                nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];
+            } else {
+                nAB = tsk_ld_calc_overlap_within_tree(self, sA, sB);
+            }
+        }
+        fAB = nAB / n;
+        D = fAB - fA * fB;
+        r2[j] = D * D / (fA * fB * (1 - fA) * (1 - fB));
+    }
+
+    /* Now fast forward the inner iterator and unmark all nodes that
+     * were set to 1 as we moved back. */
+    tB->mark = 0;
+    while (tB->index < tA->index) {
+        ret = tsk_tree_next(tB);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+    }
+    *num_r2_values = (tsk_size_t) j;
+    ret = 0;
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_ld_calc_get_r2_array(tsk_ld_calc_t *self, tsk_id_t a, int direction,
+    tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values)
+{
+    int ret = TSK_ERR_GENERIC;
+
+    if (a < 0 || a >= (tsk_id_t) self->num_sites) {
+        ret = TSK_ERR_OUT_OF_BOUNDS;
+        goto out;
+    }
+    ret = tsk_ld_calc_position_trees(self, a);
+    if (ret != 0) {
+        goto out;
+    }
+    if (direction == TSK_DIR_FORWARD) {
+        ret = tsk_ld_calc_get_r2_array_forward(
+            self, a, max_sites, max_distance, r2, num_r2_values);
+    } else if (direction == TSK_DIR_REVERSE) {
+        ret = tsk_ld_calc_get_r2_array_reverse(
+            self, a, max_sites, max_distance, r2, num_r2_values);
+    } else {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2)
+{
+    int ret = TSK_ERR_GENERIC;
+    tsk_site_t sA, sB;
+    double fA, fB, fAB, D;
+    tsk_tree_t *tA, *tB;
+    double n = (double) tsk_treeseq_get_num_samples(self->tree_sequence);
+    double nAB;
+    tsk_id_t tmp;
+
+    if (a < 0 || b < 0 || a >= (tsk_id_t) self->num_sites
+        || b >= (tsk_id_t) self->num_sites) {
+        ret = TSK_ERR_OUT_OF_BOUNDS;
+        goto out;
+    }
+    if (a > b) {
+        tmp = a;
+        a = b;
+        b = tmp;
+    }
+    ret = tsk_ld_calc_position_trees(self, a);
+    if (ret != 0) {
+        goto out;
+    }
+    /* We can probably do a lot better than this implementation... */
+    tA = self->outer_tree;
+    tB = self->inner_tree;
+    ret = tsk_treeseq_get_site(self->tree_sequence, a, &sA);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_get_site(self->tree_sequence, b, &sB);
+    if (ret != 0) {
+        goto out;
+    }
+    if (sA.mutations_length > 1 || sB.mutations_length > 1) {
+        ret = TSK_ERR_ONLY_INFINITE_SITES;
+        goto out;
+    }
+    tsk_bug_assert(sA.mutations_length == 1);
+    /* tsk_bug_assert(tA->parent[sA.mutations[0].node] != TSK_NULL); */
+    fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
+    tsk_bug_assert(fA > 0);
+    ret = tsk_ld_calc_set_tracked_samples(self, sA);
+    if (ret != 0) {
+        goto out;
+    }
+
+    while (sB.position >= tB->right) {
+        ret = tsk_tree_next(tB);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+    }
+    /* tsk_bug_assert(tB->parent[sB.mutations[0].node] != TSK_NULL); */
+    fB = ((double) tB->num_samples[sB.mutations[0].node]) / n;
+    tsk_bug_assert(fB > 0);
+    nAB = (double) tB->num_tracked_samples[sB.mutations[0].node];
+    fAB = nAB / n;
+    D = fAB - fA * fB;
+    *r2 = D * D / (fA * fB * (1 - fA) * (1 - fB));
+
+    /* Now rewind the inner iterator back. */
+    while (tB->index > tA->index) {
+        ret = tsk_tree_prev(tB);
+        if (ret < 0) {
+            goto out;
+        }
+        tsk_bug_assert(ret == 1);
+    }
+    ret = 0;
+out:
+    return ret;
+}

--- a/subprojects/tskit/tskit/stats.h
+++ b/subprojects/tskit/tskit/stats.h
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2016-2017 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef TSK_STATS_H
+#define TSK_STATS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <tskit/trees.h>
+
+typedef struct {
+    tsk_tree_t *outer_tree;
+    tsk_tree_t *inner_tree;
+    tsk_size_t num_sites;
+    int tree_changed;
+    const tsk_treeseq_t *tree_sequence;
+} tsk_ld_calc_t;
+
+int tsk_ld_calc_init(tsk_ld_calc_t *self, const tsk_treeseq_t *tree_sequence);
+int tsk_ld_calc_free(tsk_ld_calc_t *self);
+void tsk_ld_calc_print_state(const tsk_ld_calc_t *self, FILE *out);
+int tsk_ld_calc_get_r2(tsk_ld_calc_t *self, tsk_id_t a, tsk_id_t b, double *r2);
+int tsk_ld_calc_get_r2_array(tsk_ld_calc_t *self, tsk_id_t a, int direction,
+    tsk_size_t max_sites, double max_distance, double *r2, tsk_size_t *num_r2_values);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/subprojects/tskit/tskit/tables.c
+++ b/subprojects/tskit/tskit/tables.c
@@ -1,0 +1,9557 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 Tskit Developers
+ * Copyright (c) 2017-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <float.h>
+#include <math.h>
+
+#define _TSK_WORKAROUND_FALSE_CLANG_WARNING
+#include <tskit/tables.h>
+
+#define DEFAULT_SIZE_INCREMENT 1024
+#define TABLE_SEP "-----------------------------------------\n"
+
+#define TSK_COL_OPTIONAL (1 << 0)
+
+typedef struct {
+    const char *name;
+    void **array_dest;
+    tsk_size_t *len_dest;
+    tsk_size_t len_offset;
+    int type;
+    tsk_flags_t options;
+} read_table_col_t;
+
+typedef struct {
+    const char *name;
+    void *array;
+    tsk_size_t len;
+    int type;
+} write_table_col_t;
+
+/* Returns true if adding the specified number of rows would result in overflow.
+ * Tables can support indexes from 0 to INT32_MAX, and therefore have at most
+ * INT32_MAX + 1 rows */
+static bool
+check_table_overflow(tsk_size_t current_size, tsk_size_t additional_rows)
+{
+    uint64_t new_size = (uint64_t) current_size + (uint64_t) additional_rows;
+    return new_size > ((uint64_t) INT32_MAX) + 1;
+}
+
+/* Returns true if adding the specified number of elements would result in overflow
+ * of an offset column.
+ */
+static bool
+check_offset_overflow(tsk_size_t current_size, tsk_size_t additional_elements)
+{
+    uint64_t new_size = (uint64_t) current_size + (uint64_t) additional_elements;
+    return new_size > UINT32_MAX;
+}
+
+static int
+read_table_cols(kastore_t *store, read_table_col_t *read_cols, size_t num_cols)
+{
+    int ret = 0;
+    size_t len;
+    int type;
+    size_t j;
+    tsk_size_t last_len;
+
+    /* Set all the size destinations to -1 so we can detect the first time we
+     * read it. Therefore, destinations that are supposed to have the same
+     * length will take the value of the first instance, and we check each
+     * subsequent value against this. */
+    for (j = 0; j < num_cols; j++) {
+        *read_cols[j].len_dest = (tsk_size_t) -1;
+    }
+    for (j = 0; j < num_cols; j++) {
+        ret = kastore_containss(store, read_cols[j].name);
+        if (ret < 0) {
+            ret = tsk_set_kas_error(ret);
+            goto out;
+        }
+        if (ret == 1) {
+            ret = kastore_gets(
+                store, read_cols[j].name, read_cols[j].array_dest, &len, &type);
+            if (ret != 0) {
+                ret = tsk_set_kas_error(ret);
+                goto out;
+            }
+            last_len = *read_cols[j].len_dest;
+            if (last_len == (tsk_size_t) -1) {
+                if (len < read_cols[j].len_offset) {
+                    ret = TSK_ERR_FILE_FORMAT;
+                    goto out;
+                }
+                *read_cols[j].len_dest = (tsk_size_t)(len - read_cols[j].len_offset);
+            } else if ((last_len + read_cols[j].len_offset) != (tsk_size_t) len) {
+                ret = TSK_ERR_FILE_FORMAT;
+                goto out;
+            }
+            if (type != read_cols[j].type) {
+                ret = TSK_ERR_FILE_FORMAT;
+                goto out;
+            }
+        } else if (!(read_cols[j].options & TSK_COL_OPTIONAL)) {
+            ret = TSK_ERR_REQUIRED_COL_NOT_FOUND;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+write_table_cols(kastore_t *store, write_table_col_t *write_cols, size_t num_cols)
+{
+    int ret = 0;
+    size_t j;
+
+    for (j = 0; j < num_cols; j++) {
+        ret = kastore_puts(store, write_cols[j].name, write_cols[j].array,
+            write_cols[j].len, write_cols[j].type, 0);
+        if (ret != 0) {
+            ret = tsk_set_kas_error(ret);
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/* Checks that the specified list of offsets is well-formed. */
+static int
+check_offsets(
+    size_t num_rows, const tsk_size_t *offsets, tsk_size_t length, bool check_length)
+{
+    int ret = TSK_ERR_BAD_OFFSET;
+    size_t j;
+
+    if (offsets[0] != 0) {
+        goto out;
+    }
+    if (check_length && offsets[num_rows] != length) {
+        goto out;
+    }
+    for (j = 0; j < num_rows; j++) {
+        if (offsets[j] > offsets[j + 1]) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+expand_column(void **column, size_t new_max_rows, size_t element_size)
+{
+    int ret = 0;
+    void *tmp;
+
+    tmp = realloc((void **) *column, new_max_rows * element_size);
+    if (tmp == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    *column = tmp;
+out:
+    return ret;
+}
+
+static int
+replace_string(
+    char **str, tsk_size_t *len, const char *new_str, const tsk_size_t new_len)
+{
+    int ret = 0;
+    tsk_safe_free(*str);
+    *str = NULL;
+    *len = new_len;
+    if (new_len > 0) {
+        *str = malloc(new_len * sizeof(char));
+        if (*str == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        memcpy(*str, new_str, new_len * sizeof(char));
+    }
+out:
+    return ret;
+}
+
+static int
+write_metadata_schema_header(
+    FILE *out, const char *metadata_schema, tsk_size_t metadata_schema_length)
+{
+    const char *fmt = "#metadata_schema#\n"
+                      "%.*s\n"
+                      "#end#metadata_schema\n";
+    return fprintf(out, fmt, metadata_schema_length, metadata_schema);
+}
+
+/*************************
+ * individual table
+ *************************/
+
+static int
+tsk_individual_table_expand_main_columns(
+    tsk_individual_table_t *self, tsk_size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment = TSK_MAX(additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column((void **) &self->flags, new_size, sizeof(tsk_flags_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->location_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->metadata_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_individual_table_expand_location(
+    tsk_individual_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX(additional_length, self->max_location_length_increment);
+    tsk_size_t new_size = self->max_location_length + increment;
+
+    if (check_offset_overflow(self->location_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->location_length + additional_length) > self->max_location_length) {
+        ret = expand_column((void **) &self->location, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_location_length = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_individual_table_expand_metadata(
+    tsk_individual_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX(additional_length, self->max_metadata_length_increment);
+    tsk_size_t new_size = self->max_metadata_length + increment;
+
+    if (check_offset_overflow(self->metadata_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_individual_table_set_max_rows_increment(
+    tsk_individual_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = (tsk_size_t) max_rows_increment;
+    return 0;
+}
+
+int
+tsk_individual_table_set_max_metadata_length_increment(
+    tsk_individual_table_t *self, tsk_size_t max_metadata_length_increment)
+{
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_metadata_length_increment = (tsk_size_t) max_metadata_length_increment;
+    return 0;
+}
+
+int
+tsk_individual_table_set_max_location_length_increment(
+    tsk_individual_table_t *self, tsk_size_t max_location_length_increment)
+{
+    if (max_location_length_increment == 0) {
+        max_location_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_location_length_increment = (tsk_size_t) max_location_length_increment;
+    return 0;
+}
+
+int
+tsk_individual_table_init(tsk_individual_table_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_individual_table_t));
+    /* Allocate space for one row initially, ensuring we always have valid pointers
+     * even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_location_length_increment = 1;
+    self->max_metadata_length_increment = 1;
+    ret = tsk_individual_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_expand_location(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->location_offset[0] = 0;
+    ret = tsk_individual_table_expand_metadata(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->metadata_offset[0] = 0;
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_location_length_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    tsk_individual_table_set_metadata_schema(self, NULL, 0);
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_individual_table_copy(const tsk_individual_table_t *self,
+    tsk_individual_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_individual_table_init(dest, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_individual_table_set_columns(dest, self->num_rows, self->flags,
+        self->location, self->location_offset, self->metadata, self->metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_individual_table_set_columns(tsk_individual_table_t *self, tsk_size_t num_rows,
+    const tsk_flags_t *flags, const double *location, const tsk_size_t *location_offset,
+    const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+
+    ret = tsk_individual_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_append_columns(
+        self, num_rows, flags, location, location_offset, metadata, metadata_offset);
+out:
+    return ret;
+}
+
+int
+tsk_individual_table_append_columns(tsk_individual_table_t *self, tsk_size_t num_rows,
+    const tsk_flags_t *flags, const double *location, const tsk_size_t *location_offset,
+    const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+    tsk_size_t j, metadata_length, location_length;
+
+    if (flags == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((location == NULL) != (location_offset == NULL)) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    ret = tsk_individual_table_expand_main_columns(self, (tsk_size_t) num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->flags + self->num_rows, flags, num_rows * sizeof(tsk_flags_t));
+    if (location == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->location_offset[self->num_rows + j + 1]
+                = (tsk_size_t) self->location_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, location_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_rows; j++) {
+            self->location_offset[self->num_rows + j]
+                = (tsk_size_t) self->location_length + location_offset[j];
+        }
+        location_length = location_offset[num_rows];
+        ret = tsk_individual_table_expand_location(self, location_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->location + self->location_length, location,
+            location_length * sizeof(double));
+        self->location_length += location_length;
+    }
+    if (metadata == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j + 1]
+                = (tsk_size_t) self->metadata_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, metadata_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j]
+                = (tsk_size_t) self->metadata_length + metadata_offset[j];
+        }
+        metadata_length = metadata_offset[num_rows];
+        ret = tsk_individual_table_expand_metadata(self, metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->metadata + self->metadata_length, metadata,
+            metadata_length * sizeof(char));
+        self->metadata_length += metadata_length;
+    }
+    self->num_rows += (tsk_size_t) num_rows;
+    self->location_offset[self->num_rows] = self->location_length;
+    self->metadata_offset[self->num_rows] = self->metadata_length;
+out:
+    return ret;
+}
+
+static tsk_id_t
+tsk_individual_table_add_row_internal(tsk_individual_table_t *self, tsk_flags_t flags,
+    const double *location, tsk_size_t location_length, const char *metadata,
+    tsk_size_t metadata_length)
+{
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    tsk_bug_assert(self->location_length + location_length <= self->max_location_length);
+    self->flags[self->num_rows] = flags;
+    memcpy(self->location + self->location_length, location,
+        location_length * sizeof(double));
+    self->location_offset[self->num_rows + 1] = self->location_length + location_length;
+    self->location_length += location_length;
+    memcpy(self->metadata + self->metadata_length, metadata,
+        metadata_length * sizeof(char));
+    self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
+    self->metadata_length += metadata_length;
+    self->num_rows++;
+    return (tsk_id_t) self->num_rows - 1;
+}
+
+tsk_id_t
+tsk_individual_table_add_row(tsk_individual_table_t *self, tsk_flags_t flags,
+    const double *location, tsk_size_t location_length, const char *metadata,
+    tsk_size_t metadata_length)
+{
+    int ret = 0;
+
+    ret = tsk_individual_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_expand_location(self, (tsk_size_t) location_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_expand_metadata(self, (tsk_size_t) metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_add_row_internal(self, flags, location,
+        (tsk_size_t) location_length, metadata, (tsk_size_t) metadata_length);
+out:
+    return ret;
+}
+
+int
+tsk_individual_table_clear(tsk_individual_table_t *self)
+{
+    return tsk_individual_table_truncate(self, 0);
+}
+
+int
+tsk_individual_table_truncate(tsk_individual_table_t *self, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > self->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = num_rows;
+    self->location_length = self->location_offset[num_rows];
+    self->metadata_length = self->metadata_offset[num_rows];
+out:
+    return ret;
+}
+
+int
+tsk_individual_table_free(tsk_individual_table_t *self)
+{
+    tsk_safe_free(self->flags);
+    tsk_safe_free(self->location);
+    tsk_safe_free(self->location_offset);
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_offset);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+void
+tsk_individual_table_print_state(const tsk_individual_table_t *self, FILE *out)
+{
+    tsk_size_t j, k;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "tsk_individual_tbl: %p:\n", (const void *) self);
+    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->metadata_length, (int) self->max_metadata_length,
+        (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    /* We duplicate the dump_text code here because we want to output
+     * the offset columns. */
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    fprintf(out, "id\tflags\tlocation_offset\tlocation\t");
+    fprintf(out, "metadata_offset\tmetadata\n");
+    for (j = 0; j < self->num_rows; j++) {
+        fprintf(out, "%d\t%d\t", (int) j, self->flags[j]);
+        fprintf(out, "%d\t", self->location_offset[j]);
+        for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
+            fprintf(out, "%f", self->location[k]);
+            if (k + 1 < self->location_offset[j + 1]) {
+                fprintf(out, ",");
+            }
+        }
+        fprintf(out, "\t");
+        fprintf(out, "%d\t", self->metadata_offset[j]);
+        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
+            fprintf(out, "%c", self->metadata[k]);
+        }
+        fprintf(out, "\n");
+    }
+}
+
+static inline void
+tsk_individual_table_get_row_unsafe(
+    const tsk_individual_table_t *self, tsk_id_t index, tsk_individual_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->flags = self->flags[index];
+    row->location_length
+        = self->location_offset[index + 1] - self->location_offset[index];
+    row->location = self->location + self->location_offset[index];
+    row->metadata_length
+        = self->metadata_offset[index + 1] - self->metadata_offset[index];
+    row->metadata = self->metadata + self->metadata_offset[index];
+    /* Also have referencing individuals here. Should this be a different struct?
+     * See also site. */
+    row->nodes_length = 0;
+    row->nodes = NULL;
+}
+
+int
+tsk_individual_table_get_row(
+    const tsk_individual_table_t *self, tsk_id_t index, tsk_individual_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_individual_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+int
+tsk_individual_table_set_metadata_schema(tsk_individual_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_individual_table_dump_text(const tsk_individual_table_t *self, FILE *out)
+{
+    int ret = TSK_ERR_IO;
+    tsk_size_t j, k;
+    tsk_size_t metadata_len;
+    int err;
+
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err < 0) {
+        goto out;
+    }
+    err = fprintf(out, "id\tflags\tlocation\tmetadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%d\t", (int) j, (int) self->flags[j]);
+        if (err < 0) {
+            goto out;
+        }
+        for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
+            err = fprintf(out, "%.*g", TSK_DBL_DECIMAL_DIG, self->location[k]);
+            if (err < 0) {
+                goto out;
+            }
+            if (k + 1 < self->location_offset[j + 1]) {
+                err = fprintf(out, ",");
+                if (err < 0) {
+                    goto out;
+                }
+            }
+        }
+        err = fprintf(
+            out, "\t%.*s\n", metadata_len, self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool
+tsk_individual_table_equals(const tsk_individual_table_t *self,
+    const tsk_individual_table_t *other, tsk_flags_t options)
+{
+    bool ret
+        = self->num_rows == other->num_rows
+          && memcmp(self->flags, other->flags, self->num_rows * sizeof(tsk_flags_t)) == 0
+          && memcmp(self->location_offset, other->location_offset,
+                 (self->num_rows + 1) * sizeof(tsk_size_t))
+                 == 0
+          && memcmp(
+                 self->location, other->location, self->location_length * sizeof(double))
+                 == 0;
+    if (!(options & TSK_CMP_IGNORE_METADATA)) {
+        ret = ret && self->metadata_length == other->metadata_length
+              && self->metadata_schema_length == other->metadata_schema_length
+              && memcmp(self->metadata_offset, other->metadata_offset,
+                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                     == 0
+              && memcmp(self->metadata, other->metadata,
+                     self->metadata_length * sizeof(char))
+                     == 0
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0;
+    }
+    return ret;
+}
+
+static int
+tsk_individual_table_dump(const tsk_individual_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        { "individuals/flags", (void *) self->flags, self->num_rows, KAS_UINT32 },
+        { "individuals/location", (void *) self->location, self->location_length,
+            KAS_FLOAT64 },
+        { "individuals/location_offset", (void *) self->location_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "individuals/metadata", (void *) self->metadata, self->metadata_length,
+            KAS_UINT8 },
+        { "individuals/metadata_offset", (void *) self->metadata_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "individuals/metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_UINT8 },
+    };
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+tsk_individual_table_load(tsk_individual_table_t *self, kastore_t *store)
+{
+    int ret = 0;
+    tsk_flags_t *flags = NULL;
+    double *location = NULL;
+    tsk_size_t *location_offset = NULL;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+    char *metadata_schema = NULL;
+    tsk_size_t num_rows, location_length, metadata_length, metadata_schema_length;
+
+    read_table_col_t read_cols[] = {
+        { "individuals/flags", (void **) &flags, &num_rows, 0, KAS_UINT32, 0 },
+        { "individuals/location", (void **) &location, &location_length, 0, KAS_FLOAT64,
+            0 },
+        { "individuals/location_offset", (void **) &location_offset, &num_rows, 1,
+            KAS_UINT32, 0 },
+        { "individuals/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
+            0 },
+        { "individuals/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
+            KAS_UINT32, 0 },
+        { "individuals/metadata_schema", (void **) &metadata_schema,
+            &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if (location_offset[num_rows] != location_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    if (metadata_offset[num_rows] != metadata_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_individual_table_set_columns(
+        self, num_rows, flags, location, location_offset, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_schema != NULL) {
+        ret = tsk_individual_table_set_metadata_schema(
+            self, metadata_schema, metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * node table
+ *************************/
+
+static int
+tsk_node_table_expand_main_columns(tsk_node_table_t *self, tsk_size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment = TSK_MAX(additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column((void **) &self->flags, new_size, sizeof(tsk_flags_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->time, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->population, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->individual, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->metadata_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_node_table_expand_metadata(tsk_node_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX(additional_length, self->max_metadata_length_increment);
+    tsk_size_t new_size = self->max_metadata_length + increment;
+
+    if (check_offset_overflow(self->metadata_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_node_table_set_max_rows_increment(
+    tsk_node_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = max_rows_increment;
+    return 0;
+}
+
+int
+tsk_node_table_set_max_metadata_length_increment(
+    tsk_node_table_t *self, tsk_size_t max_metadata_length_increment)
+{
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_metadata_length_increment = max_metadata_length_increment;
+    return 0;
+}
+
+int
+tsk_node_table_init(tsk_node_table_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_node_table_t));
+    /* Allocate space for one row initially, ensuring we always have valid pointers
+     * even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_metadata_length_increment = 1;
+    ret = tsk_node_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_expand_metadata(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->metadata_offset[0] = 0;
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    tsk_node_table_set_metadata_schema(self, NULL, 0);
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_node_table_copy(
+    const tsk_node_table_t *self, tsk_node_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_node_table_init(dest, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_node_table_set_columns(dest, self->num_rows, self->flags, self->time,
+        self->population, self->individual, self->metadata, self->metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_node_table_set_columns(tsk_node_table_t *self, tsk_size_t num_rows,
+    const tsk_flags_t *flags, const double *time, const tsk_id_t *population,
+    const tsk_id_t *individual, const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+
+    ret = tsk_node_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_append_columns(
+        self, num_rows, flags, time, population, individual, metadata, metadata_offset);
+out:
+    return ret;
+}
+
+int
+tsk_node_table_append_columns(tsk_node_table_t *self, tsk_size_t num_rows,
+    const tsk_flags_t *flags, const double *time, const tsk_id_t *population,
+    const tsk_id_t *individual, const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+    tsk_size_t j, metadata_length;
+
+    if (flags == NULL || time == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    ret = tsk_node_table_expand_main_columns(self, num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->time + self->num_rows, time, num_rows * sizeof(double));
+    memcpy(self->flags + self->num_rows, flags, num_rows * sizeof(tsk_flags_t));
+    if (metadata == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j + 1] = self->metadata_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, metadata_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j]
+                = (tsk_size_t) self->metadata_length + metadata_offset[j];
+        }
+        metadata_length = metadata_offset[num_rows];
+        ret = tsk_node_table_expand_metadata(self, metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->metadata + self->metadata_length, metadata,
+            metadata_length * sizeof(char));
+        self->metadata_length += metadata_length;
+    }
+    if (population == NULL) {
+        /* Set population to NULL_POPULATION (-1) if not specified */
+        memset(self->population + self->num_rows, 0xff, num_rows * sizeof(tsk_id_t));
+    } else {
+        memcpy(
+            self->population + self->num_rows, population, num_rows * sizeof(tsk_id_t));
+    }
+    if (individual == NULL) {
+        /* Set individual to NULL_INDIVIDUAL (-1) if not specified */
+        memset(self->individual + self->num_rows, 0xff, num_rows * sizeof(tsk_id_t));
+    } else {
+        memcpy(
+            self->individual + self->num_rows, individual, num_rows * sizeof(tsk_id_t));
+    }
+    self->num_rows += (tsk_size_t) num_rows;
+    self->metadata_offset[self->num_rows] = self->metadata_length;
+out:
+    return ret;
+}
+
+static tsk_id_t
+tsk_node_table_add_row_internal(tsk_node_table_t *self, tsk_flags_t flags, double time,
+    tsk_id_t population, tsk_id_t individual, const char *metadata,
+    tsk_size_t metadata_length)
+{
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
+    self->flags[self->num_rows] = flags;
+    self->time[self->num_rows] = time;
+    self->population[self->num_rows] = population;
+    self->individual[self->num_rows] = individual;
+    self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
+    self->metadata_length += metadata_length;
+    self->num_rows++;
+    return (tsk_id_t) self->num_rows - 1;
+}
+
+tsk_id_t
+tsk_node_table_add_row(tsk_node_table_t *self, tsk_flags_t flags, double time,
+    tsk_id_t population, tsk_id_t individual, const char *metadata,
+    tsk_size_t metadata_length)
+{
+    int ret = 0;
+
+    ret = tsk_node_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_expand_metadata(self, metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_add_row_internal(
+        self, flags, time, population, individual, metadata, metadata_length);
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_node_table_clear(tsk_node_table_t *self)
+{
+    return tsk_node_table_truncate(self, 0);
+}
+
+int
+tsk_node_table_truncate(tsk_node_table_t *self, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > self->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = num_rows;
+    self->metadata_length = self->metadata_offset[num_rows];
+out:
+    return ret;
+}
+
+int
+tsk_node_table_free(tsk_node_table_t *self)
+{
+    tsk_safe_free(self->flags);
+    tsk_safe_free(self->time);
+    tsk_safe_free(self->population);
+    tsk_safe_free(self->individual);
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_offset);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+void
+tsk_node_table_print_state(const tsk_node_table_t *self, FILE *out)
+{
+    size_t j, k;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "tsk_node_tbl: %p:\n", (const void *) self);
+    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->metadata_length, (int) self->max_metadata_length,
+        (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    /* We duplicate the dump_text code here for simplicity because we want to output
+     * the flags column directly. */
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    fprintf(out, "id\tflags\ttime\tpopulation\tindividual\tmetadata_offset\tmetadata\n");
+    for (j = 0; j < self->num_rows; j++) {
+        fprintf(out, "%d\t%d\t%f\t%d\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
+            (int) self->population[j], self->individual[j], self->metadata_offset[j]);
+        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
+            fprintf(out, "%c", self->metadata[k]);
+        }
+        fprintf(out, "\n");
+    }
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == self->metadata_length);
+}
+
+int
+tsk_node_table_set_metadata_schema(tsk_node_table_t *self, const char *metadata_schema,
+    tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_node_table_dump_text(const tsk_node_table_t *self, FILE *out)
+{
+    int ret = TSK_ERR_IO;
+    size_t j;
+    tsk_size_t metadata_len;
+    int err;
+
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err < 0) {
+        goto out;
+    }
+    err = fprintf(out, "id\tis_sample\ttime\tpopulation\tindividual\tmetadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%d\t%f\t%d\t%d\t%.*s\n", (int) j,
+            (int) (self->flags[j] & TSK_NODE_IS_SAMPLE), self->time[j],
+            self->population[j], self->individual[j], metadata_len,
+            self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool
+tsk_node_table_equals(
+    const tsk_node_table_t *self, const tsk_node_table_t *other, tsk_flags_t options)
+{
+    bool ret
+        = self->num_rows == other->num_rows
+          && memcmp(self->time, other->time, self->num_rows * sizeof(double)) == 0
+          && memcmp(self->flags, other->flags, self->num_rows * sizeof(tsk_flags_t)) == 0
+          && memcmp(
+                 self->population, other->population, self->num_rows * sizeof(tsk_id_t))
+                 == 0
+          && memcmp(
+                 self->individual, other->individual, self->num_rows * sizeof(tsk_id_t))
+                 == 0;
+    if (!(options & TSK_CMP_IGNORE_METADATA)) {
+        ret = ret && self->metadata_length == other->metadata_length
+              && self->metadata_schema_length == other->metadata_schema_length
+              && memcmp(self->metadata_offset, other->metadata_offset,
+                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                     == 0
+              && memcmp(self->metadata, other->metadata,
+                     self->metadata_length * sizeof(char))
+                     == 0
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0;
+    }
+    return ret;
+}
+
+static inline void
+tsk_node_table_get_row_unsafe(
+    const tsk_node_table_t *self, tsk_id_t index, tsk_node_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->flags = self->flags[index];
+    row->time = self->time[index];
+    row->population = self->population[index];
+    row->individual = self->individual[index];
+    row->metadata_length
+        = self->metadata_offset[index + 1] - self->metadata_offset[index];
+    row->metadata = self->metadata + self->metadata_offset[index];
+}
+
+int
+tsk_node_table_get_row(const tsk_node_table_t *self, tsk_id_t index, tsk_node_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_node_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+static int
+tsk_node_table_dump(const tsk_node_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        { "nodes/time", (void *) self->time, self->num_rows, KAS_FLOAT64 },
+        { "nodes/flags", (void *) self->flags, self->num_rows, KAS_UINT32 },
+        { "nodes/population", (void *) self->population, self->num_rows, KAS_INT32 },
+        { "nodes/individual", (void *) self->individual, self->num_rows, KAS_INT32 },
+        { "nodes/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8 },
+        { "nodes/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
+            KAS_UINT32 },
+        { "nodes/metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_UINT8 },
+
+    };
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+tsk_node_table_load(tsk_node_table_t *self, kastore_t *store)
+{
+    int ret = 0;
+    char *metadata_schema = NULL;
+    double *time = NULL;
+    tsk_flags_t *flags = NULL;
+    tsk_id_t *population = NULL;
+    tsk_id_t *individual = NULL;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+    tsk_size_t num_rows, metadata_length, metadata_schema_length;
+
+    read_table_col_t read_cols[] = {
+        { "nodes/time", (void **) &time, &num_rows, 0, KAS_FLOAT64, 0 },
+        { "nodes/flags", (void **) &flags, &num_rows, 0, KAS_UINT32, 0 },
+        { "nodes/population", (void **) &population, &num_rows, 0, KAS_INT32, 0 },
+        { "nodes/individual", (void **) &individual, &num_rows, 0, KAS_INT32, 0 },
+        { "nodes/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8, 0 },
+        { "nodes/metadata_offset", (void **) &metadata_offset, &num_rows, 1, KAS_UINT32,
+            0 },
+        { "nodes/metadata_schema", (void **) &metadata_schema, &metadata_schema_length,
+            0, KAS_UINT8, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_offset[num_rows] != metadata_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_node_table_set_columns(
+        self, num_rows, flags, time, population, individual, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_schema != NULL) {
+        ret = tsk_node_table_set_metadata_schema(
+            self, metadata_schema, metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * edge table
+ *************************/
+
+static int
+tsk_edge_table_has_metadata(const tsk_edge_table_t *self)
+{
+    return !(self->options & TSK_NO_METADATA);
+}
+
+static int
+tsk_edge_table_expand_main_columns(tsk_edge_table_t *self, size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX((tsk_size_t) additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column((void **) &self->left, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->right, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->parent, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->child, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        if (tsk_edge_table_has_metadata(self)) {
+            ret = expand_column(
+                (void **) &self->metadata_offset, new_size + 1, sizeof(tsk_size_t));
+            if (ret != 0) {
+                goto out;
+            }
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_edge_table_expand_metadata(tsk_edge_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX(additional_length, self->max_metadata_length_increment);
+    tsk_size_t new_size = self->max_metadata_length + increment;
+
+    if (check_offset_overflow(self->metadata_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_edge_table_set_max_rows_increment(
+    tsk_edge_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = max_rows_increment;
+    return 0;
+}
+
+int
+tsk_edge_table_set_max_metadata_length_increment(
+    tsk_edge_table_t *self, tsk_size_t max_metadata_length_increment)
+{
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_metadata_length_increment = max_metadata_length_increment;
+    return 0;
+}
+
+int
+tsk_edge_table_init(tsk_edge_table_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(*self));
+    self->options = options;
+
+    /* Allocate space for one row initially, ensuring we always have valid
+     * pointers even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_metadata_length_increment = 1;
+    ret = tsk_edge_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    if (tsk_edge_table_has_metadata(self)) {
+        ret = tsk_edge_table_expand_metadata(self, 1);
+        if (ret != 0) {
+            goto out;
+        }
+        self->metadata_offset[0] = 0;
+    }
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    tsk_edge_table_set_metadata_schema(self, NULL, 0);
+out:
+    return ret;
+}
+
+tsk_id_t
+tsk_edge_table_add_row(tsk_edge_table_t *self, double left, double right,
+    tsk_id_t parent, tsk_id_t child, const char *metadata, tsk_size_t metadata_length)
+{
+    int ret = 0;
+
+    if (metadata_length > 0 && !tsk_edge_table_has_metadata(self)) {
+        ret = TSK_ERR_METADATA_DISABLED;
+        goto out;
+    }
+
+    ret = tsk_edge_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    self->left[self->num_rows] = left;
+    self->right[self->num_rows] = right;
+    self->parent[self->num_rows] = parent;
+    self->child[self->num_rows] = child;
+
+    if (tsk_edge_table_has_metadata(self)) {
+        ret = tsk_edge_table_expand_metadata(self, metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+        tsk_bug_assert(
+            self->metadata_length + metadata_length <= self->max_metadata_length);
+        memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
+        self->metadata_offset[self->num_rows + 1]
+            = self->metadata_length + metadata_length;
+        self->metadata_length += metadata_length;
+    }
+    ret = (tsk_id_t) self->num_rows;
+    self->num_rows++;
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_edge_table_copy(
+    const tsk_edge_table_t *self, tsk_edge_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_edge_table_init(dest, options);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    /* We can't use TSK_NO_METADATA in dest if metadata_length is non-zero.
+     * This also captures the case where TSK_NO_METADATA is set on this table.
+     */
+    if (self->metadata_length > 0 && !tsk_edge_table_has_metadata(dest)) {
+        ret = TSK_ERR_METADATA_DISABLED;
+        goto out;
+    }
+    if (tsk_edge_table_has_metadata(dest)) {
+        metadata = self->metadata;
+        metadata_offset = self->metadata_offset;
+    }
+    ret = tsk_edge_table_set_columns(dest, self->num_rows, self->left, self->right,
+        self->parent, self->child, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+out:
+    return ret;
+}
+
+int
+tsk_edge_table_set_columns(tsk_edge_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *parent,
+    const tsk_id_t *child, const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret = 0;
+
+    ret = tsk_edge_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_append_columns(
+        self, num_rows, left, right, parent, child, metadata, metadata_offset);
+out:
+    return ret;
+}
+
+int
+tsk_edge_table_append_columns(tsk_edge_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *parent,
+    const tsk_id_t *child, const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+    tsk_size_t j, metadata_length;
+
+    if (left == NULL || right == NULL || parent == NULL || child == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if (metadata != NULL && !tsk_edge_table_has_metadata(self)) {
+        ret = TSK_ERR_METADATA_DISABLED;
+        goto out;
+    }
+
+    ret = tsk_edge_table_expand_main_columns(self, num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->left + self->num_rows, left, num_rows * sizeof(double));
+    memcpy(self->right + self->num_rows, right, num_rows * sizeof(double));
+    memcpy(self->parent + self->num_rows, parent, num_rows * sizeof(tsk_id_t));
+    memcpy(self->child + self->num_rows, child, num_rows * sizeof(tsk_id_t));
+    if (tsk_edge_table_has_metadata(self)) {
+        if (metadata == NULL) {
+            for (j = 0; j < num_rows; j++) {
+                self->metadata_offset[self->num_rows + j + 1] = self->metadata_length;
+            }
+        } else {
+            ret = check_offsets(num_rows, metadata_offset, 0, false);
+            if (ret != 0) {
+                goto out;
+            }
+            for (j = 0; j < num_rows; j++) {
+                self->metadata_offset[self->num_rows + j]
+                    = (tsk_size_t) self->metadata_length + metadata_offset[j];
+            }
+            metadata_length = metadata_offset[num_rows];
+            ret = tsk_edge_table_expand_metadata(self, metadata_length);
+            if (ret != 0) {
+                goto out;
+            }
+            memcpy(self->metadata + self->metadata_length, metadata,
+                metadata_length * sizeof(char));
+            self->metadata_length += metadata_length;
+        }
+        self->num_rows += num_rows;
+        self->metadata_offset[self->num_rows] = self->metadata_length;
+    } else {
+        self->num_rows += num_rows;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_edge_table_clear(tsk_edge_table_t *self)
+{
+    return tsk_edge_table_truncate(self, 0);
+}
+
+int
+tsk_edge_table_truncate(tsk_edge_table_t *self, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > self->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = num_rows;
+    if (tsk_edge_table_has_metadata(self)) {
+        self->metadata_length = self->metadata_offset[num_rows];
+    }
+out:
+    return ret;
+}
+
+int
+tsk_edge_table_free(tsk_edge_table_t *self)
+{
+    tsk_safe_free(self->left);
+    tsk_safe_free(self->right);
+    tsk_safe_free(self->parent);
+    tsk_safe_free(self->child);
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_offset);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+static inline void
+tsk_edge_table_get_row_unsafe(
+    const tsk_edge_table_t *self, tsk_id_t index, tsk_edge_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->left = self->left[index];
+    row->right = self->right[index];
+    row->parent = self->parent[index];
+    row->child = self->child[index];
+    if (tsk_edge_table_has_metadata(self)) {
+        row->metadata_length
+            = self->metadata_offset[index + 1] - self->metadata_offset[index];
+        row->metadata = self->metadata + self->metadata_offset[index];
+    } else {
+        row->metadata_length = 0;
+        row->metadata = NULL;
+    }
+}
+
+int
+tsk_edge_table_get_row(const tsk_edge_table_t *self, tsk_id_t index, tsk_edge_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_EDGE_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_edge_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+void
+tsk_edge_table_print_state(const tsk_edge_table_t *self, FILE *out)
+{
+    int ret;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "edge_table: %p:\n", (const void *) self);
+    fprintf(out, "options         = 0x%X\n", self->options);
+    fprintf(out, "num_rows        = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->metadata_length, (int) self->max_metadata_length,
+        (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    ret = tsk_edge_table_dump_text(self, out);
+    tsk_bug_assert(ret == 0);
+}
+
+int
+tsk_edge_table_set_metadata_schema(tsk_edge_table_t *self, const char *metadata_schema,
+    tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_edge_table_dump_text(const tsk_edge_table_t *self, FILE *out)
+{
+    tsk_id_t j;
+    int ret = TSK_ERR_IO;
+    tsk_edge_t row;
+    int err;
+
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err < 0) {
+        goto out;
+    }
+    err = fprintf(out, "id\tleft\tright\tparent\tchild\tmetadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < (tsk_id_t) self->num_rows; j++) {
+        tsk_edge_table_get_row_unsafe(self, j, &row);
+        err = fprintf(out, "%d\t%.3f\t%.3f\t%d\t%d\t%.*s\n", j, row.left, row.right,
+            row.parent, row.child, row.metadata_length, row.metadata);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool
+tsk_edge_table_equals(
+    const tsk_edge_table_t *self, const tsk_edge_table_t *other, tsk_flags_t options)
+{
+    bool metadata_equal;
+    bool ret
+        = self->num_rows == other->num_rows
+          && memcmp(self->left, other->left, self->num_rows * sizeof(double)) == 0
+          && memcmp(self->right, other->right, self->num_rows * sizeof(double)) == 0
+          && memcmp(self->parent, other->parent, self->num_rows * sizeof(tsk_id_t)) == 0
+          && memcmp(self->child, other->child, self->num_rows * sizeof(tsk_id_t)) == 0;
+
+    if (!(options & TSK_CMP_IGNORE_METADATA)) {
+        ret = ret && self->metadata_schema_length == other->metadata_schema_length
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0;
+        metadata_equal = false;
+        if (self->metadata_length == other->metadata_length) {
+            if (tsk_edge_table_has_metadata(self)
+                && tsk_edge_table_has_metadata(other)) {
+                metadata_equal = memcmp(self->metadata_offset, other->metadata_offset,
+                                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                                     == 0
+                                 && memcmp(self->metadata, other->metadata,
+                                        self->metadata_length * sizeof(char))
+                                        == 0;
+            } else {
+                /* The only way that the metadata lengths can be equal (which
+                 * we've already tested) and either one or the other of the tables
+                 * hasn't got metadata is if they are both zero length. */
+                tsk_bug_assert(self->metadata_length == 0);
+                metadata_equal = true;
+            }
+        }
+        ret = ret && metadata_equal;
+    }
+    return ret;
+}
+
+static int
+tsk_edge_table_dump(const tsk_edge_table_t *self, kastore_t *store)
+{
+    int ret = TSK_ERR_IO;
+
+    write_table_col_t write_cols[] = {
+        { "edges/left", (void *) self->left, self->num_rows, KAS_FLOAT64 },
+        { "edges/right", (void *) self->right, self->num_rows, KAS_FLOAT64 },
+        { "edges/parent", (void *) self->parent, self->num_rows, KAS_INT32 },
+        { "edges/child", (void *) self->child, self->num_rows, KAS_INT32 },
+        { "edges/metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_UINT8 },
+    };
+    write_table_col_t write_cols_metadata[] = {
+        { "edges/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8 },
+        { "edges/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
+            KAS_UINT32 },
+    };
+
+    ret = write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if (tsk_edge_table_has_metadata(self)) {
+        ret = write_table_cols(store, write_cols_metadata,
+            sizeof(write_cols_metadata) / sizeof(*write_cols_metadata));
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_edge_table_load(tsk_edge_table_t *self, kastore_t *store)
+{
+    int ret = 0;
+    char *metadata_schema = NULL;
+    double *left = NULL;
+    double *right = NULL;
+    tsk_id_t *parent = NULL;
+    tsk_id_t *child = NULL;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+    tsk_size_t num_rows, metadata_length, metadata_schema_length;
+
+    read_table_col_t read_cols[] = {
+        { "edges/left", (void **) &left, &num_rows, 0, KAS_FLOAT64, 0 },
+        { "edges/right", (void **) &right, &num_rows, 0, KAS_FLOAT64, 0 },
+        { "edges/parent", (void **) &parent, &num_rows, 0, KAS_INT32, 0 },
+        { "edges/child", (void **) &child, &num_rows, 0, KAS_INT32, 0 },
+        { "edges/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
+            TSK_COL_OPTIONAL },
+        { "edges/metadata_offset", (void **) &metadata_offset, &num_rows, 1, KAS_UINT32,
+            TSK_COL_OPTIONAL },
+        { "edges/metadata_schema", (void **) &metadata_schema, &metadata_schema_length,
+            0, KAS_UINT8, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BOTH_COLUMNS_REQUIRED;
+        goto out;
+    }
+    if (metadata != NULL && metadata_offset[num_rows] != metadata_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_edge_table_set_columns(
+        self, num_rows, left, right, parent, child, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_schema != NULL) {
+        ret = tsk_edge_table_set_metadata_schema(
+            self, metadata_schema, metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+int
+tsk_edge_table_squash(tsk_edge_table_t *self)
+{
+    int k;
+    int ret = 0;
+    tsk_edge_t *edges = NULL;
+    tsk_size_t num_output_edges;
+
+    if (self->metadata_length > 0) {
+        ret = TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA;
+        goto out;
+    }
+
+    edges = malloc(self->num_rows * sizeof(tsk_edge_t));
+    if (edges == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    for (k = 0; k < (int) self->num_rows; k++) {
+        edges[k].left = self->left[k];
+        edges[k].right = self->right[k];
+        edges[k].parent = self->parent[k];
+        edges[k].child = self->child[k];
+        edges[k].metadata_length = 0;
+    }
+
+    ret = tsk_squash_edges(edges, self->num_rows, &num_output_edges);
+    if (ret != 0) {
+        goto out;
+    }
+    tsk_edge_table_clear(self);
+    tsk_bug_assert(num_output_edges <= self->max_rows);
+    self->num_rows = num_output_edges;
+    for (k = 0; k < (int) num_output_edges; k++) {
+        self->left[k] = edges[k].left;
+        self->right[k] = edges[k].right;
+        self->parent[k] = edges[k].parent;
+        self->child[k] = edges[k].child;
+    }
+out:
+    tsk_safe_free(edges);
+    return ret;
+}
+
+/*************************
+ * site table
+ *************************/
+
+static int
+tsk_site_table_expand_main_columns(tsk_site_table_t *self, tsk_size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment = TSK_MAX(additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column((void **) &self->position, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->ancestral_state_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->metadata_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_site_table_expand_ancestral_state(tsk_site_table_t *self, size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment = (tsk_size_t) TSK_MAX(
+        additional_length, self->max_ancestral_state_length_increment);
+    tsk_size_t new_size = self->max_ancestral_state_length + increment;
+
+    if (check_offset_overflow(self->ancestral_state_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->ancestral_state_length + additional_length)
+        > self->max_ancestral_state_length) {
+        ret = expand_column((void **) &self->ancestral_state, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_ancestral_state_length = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_site_table_expand_metadata(tsk_site_table_t *self, size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = (tsk_size_t) TSK_MAX(additional_length, self->max_metadata_length_increment);
+    tsk_size_t new_size = self->max_metadata_length + increment;
+
+    if (check_offset_overflow(self->metadata_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_site_table_set_max_rows_increment(
+    tsk_site_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = max_rows_increment;
+    return 0;
+}
+
+int
+tsk_site_table_set_max_metadata_length_increment(
+    tsk_site_table_t *self, tsk_size_t max_metadata_length_increment)
+{
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_metadata_length_increment = max_metadata_length_increment;
+    return 0;
+}
+
+int
+tsk_site_table_set_max_ancestral_state_length_increment(
+    tsk_site_table_t *self, tsk_size_t max_ancestral_state_length_increment)
+{
+    if (max_ancestral_state_length_increment == 0) {
+        max_ancestral_state_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_ancestral_state_length_increment = max_ancestral_state_length_increment;
+    return 0;
+}
+
+int
+tsk_site_table_init(tsk_site_table_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_site_table_t));
+
+    /* Allocate space for one row initially, ensuring we always have valid pointers
+     * even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_ancestral_state_length_increment = 1;
+    self->max_metadata_length_increment = 1;
+    ret = tsk_site_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_expand_ancestral_state(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_expand_metadata(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->ancestral_state_offset[0] = 0;
+    self->metadata_offset[0] = 0;
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_ancestral_state_length_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    tsk_site_table_set_metadata_schema(self, NULL, 0);
+out:
+    return ret;
+}
+
+tsk_id_t
+tsk_site_table_add_row(tsk_site_table_t *self, double position,
+    const char *ancestral_state, tsk_size_t ancestral_state_length, const char *metadata,
+    tsk_size_t metadata_length)
+{
+    int ret = 0;
+    tsk_size_t ancestral_state_offset, metadata_offset;
+
+    ret = tsk_site_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->position[self->num_rows] = position;
+
+    ancestral_state_offset = (tsk_size_t) self->ancestral_state_length;
+    tsk_bug_assert(
+        self->ancestral_state_offset[self->num_rows] == ancestral_state_offset);
+    ret = tsk_site_table_expand_ancestral_state(self, ancestral_state_length);
+    if (ret != 0) {
+        goto out;
+    }
+    self->ancestral_state_length += ancestral_state_length;
+    memcpy(self->ancestral_state + ancestral_state_offset, ancestral_state,
+        ancestral_state_length);
+    self->ancestral_state_offset[self->num_rows + 1] = self->ancestral_state_length;
+
+    metadata_offset = (tsk_size_t) self->metadata_length;
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == metadata_offset);
+    ret = tsk_site_table_expand_metadata(self, metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    self->metadata_length += metadata_length;
+    memcpy(self->metadata + metadata_offset, metadata, metadata_length);
+    self->metadata_offset[self->num_rows + 1] = self->metadata_length;
+
+    ret = (tsk_id_t) self->num_rows;
+    self->num_rows++;
+out:
+    return ret;
+}
+
+int
+tsk_site_table_append_columns(tsk_site_table_t *self, tsk_size_t num_rows,
+    const double *position, const char *ancestral_state,
+    const tsk_size_t *ancestral_state_offset, const char *metadata,
+    const tsk_size_t *metadata_offset)
+{
+    int ret = 0;
+    tsk_size_t j, ancestral_state_length, metadata_length;
+
+    if (position == NULL || ancestral_state == NULL || ancestral_state_offset == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+
+    ret = tsk_site_table_expand_main_columns(self, num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->position + self->num_rows, position, num_rows * sizeof(double));
+
+    /* Metadata column */
+    if (metadata == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j + 1] = self->metadata_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, metadata_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        metadata_length = metadata_offset[num_rows];
+        ret = tsk_site_table_expand_metadata(self, metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->metadata + self->metadata_length, metadata,
+            metadata_length * sizeof(char));
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j]
+                = self->metadata_length + metadata_offset[j];
+        }
+        self->metadata_length += metadata_length;
+    }
+    self->metadata_offset[self->num_rows + num_rows] = self->metadata_length;
+
+    /* Ancestral state column */
+    ret = check_offsets(num_rows, ancestral_state_offset, 0, false);
+    if (ret != 0) {
+        goto out;
+    }
+    ancestral_state_length = ancestral_state_offset[num_rows];
+    ret = tsk_site_table_expand_ancestral_state(self, ancestral_state_length);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->ancestral_state + self->ancestral_state_length, ancestral_state,
+        ancestral_state_length * sizeof(char));
+    for (j = 0; j < num_rows; j++) {
+        self->ancestral_state_offset[self->num_rows + j]
+            = self->ancestral_state_length + ancestral_state_offset[j];
+    }
+    self->ancestral_state_length += ancestral_state_length;
+    self->ancestral_state_offset[self->num_rows + num_rows]
+        = self->ancestral_state_length;
+
+    self->num_rows += num_rows;
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_site_table_copy(
+    const tsk_site_table_t *self, tsk_site_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_site_table_init(dest, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_site_table_set_columns(dest, self->num_rows, self->position,
+        self->ancestral_state, self->ancestral_state_offset, self->metadata,
+        self->metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+out:
+    return ret;
+}
+
+int
+tsk_site_table_set_columns(tsk_site_table_t *self, tsk_size_t num_rows,
+    const double *position, const char *ancestral_state,
+    const tsk_size_t *ancestral_state_offset, const char *metadata,
+    const tsk_size_t *metadata_offset)
+{
+    int ret = 0;
+
+    ret = tsk_site_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_append_columns(self, num_rows, position, ancestral_state,
+        ancestral_state_offset, metadata, metadata_offset);
+out:
+    return ret;
+}
+
+bool
+tsk_site_table_equals(
+    const tsk_site_table_t *self, const tsk_site_table_t *other, tsk_flags_t options)
+{
+    bool ret
+        = self->num_rows == other->num_rows
+          && self->ancestral_state_length == other->ancestral_state_length
+          && memcmp(self->position, other->position, self->num_rows * sizeof(double))
+                 == 0
+          && memcmp(self->ancestral_state_offset, other->ancestral_state_offset,
+                 (self->num_rows + 1) * sizeof(tsk_size_t))
+                 == 0
+          && memcmp(self->ancestral_state, other->ancestral_state,
+                 self->ancestral_state_length * sizeof(char))
+                 == 0;
+    if (!(options & TSK_CMP_IGNORE_METADATA)) {
+        ret = ret && self->metadata_length == other->metadata_length
+              && self->metadata_schema_length == other->metadata_schema_length
+              && memcmp(self->metadata_offset, other->metadata_offset,
+                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                     == 0
+              && memcmp(self->metadata, other->metadata,
+                     self->metadata_length * sizeof(char))
+                     == 0
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0;
+    }
+    return ret;
+}
+
+int
+tsk_site_table_clear(tsk_site_table_t *self)
+{
+    return tsk_site_table_truncate(self, 0);
+}
+
+int
+tsk_site_table_truncate(tsk_site_table_t *self, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > self->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = num_rows;
+    self->ancestral_state_length = self->ancestral_state_offset[num_rows];
+    self->metadata_length = self->metadata_offset[num_rows];
+out:
+    return ret;
+}
+
+int
+tsk_site_table_free(tsk_site_table_t *self)
+{
+    tsk_safe_free(self->position);
+    tsk_safe_free(self->ancestral_state);
+    tsk_safe_free(self->ancestral_state_offset);
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_offset);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+void
+tsk_site_table_print_state(const tsk_site_table_t *self, FILE *out)
+{
+    int ret;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "site_table: %p:\n", (const void *) self);
+    fprintf(out, "num_rows = %d\t(max= %d\tincrement = %d)\n", (int) self->num_rows,
+        (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "ancestral_state_length = %d\t(max= %d\tincrement = %d)\n",
+        (int) self->ancestral_state_length, (int) self->max_ancestral_state_length,
+        (int) self->max_ancestral_state_length_increment);
+    fprintf(out, "metadata_length = %d(\tmax= %d\tincrement = %d)\n",
+        (int) self->metadata_length, (int) self->max_metadata_length,
+        (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    ret = tsk_site_table_dump_text(self, out);
+    tsk_bug_assert(ret == 0);
+
+    tsk_bug_assert(self->ancestral_state_offset[0] == 0);
+    tsk_bug_assert(
+        self->ancestral_state_length == self->ancestral_state_offset[self->num_rows]);
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_length == self->metadata_offset[self->num_rows]);
+}
+
+static inline void
+tsk_site_table_get_row_unsafe(
+    const tsk_site_table_t *self, tsk_id_t index, tsk_site_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->position = self->position[index];
+    row->ancestral_state_length
+        = self->ancestral_state_offset[index + 1] - self->ancestral_state_offset[index];
+    row->ancestral_state = self->ancestral_state + self->ancestral_state_offset[index];
+    row->metadata_length
+        = self->metadata_offset[index + 1] - self->metadata_offset[index];
+    row->metadata = self->metadata + self->metadata_offset[index];
+    /* This struct has a placeholder for mutations. Probably should be separate
+     * structs for this (tsk_site_table_row_t?) */
+    row->mutations_length = 0;
+    row->mutations = NULL;
+}
+
+int
+tsk_site_table_get_row(const tsk_site_table_t *self, tsk_id_t index, tsk_site_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_SITE_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_site_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+int
+tsk_site_table_set_metadata_schema(tsk_site_table_t *self, const char *metadata_schema,
+    tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_site_table_dump_text(const tsk_site_table_t *self, FILE *out)
+{
+    size_t j;
+    int ret = TSK_ERR_IO;
+    int err;
+    tsk_size_t ancestral_state_len, metadata_len;
+
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err < 0) {
+        goto out;
+    }
+    err = fprintf(out, "id\tposition\tancestral_state\tmetadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        ancestral_state_len
+            = self->ancestral_state_offset[j + 1] - self->ancestral_state_offset[j];
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%f\t%.*s\t%.*s\n", (int) j, self->position[j],
+            ancestral_state_len, self->ancestral_state + self->ancestral_state_offset[j],
+            metadata_len, self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+tsk_site_table_dump(const tsk_site_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        { "sites/position", (void *) self->position, self->num_rows, KAS_FLOAT64 },
+        { "sites/ancestral_state", (void *) self->ancestral_state,
+            self->ancestral_state_length, KAS_UINT8 },
+        { "sites/ancestral_state_offset", (void *) self->ancestral_state_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "sites/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8 },
+        { "sites/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
+            KAS_UINT32 },
+        { "sites/metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_UINT8 },
+    };
+
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+tsk_site_table_load(tsk_site_table_t *self, kastore_t *store)
+{
+    int ret = 0;
+    char *metadata_schema = NULL;
+    double *position = NULL;
+    char *ancestral_state = NULL;
+    tsk_size_t *ancestral_state_offset = NULL;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+    tsk_size_t num_rows, ancestral_state_length, metadata_length, metadata_schema_length;
+
+    read_table_col_t read_cols[] = {
+        { "sites/position", (void **) &position, &num_rows, 0, KAS_FLOAT64, 0 },
+        { "sites/ancestral_state", (void **) &ancestral_state, &ancestral_state_length,
+            0, KAS_UINT8, 0 },
+        { "sites/ancestral_state_offset", (void **) &ancestral_state_offset, &num_rows,
+            1, KAS_UINT32, 0 },
+        { "sites/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8, 0 },
+        { "sites/metadata_offset", (void **) &metadata_offset, &num_rows, 1, KAS_UINT32,
+            0 },
+        { "sites/metadata_schema", (void **) &metadata_schema, &metadata_schema_length,
+            0, KAS_UINT8, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if (ancestral_state_offset[num_rows] != ancestral_state_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    if (metadata_offset[num_rows] != metadata_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_site_table_set_columns(self, num_rows, position, ancestral_state,
+        ancestral_state_offset, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_schema != NULL) {
+        ret = tsk_site_table_set_metadata_schema(
+            self, metadata_schema, metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * mutation table
+ *************************/
+
+static int
+tsk_mutation_table_expand_main_columns(
+    tsk_mutation_table_t *self, size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = (tsk_size_t) TSK_MAX(additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column((void **) &self->site, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->node, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->parent, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->time, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->derived_state_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->metadata_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_mutation_table_expand_derived_state(
+    tsk_mutation_table_t *self, size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment = (tsk_size_t) TSK_MAX(
+        additional_length, self->max_derived_state_length_increment);
+    tsk_size_t new_size = self->max_derived_state_length + increment;
+
+    if (check_offset_overflow(self->derived_state_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->derived_state_length + additional_length)
+        > self->max_derived_state_length) {
+        ret = expand_column((void **) &self->derived_state, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_derived_state_length = (tsk_size_t) new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_mutation_table_expand_metadata(tsk_mutation_table_t *self, size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = (tsk_size_t) TSK_MAX(additional_length, self->max_metadata_length_increment);
+    tsk_size_t new_size = self->max_metadata_length + increment;
+
+    if (check_offset_overflow(self->metadata_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_mutation_table_set_max_rows_increment(
+    tsk_mutation_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = max_rows_increment;
+    return 0;
+}
+
+int
+tsk_mutation_table_set_max_metadata_length_increment(
+    tsk_mutation_table_t *self, tsk_size_t max_metadata_length_increment)
+{
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_metadata_length_increment = max_metadata_length_increment;
+    return 0;
+}
+
+int
+tsk_mutation_table_set_max_derived_state_length_increment(
+    tsk_mutation_table_t *self, tsk_size_t max_derived_state_length_increment)
+{
+    if (max_derived_state_length_increment == 0) {
+        max_derived_state_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_derived_state_length_increment = max_derived_state_length_increment;
+    return 0;
+}
+
+int
+tsk_mutation_table_init(tsk_mutation_table_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_mutation_table_t));
+
+    /* Allocate space for one row initially, ensuring we always have valid pointers
+     * even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_derived_state_length_increment = 1;
+    self->max_metadata_length_increment = 1;
+    ret = tsk_mutation_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_expand_derived_state(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_expand_metadata(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->derived_state_offset[0] = 0;
+    self->metadata_offset[0] = 0;
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_derived_state_length_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    tsk_mutation_table_set_metadata_schema(self, NULL, 0);
+out:
+    return ret;
+}
+
+tsk_id_t
+tsk_mutation_table_add_row(tsk_mutation_table_t *self, tsk_id_t site, tsk_id_t node,
+    tsk_id_t parent, double time, const char *derived_state,
+    tsk_size_t derived_state_length, const char *metadata, tsk_size_t metadata_length)
+{
+    tsk_size_t derived_state_offset, metadata_offset;
+    int ret;
+
+    ret = tsk_mutation_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->site[self->num_rows] = site;
+    self->node[self->num_rows] = node;
+    self->parent[self->num_rows] = parent;
+    self->time[self->num_rows] = time;
+
+    derived_state_offset = self->derived_state_length;
+    tsk_bug_assert(self->derived_state_offset[self->num_rows] == derived_state_offset);
+    ret = tsk_mutation_table_expand_derived_state(self, derived_state_length);
+    if (ret != 0) {
+        goto out;
+    }
+    self->derived_state_length += derived_state_length;
+    memcpy(
+        self->derived_state + derived_state_offset, derived_state, derived_state_length);
+    self->derived_state_offset[self->num_rows + 1] = self->derived_state_length;
+
+    metadata_offset = self->metadata_length;
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == metadata_offset);
+    ret = tsk_mutation_table_expand_metadata(self, metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    self->metadata_length += metadata_length;
+    memcpy(self->metadata + metadata_offset, metadata, metadata_length);
+    self->metadata_offset[self->num_rows + 1] = self->metadata_length;
+
+    ret = (tsk_id_t) self->num_rows;
+    self->num_rows++;
+out:
+    return ret;
+}
+
+int
+tsk_mutation_table_append_columns(tsk_mutation_table_t *self, tsk_size_t num_rows,
+    const tsk_id_t *site, const tsk_id_t *node, const tsk_id_t *parent,
+    const double *time, const char *derived_state,
+    const tsk_size_t *derived_state_offset, const char *metadata,
+    const tsk_size_t *metadata_offset)
+{
+    int ret = 0;
+    tsk_size_t j, derived_state_length, metadata_length;
+
+    if (site == NULL || node == NULL || derived_state == NULL
+        || derived_state_offset == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+
+    ret = tsk_mutation_table_expand_main_columns(self, num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->site + self->num_rows, site, num_rows * sizeof(tsk_id_t));
+    memcpy(self->node + self->num_rows, node, num_rows * sizeof(tsk_id_t));
+    if (parent == NULL) {
+        /* If parent is NULL, set all parents to the null mutation */
+        memset(self->parent + self->num_rows, 0xff, num_rows * sizeof(tsk_id_t));
+    } else {
+        memcpy(self->parent + self->num_rows, parent, num_rows * sizeof(tsk_id_t));
+    }
+    if (time == NULL) {
+        /* If time is NULL, set all times to TSK_UNKNOWN_TIME which is the
+         * default */
+        for (j = 0; j < num_rows; j++) {
+            self->time[self->num_rows + j] = TSK_UNKNOWN_TIME;
+        }
+    } else {
+        memcpy(self->time + self->num_rows, time, num_rows * sizeof(double));
+    }
+
+    /* Metadata column */
+    if (metadata == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j + 1] = self->metadata_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, metadata_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        metadata_length = metadata_offset[num_rows];
+        ret = tsk_mutation_table_expand_metadata(self, metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->metadata + self->metadata_length, metadata,
+            metadata_length * sizeof(char));
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j]
+                = self->metadata_length + metadata_offset[j];
+        }
+        self->metadata_length += metadata_length;
+    }
+    self->metadata_offset[self->num_rows + num_rows] = self->metadata_length;
+
+    /* Derived state column */
+    ret = check_offsets(num_rows, derived_state_offset, 0, false);
+    if (ret != 0) {
+        goto out;
+    }
+    derived_state_length = derived_state_offset[num_rows];
+    ret = tsk_mutation_table_expand_derived_state(self, derived_state_length);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->derived_state + self->derived_state_length, derived_state,
+        derived_state_length * sizeof(char));
+    for (j = 0; j < num_rows; j++) {
+        self->derived_state_offset[self->num_rows + j]
+            = self->derived_state_length + derived_state_offset[j];
+    }
+    self->derived_state_length += derived_state_length;
+    self->derived_state_offset[self->num_rows + num_rows] = self->derived_state_length;
+
+    self->num_rows += num_rows;
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_mutation_table_copy(
+    const tsk_mutation_table_t *self, tsk_mutation_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_mutation_table_init(dest, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_mutation_table_set_columns(dest, self->num_rows, self->site, self->node,
+        self->parent, self->time, self->derived_state, self->derived_state_offset,
+        self->metadata, self->metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+out:
+    return ret;
+}
+
+int
+tsk_mutation_table_set_columns(tsk_mutation_table_t *self, tsk_size_t num_rows,
+    const tsk_id_t *site, const tsk_id_t *node, const tsk_id_t *parent,
+    const double *time, const char *derived_state,
+    const tsk_size_t *derived_state_offset, const char *metadata,
+    const tsk_size_t *metadata_offset)
+{
+    int ret = 0;
+
+    ret = tsk_mutation_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_append_columns(self, num_rows, site, node, parent, time,
+        derived_state, derived_state_offset, metadata, metadata_offset);
+out:
+    return ret;
+}
+
+bool
+tsk_mutation_table_equals(const tsk_mutation_table_t *self,
+    const tsk_mutation_table_t *other, tsk_flags_t options)
+{
+    bool ret
+        = self->num_rows == other->num_rows
+          && self->derived_state_length == other->derived_state_length
+          && memcmp(self->site, other->site, self->num_rows * sizeof(tsk_id_t)) == 0
+          && memcmp(self->node, other->node, self->num_rows * sizeof(tsk_id_t)) == 0
+          && memcmp(self->parent, other->parent, self->num_rows * sizeof(tsk_id_t)) == 0
+          && memcmp(self->time, other->time, self->num_rows * sizeof(double)) == 0
+          && memcmp(self->derived_state_offset, other->derived_state_offset,
+                 (self->num_rows + 1) * sizeof(tsk_size_t))
+                 == 0
+          && memcmp(self->derived_state, other->derived_state,
+                 self->derived_state_length * sizeof(char))
+                 == 0;
+    if (!(options & TSK_CMP_IGNORE_METADATA)) {
+        ret = ret && self->metadata_length == other->metadata_length
+              && self->metadata_schema_length == other->metadata_schema_length
+              && memcmp(self->metadata_offset, other->metadata_offset,
+                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                     == 0
+              && memcmp(self->metadata, other->metadata,
+                     self->metadata_length * sizeof(char))
+                     == 0
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0;
+    }
+    return ret;
+}
+
+int
+tsk_mutation_table_clear(tsk_mutation_table_t *self)
+{
+    return tsk_mutation_table_truncate(self, 0);
+}
+
+int
+tsk_mutation_table_truncate(tsk_mutation_table_t *mutations, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > mutations->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    mutations->num_rows = num_rows;
+    mutations->derived_state_length = mutations->derived_state_offset[num_rows];
+    mutations->metadata_length = mutations->metadata_offset[num_rows];
+out:
+    return ret;
+}
+
+int
+tsk_mutation_table_free(tsk_mutation_table_t *self)
+{
+    tsk_safe_free(self->node);
+    tsk_safe_free(self->site);
+    tsk_safe_free(self->parent);
+    tsk_safe_free(self->time);
+    tsk_safe_free(self->derived_state);
+    tsk_safe_free(self->derived_state_offset);
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_offset);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+void
+tsk_mutation_table_print_state(const tsk_mutation_table_t *self, FILE *out)
+{
+    int ret;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "mutation_table: %p:\n", (const void *) self);
+    fprintf(out, "num_rows = %d\tmax= %d\tincrement = %d)\n", (int) self->num_rows,
+        (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "derived_state_length = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->derived_state_length, (int) self->max_derived_state_length,
+        (int) self->max_derived_state_length_increment);
+    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->metadata_length, (int) self->max_metadata_length,
+        (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    ret = tsk_mutation_table_dump_text(self, out);
+    tsk_bug_assert(ret == 0);
+    tsk_bug_assert(self->derived_state_offset[0] == 0);
+    tsk_bug_assert(
+        self->derived_state_length == self->derived_state_offset[self->num_rows]);
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_length == self->metadata_offset[self->num_rows]);
+}
+
+static inline void
+tsk_mutation_table_get_row_unsafe(
+    const tsk_mutation_table_t *self, tsk_id_t index, tsk_mutation_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->site = self->site[index];
+    row->node = self->node[index];
+    row->parent = self->parent[index];
+    row->time = self->time[index];
+    row->derived_state_length
+        = self->derived_state_offset[index + 1] - self->derived_state_offset[index];
+    row->derived_state = self->derived_state + self->derived_state_offset[index];
+    row->metadata_length
+        = self->metadata_offset[index + 1] - self->metadata_offset[index];
+    row->metadata = self->metadata + self->metadata_offset[index];
+}
+
+int
+tsk_mutation_table_get_row(
+    const tsk_mutation_table_t *self, tsk_id_t index, tsk_mutation_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_MUTATION_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_mutation_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+int
+tsk_mutation_table_set_metadata_schema(tsk_mutation_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_mutation_table_dump_text(const tsk_mutation_table_t *self, FILE *out)
+{
+    int ret = TSK_ERR_IO;
+    int err;
+    tsk_size_t j, derived_state_len, metadata_len;
+
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err < 0) {
+        goto out;
+    }
+    err = fprintf(out, "id\tsite\tnode\tparent\ttime\tderived_state\tmetadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        derived_state_len
+            = self->derived_state_offset[j + 1] - self->derived_state_offset[j];
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%d\t%d\t%d\t%f\t%.*s\t%.*s\n", (int) j, self->site[j],
+            self->node[j], self->parent[j], self->time[j], derived_state_len,
+            self->derived_state + self->derived_state_offset[j], metadata_len,
+            self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+tsk_mutation_table_dump(const tsk_mutation_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        { "mutations/site", (void *) self->site, self->num_rows, KAS_INT32 },
+        { "mutations/node", (void *) self->node, self->num_rows, KAS_INT32 },
+        { "mutations/parent", (void *) self->parent, self->num_rows, KAS_INT32 },
+        { "mutations/time", (void *) self->time, self->num_rows, KAS_FLOAT64 },
+        { "mutations/derived_state", (void *) self->derived_state,
+            self->derived_state_length, KAS_UINT8 },
+        { "mutations/derived_state_offset", (void *) self->derived_state_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "mutations/metadata", (void *) self->metadata, self->metadata_length,
+            KAS_UINT8 },
+        { "mutations/metadata_offset", (void *) self->metadata_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "mutations/metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_UINT8 },
+
+    };
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+tsk_mutation_table_load(tsk_mutation_table_t *self, kastore_t *store)
+{
+    int ret = 0;
+    tsk_id_t *node = NULL;
+    tsk_id_t *site = NULL;
+    tsk_id_t *parent = NULL;
+    double *time = NULL;
+    char *derived_state = NULL;
+    tsk_size_t *derived_state_offset = NULL;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+    char *metadata_schema = NULL;
+    tsk_size_t num_rows, derived_state_length, metadata_length, metadata_schema_length;
+
+    read_table_col_t read_cols[] = {
+        { "mutations/site", (void **) &site, &num_rows, 0, KAS_INT32, 0 },
+        { "mutations/node", (void **) &node, &num_rows, 0, KAS_INT32, 0 },
+        { "mutations/parent", (void **) &parent, &num_rows, 0, KAS_INT32, 0 },
+        { "mutations/time", (void **) &time, &num_rows, 0, KAS_FLOAT64,
+            TSK_COL_OPTIONAL },
+        { "mutations/derived_state", (void **) &derived_state, &derived_state_length, 0,
+            KAS_UINT8, 0 },
+        { "mutations/derived_state_offset", (void **) &derived_state_offset, &num_rows,
+            1, KAS_UINT32, 0 },
+        { "mutations/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8, 0 },
+        { "mutations/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
+            KAS_UINT32, 0 },
+        { "mutations/metadata_schema", (void **) &metadata_schema,
+            &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if (derived_state_offset[num_rows] != derived_state_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    if (metadata_offset[num_rows] != metadata_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_mutation_table_set_columns(self, num_rows, site, node, parent, time,
+        derived_state, derived_state_offset, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_schema != NULL) {
+        ret = tsk_mutation_table_set_metadata_schema(
+            self, metadata_schema, metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * migration table
+ *************************/
+
+static int
+tsk_migration_table_expand_main_columns(
+    tsk_migration_table_t *self, size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX((tsk_size_t) additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column((void **) &self->left, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->right, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->node, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->source, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->dest, new_size, sizeof(tsk_id_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->time, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->metadata_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_migration_table_expand_metadata(
+    tsk_migration_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX(additional_length, self->max_metadata_length_increment);
+    tsk_size_t new_size = self->max_metadata_length + increment;
+
+    if (check_offset_overflow(self->metadata_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_migration_table_set_max_rows_increment(
+    tsk_migration_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = max_rows_increment;
+    return 0;
+}
+
+int
+tsk_migration_table_set_max_metadata_length_increment(
+    tsk_migration_table_t *self, tsk_size_t max_metadata_length_increment)
+{
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_metadata_length_increment = max_metadata_length_increment;
+    return 0;
+}
+
+int
+tsk_migration_table_init(tsk_migration_table_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_migration_table_t));
+
+    /* Allocate space for one row initially, ensuring we always have valid pointers
+     * even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_metadata_length_increment = 1;
+    ret = tsk_migration_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_expand_metadata(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->metadata_offset[0] = 0;
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    tsk_migration_table_set_metadata_schema(self, NULL, 0);
+out:
+    return ret;
+}
+
+int
+tsk_migration_table_append_columns(tsk_migration_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *node,
+    const tsk_id_t *source, const tsk_id_t *dest, const double *time,
+    const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+    tsk_size_t j, metadata_length;
+
+    if (left == NULL || right == NULL || node == NULL || source == NULL || dest == NULL
+        || time == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+
+    ret = tsk_migration_table_expand_main_columns(self, num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->left + self->num_rows, left, num_rows * sizeof(double));
+    memcpy(self->right + self->num_rows, right, num_rows * sizeof(double));
+    memcpy(self->node + self->num_rows, node, num_rows * sizeof(tsk_id_t));
+    memcpy(self->source + self->num_rows, source, num_rows * sizeof(tsk_id_t));
+    memcpy(self->dest + self->num_rows, dest, num_rows * sizeof(tsk_id_t));
+    memcpy(self->time + self->num_rows, time, num_rows * sizeof(double));
+    if (metadata == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j + 1] = self->metadata_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, metadata_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j]
+                = (tsk_size_t) self->metadata_length + metadata_offset[j];
+        }
+        metadata_length = metadata_offset[num_rows];
+        ret = tsk_migration_table_expand_metadata(self, metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->metadata + self->metadata_length, metadata,
+            metadata_length * sizeof(char));
+        self->metadata_length += metadata_length;
+    }
+
+    self->num_rows += num_rows;
+    self->metadata_offset[self->num_rows] = self->metadata_length;
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_migration_table_copy(
+    const tsk_migration_table_t *self, tsk_migration_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_migration_table_init(dest, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_migration_table_set_columns(dest, self->num_rows, self->left, self->right,
+        self->node, self->source, self->dest, self->time, self->metadata,
+        self->metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+out:
+    return ret;
+}
+
+int
+tsk_migration_table_set_columns(tsk_migration_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *node,
+    const tsk_id_t *source, const tsk_id_t *dest, const double *time,
+    const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+
+    ret = tsk_migration_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_append_columns(self, num_rows, left, right, node, source,
+        dest, time, metadata, metadata_offset);
+out:
+    return ret;
+}
+
+tsk_id_t
+tsk_migration_table_add_row(tsk_migration_table_t *self, double left, double right,
+    tsk_id_t node, tsk_id_t source, tsk_id_t dest, double time, const char *metadata,
+    tsk_size_t metadata_length)
+{
+    int ret = 0;
+
+    ret = tsk_migration_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_expand_metadata(self, metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
+    self->left[self->num_rows] = left;
+    self->right[self->num_rows] = right;
+    self->node[self->num_rows] = node;
+    self->source[self->num_rows] = source;
+    self->dest[self->num_rows] = dest;
+    self->time[self->num_rows] = time;
+    self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
+    self->metadata_length += metadata_length;
+
+    ret = (tsk_id_t) self->num_rows;
+    self->num_rows++;
+out:
+    return ret;
+}
+
+int
+tsk_migration_table_clear(tsk_migration_table_t *self)
+{
+    return tsk_migration_table_truncate(self, 0);
+}
+
+int
+tsk_migration_table_truncate(tsk_migration_table_t *self, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > self->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = num_rows;
+    self->metadata_length = self->metadata_offset[num_rows];
+out:
+    return ret;
+}
+
+int
+tsk_migration_table_free(tsk_migration_table_t *self)
+{
+    tsk_safe_free(self->left);
+    tsk_safe_free(self->right);
+    tsk_safe_free(self->node);
+    tsk_safe_free(self->source);
+    tsk_safe_free(self->dest);
+    tsk_safe_free(self->time);
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_offset);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+void
+tsk_migration_table_print_state(const tsk_migration_table_t *self, FILE *out)
+{
+    int ret;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "migration_table: %p:\n", (const void *) self);
+    fprintf(out, "num_rows = %d\tmax= %d\tincrement = %d)\n", (int) self->num_rows,
+        (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->metadata_length, (int) self->max_metadata_length,
+        (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    ret = tsk_migration_table_dump_text(self, out);
+    tsk_bug_assert(ret == 0);
+}
+
+static inline void
+tsk_migration_table_get_row_unsafe(
+    const tsk_migration_table_t *self, tsk_id_t index, tsk_migration_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->left = self->left[index];
+    row->right = self->right[index];
+    row->node = self->node[index];
+    row->source = self->source[index];
+    row->dest = self->dest[index];
+    row->time = self->time[index];
+    row->metadata_length
+        = self->metadata_offset[index + 1] - self->metadata_offset[index];
+    row->metadata = self->metadata + self->metadata_offset[index];
+}
+
+int
+tsk_migration_table_get_row(
+    const tsk_migration_table_t *self, tsk_id_t index, tsk_migration_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_MIGRATION_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_migration_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+int
+tsk_migration_table_set_metadata_schema(tsk_migration_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_migration_table_dump_text(const tsk_migration_table_t *self, FILE *out)
+{
+    size_t j;
+    int ret = TSK_ERR_IO;
+    tsk_size_t metadata_len;
+    int err;
+
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err < 0) {
+        goto out;
+    }
+    err = fprintf(out, "left\tright\tnode\tsource\tdest\ttime\tmetadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%.3f\t%.3f\t%d\t%d\t%d\t%f\t%.*s\n", self->left[j],
+            self->right[j], (int) self->node[j], (int) self->source[j],
+            (int) self->dest[j], self->time[j], metadata_len,
+            self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool
+tsk_migration_table_equals(const tsk_migration_table_t *self,
+    const tsk_migration_table_t *other, tsk_flags_t options)
+{
+    bool ret
+        = self->num_rows == other->num_rows
+          && memcmp(self->left, other->left, self->num_rows * sizeof(double)) == 0
+          && memcmp(self->right, other->right, self->num_rows * sizeof(double)) == 0
+          && memcmp(self->node, other->node, self->num_rows * sizeof(tsk_id_t)) == 0
+          && memcmp(self->source, other->source, self->num_rows * sizeof(tsk_id_t)) == 0
+          && memcmp(self->dest, other->dest, self->num_rows * sizeof(tsk_id_t)) == 0
+          && memcmp(self->time, other->time, self->num_rows * sizeof(double)) == 0;
+
+    if (!(options & TSK_CMP_IGNORE_METADATA)) {
+        ret = ret && self->metadata_length == other->metadata_length
+              && self->metadata_schema_length == other->metadata_schema_length
+              && memcmp(self->metadata_offset, other->metadata_offset,
+                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                     == 0
+              && memcmp(self->metadata, other->metadata,
+                     self->metadata_length * sizeof(char))
+                     == 0
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0;
+    }
+    return ret;
+}
+
+static int
+tsk_migration_table_dump(const tsk_migration_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        { "migrations/left", (void *) self->left, self->num_rows, KAS_FLOAT64 },
+        { "migrations/right", (void *) self->right, self->num_rows, KAS_FLOAT64 },
+        { "migrations/node", (void *) self->node, self->num_rows, KAS_INT32 },
+        { "migrations/source", (void *) self->source, self->num_rows, KAS_INT32 },
+        { "migrations/dest", (void *) self->dest, self->num_rows, KAS_INT32 },
+        { "migrations/time", (void *) self->time, self->num_rows, KAS_FLOAT64 },
+        { "migrations/metadata", (void *) self->metadata, self->metadata_length,
+            KAS_UINT8 },
+        { "migrations/metadata_offset", (void *) self->metadata_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "migrations/metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_UINT8 },
+    };
+
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+tsk_migration_table_load(tsk_migration_table_t *self, kastore_t *store)
+{
+    int ret = 0;
+    tsk_id_t *source = NULL;
+    tsk_id_t *dest = NULL;
+    tsk_id_t *node = NULL;
+    double *left = NULL;
+    double *right = NULL;
+    double *time = NULL;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+    char *metadata_schema = NULL;
+    tsk_size_t num_rows, metadata_length, metadata_schema_length;
+
+    read_table_col_t read_cols[] = {
+        { "migrations/left", (void **) &left, &num_rows, 0, KAS_FLOAT64, 0 },
+        { "migrations/right", (void **) &right, &num_rows, 0, KAS_FLOAT64, 0 },
+        { "migrations/node", (void **) &node, &num_rows, 0, KAS_INT32, 0 },
+        { "migrations/source", (void **) &source, &num_rows, 0, KAS_INT32, 0 },
+        { "migrations/dest", (void **) &dest, &num_rows, 0, KAS_INT32, 0 },
+        { "migrations/time", (void **) &time, &num_rows, 0, KAS_FLOAT64, 0 },
+        { "migrations/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
+            TSK_COL_OPTIONAL },
+        { "migrations/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
+            KAS_UINT32, TSK_COL_OPTIONAL },
+        { "migrations/metadata_schema", (void **) &metadata_schema,
+            &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = TSK_ERR_BOTH_COLUMNS_REQUIRED;
+        goto out;
+    }
+    if (metadata != NULL && metadata_offset[num_rows] != metadata_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_migration_table_set_columns(self, num_rows, left, right, node, source,
+        dest, time, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_schema != NULL) {
+        ret = tsk_migration_table_set_metadata_schema(
+            self, metadata_schema, metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * population table
+ *************************/
+
+static int
+tsk_population_table_expand_main_columns(
+    tsk_population_table_t *self, tsk_size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment = TSK_MAX(additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column(
+            (void **) &self->metadata_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_population_table_expand_metadata(
+    tsk_population_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX(additional_length, self->max_metadata_length_increment);
+    tsk_size_t new_size = self->max_metadata_length + increment;
+
+    if (check_offset_overflow(self->metadata_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_population_table_set_max_rows_increment(
+    tsk_population_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = max_rows_increment;
+    return 0;
+}
+
+int
+tsk_population_table_set_max_metadata_length_increment(
+    tsk_population_table_t *self, tsk_size_t max_metadata_length_increment)
+{
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_metadata_length_increment = max_metadata_length_increment;
+    return 0;
+}
+
+int
+tsk_population_table_init(tsk_population_table_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_population_table_t));
+    /* Allocate space for one row initially, ensuring we always have valid pointers
+     * even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_metadata_length_increment = 1;
+    ret = tsk_population_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_expand_metadata(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->metadata_offset[0] = 0;
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    tsk_population_table_set_metadata_schema(self, NULL, 0);
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_population_table_copy(const tsk_population_table_t *self,
+    tsk_population_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_population_table_init(dest, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_population_table_set_columns(
+        dest, self->num_rows, self->metadata, self->metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+out:
+    return ret;
+}
+
+int
+tsk_population_table_set_columns(tsk_population_table_t *self, tsk_size_t num_rows,
+    const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+
+    ret = tsk_population_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_append_columns(self, num_rows, metadata, metadata_offset);
+out:
+    return ret;
+}
+
+int
+tsk_population_table_append_columns(tsk_population_table_t *self, tsk_size_t num_rows,
+    const char *metadata, const tsk_size_t *metadata_offset)
+{
+    int ret;
+    tsk_size_t j, metadata_length;
+
+    if (metadata == NULL || metadata_offset == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    ret = tsk_population_table_expand_main_columns(self, num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+
+    ret = check_offsets(num_rows, metadata_offset, 0, false);
+    if (ret != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_rows; j++) {
+        self->metadata_offset[self->num_rows + j]
+            = self->metadata_length + metadata_offset[j];
+    }
+    metadata_length = metadata_offset[num_rows];
+    ret = tsk_population_table_expand_metadata(self, metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->metadata + self->metadata_length, metadata,
+        metadata_length * sizeof(char));
+    self->metadata_length += metadata_length;
+
+    self->num_rows += num_rows;
+    self->metadata_offset[self->num_rows] = self->metadata_length;
+out:
+    return ret;
+}
+
+static tsk_id_t
+tsk_population_table_add_row_internal(
+    tsk_population_table_t *self, const char *metadata, tsk_size_t metadata_length)
+{
+    int ret = 0;
+
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
+    self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
+    self->metadata_length += metadata_length;
+    ret = (tsk_id_t) self->num_rows;
+    self->num_rows++;
+    return ret;
+}
+
+tsk_id_t
+tsk_population_table_add_row(
+    tsk_population_table_t *self, const char *metadata, tsk_size_t metadata_length)
+{
+    int ret = 0;
+
+    ret = tsk_population_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_expand_metadata(self, metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_add_row_internal(self, metadata, metadata_length);
+out:
+    return ret;
+}
+
+int
+tsk_population_table_clear(tsk_population_table_t *self)
+{
+    return tsk_population_table_truncate(self, 0);
+}
+
+int
+tsk_population_table_truncate(tsk_population_table_t *self, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > self->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = num_rows;
+    self->metadata_length = self->metadata_offset[num_rows];
+out:
+    return ret;
+}
+
+int
+tsk_population_table_free(tsk_population_table_t *self)
+{
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_offset);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+void
+tsk_population_table_print_state(const tsk_population_table_t *self, FILE *out)
+{
+    tsk_size_t j, k;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "population_table: %p:\n", (const void *) self);
+    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "metadata_length  = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->metadata_length, (int) self->max_metadata_length,
+        (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    fprintf(out, "index\tmetadata_offset\tmetadata\n");
+    for (j = 0; j < self->num_rows; j++) {
+        fprintf(out, "%d\t%d\t", (int) j, self->metadata_offset[j]);
+        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
+            fprintf(out, "%c", self->metadata[k]);
+        }
+        fprintf(out, "\n");
+    }
+    tsk_bug_assert(self->metadata_offset[0] == 0);
+    tsk_bug_assert(self->metadata_offset[self->num_rows] == self->metadata_length);
+}
+
+static inline void
+tsk_population_table_get_row_unsafe(
+    const tsk_population_table_t *self, tsk_id_t index, tsk_population_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->metadata_length
+        = self->metadata_offset[index + 1] - self->metadata_offset[index];
+    row->metadata = self->metadata + self->metadata_offset[index];
+}
+
+int
+tsk_population_table_get_row(
+    const tsk_population_table_t *self, tsk_id_t index, tsk_population_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_POPULATION_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_population_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+int
+tsk_population_table_set_metadata_schema(tsk_population_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_population_table_dump_text(const tsk_population_table_t *self, FILE *out)
+{
+    int ret = TSK_ERR_IO;
+    int err;
+    tsk_size_t j;
+    tsk_size_t metadata_len;
+
+    err = write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    if (err < 0) {
+        goto out;
+    }
+    err = fprintf(out, "metadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(
+            out, "%.*s\n", metadata_len, self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool
+tsk_population_table_equals(const tsk_population_table_t *self,
+    const tsk_population_table_t *other, tsk_flags_t options)
+{
+    /* Since we only have the metadata column in the table currently, equality
+     * reduces to comparing the number of rows if we disable metadata comparison.
+     */
+    bool ret = self->num_rows == other->num_rows;
+    if (!(options & TSK_CMP_IGNORE_METADATA)) {
+        ret = ret && self->metadata_length == other->metadata_length
+              && self->metadata_schema_length == other->metadata_schema_length
+              && memcmp(self->metadata_offset, other->metadata_offset,
+                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                     == 0
+              && memcmp(self->metadata, other->metadata,
+                     self->metadata_length * sizeof(char))
+                     == 0
+              && memcmp(self->metadata_schema, other->metadata_schema,
+                     self->metadata_schema_length * sizeof(char))
+                     == 0;
+    }
+    return ret;
+}
+
+static int
+tsk_population_table_dump(const tsk_population_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        { "populations/metadata", (void *) self->metadata, self->metadata_length,
+            KAS_UINT8 },
+        { "populations/metadata_offset", (void *) self->metadata_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "populations/metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_UINT8 },
+    };
+
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+tsk_population_table_load(tsk_population_table_t *self, kastore_t *store)
+{
+    int ret = 0;
+    char *metadata = NULL;
+    tsk_size_t *metadata_offset = NULL;
+    char *metadata_schema = NULL;
+    tsk_size_t num_rows, metadata_length, metadata_schema_length;
+
+    read_table_col_t read_cols[] = {
+        { "populations/metadata", (void **) &metadata, &metadata_length, 0, KAS_UINT8,
+            0 },
+        { "populations/metadata_offset", (void **) &metadata_offset, &num_rows, 1,
+            KAS_UINT32, 0 },
+        { "populations/metadata_schema", (void **) &metadata_schema,
+            &metadata_schema_length, 0, KAS_UINT8, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_offset[num_rows] != metadata_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_population_table_set_columns(self, num_rows, metadata, metadata_offset);
+    if (ret != 0) {
+        goto out;
+    }
+    if (metadata_schema != NULL) {
+        ret = tsk_population_table_set_metadata_schema(
+            self, metadata_schema, metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * provenance table
+ *************************/
+
+static int
+tsk_provenance_table_expand_main_columns(
+    tsk_provenance_table_t *self, tsk_size_t additional_rows)
+{
+    int ret = 0;
+    tsk_size_t increment = TSK_MAX(additional_rows, self->max_rows_increment);
+    tsk_size_t new_size = self->max_rows + increment;
+
+    if (check_table_overflow(self->max_rows, increment)) {
+        ret = TSK_ERR_TABLE_OVERFLOW;
+        goto out;
+    }
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column(
+            (void **) &self->timestamp_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column(
+            (void **) &self->record_offset, new_size + 1, sizeof(tsk_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_provenance_table_expand_timestamp(
+    tsk_provenance_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment
+        = TSK_MAX(additional_length, self->max_timestamp_length_increment);
+    tsk_size_t new_size = self->max_timestamp_length + increment;
+
+    if (check_offset_overflow(self->timestamp_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->timestamp_length + additional_length) > self->max_timestamp_length) {
+        ret = expand_column((void **) &self->timestamp, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_timestamp_length = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_provenance_table_expand_provenance(
+    tsk_provenance_table_t *self, tsk_size_t additional_length)
+{
+    int ret = 0;
+    tsk_size_t increment = TSK_MAX(additional_length, self->max_record_length_increment);
+    tsk_size_t new_size = self->max_record_length + increment;
+
+    if (check_offset_overflow(self->record_length, increment)) {
+        ret = TSK_ERR_COLUMN_OVERFLOW;
+        goto out;
+    }
+    if ((self->record_length + additional_length) > self->max_record_length) {
+        ret = expand_column((void **) &self->record, new_size, sizeof(char));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_record_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_provenance_table_set_max_rows_increment(
+    tsk_provenance_table_t *self, tsk_size_t max_rows_increment)
+{
+    if (max_rows_increment == 0) {
+        max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = max_rows_increment;
+    return 0;
+}
+
+int
+tsk_provenance_table_set_max_timestamp_length_increment(
+    tsk_provenance_table_t *self, tsk_size_t max_timestamp_length_increment)
+{
+    if (max_timestamp_length_increment == 0) {
+        max_timestamp_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_timestamp_length_increment = max_timestamp_length_increment;
+    return 0;
+}
+
+int
+tsk_provenance_table_set_max_record_length_increment(
+    tsk_provenance_table_t *self, tsk_size_t max_record_length_increment)
+{
+    if (max_record_length_increment == 0) {
+        max_record_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_record_length_increment = max_record_length_increment;
+    return 0;
+}
+
+int
+tsk_provenance_table_init(tsk_provenance_table_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_provenance_table_t));
+    /* Allocate space for one row initially, ensuring we always have valid pointers
+     * even if the table is empty */
+    self->max_rows_increment = 1;
+    self->max_timestamp_length_increment = 1;
+    self->max_record_length_increment = 1;
+    ret = tsk_provenance_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_expand_timestamp(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->timestamp_offset[0] = 0;
+    ret = tsk_provenance_table_expand_provenance(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->record_offset[0] = 0;
+    self->max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_timestamp_length_increment = DEFAULT_SIZE_INCREMENT;
+    self->max_record_length_increment = DEFAULT_SIZE_INCREMENT;
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_provenance_table_copy(const tsk_provenance_table_t *self,
+    tsk_provenance_table_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_provenance_table_init(dest, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_provenance_table_set_columns(dest, self->num_rows, self->timestamp,
+        self->timestamp_offset, self->record, self->record_offset);
+out:
+    return ret;
+}
+
+int
+tsk_provenance_table_set_columns(tsk_provenance_table_t *self, tsk_size_t num_rows,
+    const char *timestamp, const tsk_size_t *timestamp_offset, const char *record,
+    const tsk_size_t *record_offset)
+{
+    int ret;
+
+    ret = tsk_provenance_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_append_columns(
+        self, num_rows, timestamp, timestamp_offset, record, record_offset);
+out:
+    return ret;
+}
+
+int
+tsk_provenance_table_append_columns(tsk_provenance_table_t *self, tsk_size_t num_rows,
+    const char *timestamp, const tsk_size_t *timestamp_offset, const char *record,
+    const tsk_size_t *record_offset)
+{
+    int ret;
+    tsk_size_t j, timestamp_length, record_length;
+
+    if (timestamp == NULL || timestamp_offset == NULL || record == NULL
+        || record_offset == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    ret = tsk_provenance_table_expand_main_columns(self, num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+
+    ret = check_offsets(num_rows, timestamp_offset, 0, false);
+    if (ret != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_rows; j++) {
+        self->timestamp_offset[self->num_rows + j]
+            = self->timestamp_length + timestamp_offset[j];
+    }
+    timestamp_length = timestamp_offset[num_rows];
+    ret = tsk_provenance_table_expand_timestamp(self, timestamp_length);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->timestamp + self->timestamp_length, timestamp,
+        timestamp_length * sizeof(char));
+    self->timestamp_length += timestamp_length;
+
+    ret = check_offsets(num_rows, record_offset, 0, false);
+    if (ret != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_rows; j++) {
+        self->record_offset[self->num_rows + j] = self->record_length + record_offset[j];
+    }
+    record_length = record_offset[num_rows];
+    ret = tsk_provenance_table_expand_provenance(self, record_length);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->record + self->record_length, record, record_length * sizeof(char));
+    self->record_length += record_length;
+
+    self->num_rows += num_rows;
+    self->timestamp_offset[self->num_rows] = self->timestamp_length;
+    self->record_offset[self->num_rows] = self->record_length;
+out:
+    return ret;
+}
+
+static tsk_id_t
+tsk_provenance_table_add_row_internal(tsk_provenance_table_t *self,
+    const char *timestamp, tsk_size_t timestamp_length, const char *record,
+    tsk_size_t record_length)
+{
+    int ret = 0;
+
+    tsk_bug_assert(self->num_rows < self->max_rows);
+    tsk_bug_assert(
+        self->timestamp_length + timestamp_length <= self->max_timestamp_length);
+    memcpy(self->timestamp + self->timestamp_length, timestamp, timestamp_length);
+    self->timestamp_offset[self->num_rows + 1]
+        = self->timestamp_length + timestamp_length;
+    self->timestamp_length += timestamp_length;
+    tsk_bug_assert(self->record_length + record_length <= self->max_record_length);
+    memcpy(self->record + self->record_length, record, record_length);
+    self->record_offset[self->num_rows + 1] = self->record_length + record_length;
+    self->record_length += record_length;
+    ret = (tsk_id_t) self->num_rows;
+    self->num_rows++;
+    return ret;
+}
+
+tsk_id_t
+tsk_provenance_table_add_row(tsk_provenance_table_t *self, const char *timestamp,
+    tsk_size_t timestamp_length, const char *record, tsk_size_t record_length)
+{
+    int ret = 0;
+
+    ret = tsk_provenance_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_expand_timestamp(self, timestamp_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_expand_provenance(self, record_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_add_row_internal(
+        self, timestamp, timestamp_length, record, record_length);
+out:
+    return ret;
+}
+
+int
+tsk_provenance_table_clear(tsk_provenance_table_t *self)
+{
+    return tsk_provenance_table_truncate(self, 0);
+}
+
+int
+tsk_provenance_table_truncate(tsk_provenance_table_t *self, tsk_size_t num_rows)
+{
+    int ret = 0;
+
+    if (num_rows > self->num_rows) {
+        ret = TSK_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = num_rows;
+    self->timestamp_length = self->timestamp_offset[num_rows];
+    self->record_length = self->record_offset[num_rows];
+out:
+    return ret;
+}
+
+int
+tsk_provenance_table_free(tsk_provenance_table_t *self)
+{
+    tsk_safe_free(self->timestamp);
+    tsk_safe_free(self->timestamp_offset);
+    tsk_safe_free(self->record);
+    tsk_safe_free(self->record_offset);
+    return 0;
+}
+
+void
+tsk_provenance_table_print_state(const tsk_provenance_table_t *self, FILE *out)
+{
+    tsk_size_t j, k;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "provenance_table: %p:\n", (const void *) self);
+    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "timestamp_length  = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->timestamp_length, (int) self->max_timestamp_length,
+        (int) self->max_timestamp_length_increment);
+    fprintf(out, "record_length = %d\tmax= %d\tincrement = %d)\n",
+        (int) self->record_length, (int) self->max_record_length,
+        (int) self->max_record_length_increment);
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "index\ttimestamp_offset\ttimestamp\trecord_offset\tprovenance\n");
+    for (j = 0; j < self->num_rows; j++) {
+        fprintf(out, "%d\t%d\t", (int) j, self->timestamp_offset[j]);
+        for (k = self->timestamp_offset[j]; k < self->timestamp_offset[j + 1]; k++) {
+            fprintf(out, "%c", self->timestamp[k]);
+        }
+        fprintf(out, "\t%d\t", self->record_offset[j]);
+        for (k = self->record_offset[j]; k < self->record_offset[j + 1]; k++) {
+            fprintf(out, "%c", self->record[k]);
+        }
+        fprintf(out, "\n");
+    }
+    tsk_bug_assert(self->timestamp_offset[0] == 0);
+    tsk_bug_assert(self->timestamp_offset[self->num_rows] == self->timestamp_length);
+    tsk_bug_assert(self->record_offset[0] == 0);
+    tsk_bug_assert(self->record_offset[self->num_rows] == self->record_length);
+}
+
+static inline void
+tsk_provenance_table_get_row_unsafe(
+    const tsk_provenance_table_t *self, tsk_id_t index, tsk_provenance_t *row)
+{
+    row->id = (tsk_id_t) index;
+    row->timestamp_length
+        = self->timestamp_offset[index + 1] - self->timestamp_offset[index];
+    row->timestamp = self->timestamp + self->timestamp_offset[index];
+    row->record_length = self->record_offset[index + 1] - self->record_offset[index];
+    row->record = self->record + self->record_offset[index];
+}
+
+int
+tsk_provenance_table_get_row(
+    const tsk_provenance_table_t *self, tsk_id_t index, tsk_provenance_t *row)
+{
+    int ret = 0;
+
+    if (index < 0 || index >= (tsk_id_t) self->num_rows) {
+        ret = TSK_ERR_PROVENANCE_OUT_OF_BOUNDS;
+        goto out;
+    }
+    tsk_provenance_table_get_row_unsafe(self, index, row);
+out:
+    return ret;
+}
+
+int
+tsk_provenance_table_dump_text(const tsk_provenance_table_t *self, FILE *out)
+{
+    int ret = TSK_ERR_IO;
+    int err;
+    tsk_size_t j, timestamp_len, record_len;
+
+    err = fprintf(out, "record\ttimestamp\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        record_len = self->record_offset[j + 1] - self->record_offset[j];
+        timestamp_len = self->timestamp_offset[j + 1] - self->timestamp_offset[j];
+        err = fprintf(out, "%.*s\t%.*s\n", record_len,
+            self->record + self->record_offset[j], timestamp_len,
+            self->timestamp + self->timestamp_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool
+tsk_provenance_table_equals(const tsk_provenance_table_t *self,
+    const tsk_provenance_table_t *other, tsk_flags_t options)
+{
+    bool ret = self->num_rows == other->num_rows
+               && self->record_length == other->record_length
+               && memcmp(self->record_offset, other->record_offset,
+                      (self->num_rows + 1) * sizeof(tsk_size_t))
+                      == 0
+               && memcmp(self->record, other->record, self->record_length * sizeof(char))
+                      == 0;
+    if (!(options & TSK_CMP_IGNORE_TIMESTAMPS)) {
+        ret = ret && self->timestamp_length == other->timestamp_length
+              && memcmp(self->timestamp_offset, other->timestamp_offset,
+                     (self->num_rows + 1) * sizeof(tsk_size_t))
+                     == 0
+              && memcmp(self->timestamp, other->timestamp,
+                     self->timestamp_length * sizeof(char))
+                     == 0;
+    }
+    return ret;
+}
+
+static int
+tsk_provenance_table_dump(const tsk_provenance_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        { "provenances/timestamp", (void *) self->timestamp, self->timestamp_length,
+            KAS_UINT8 },
+        { "provenances/timestamp_offset", (void *) self->timestamp_offset,
+            self->num_rows + 1, KAS_UINT32 },
+        { "provenances/record", (void *) self->record, self->record_length, KAS_UINT8 },
+        { "provenances/record_offset", (void *) self->record_offset, self->num_rows + 1,
+            KAS_UINT32 },
+    };
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+tsk_provenance_table_load(tsk_provenance_table_t *self, kastore_t *store)
+{
+    int ret;
+    char *timestamp = NULL;
+    tsk_size_t *timestamp_offset = NULL;
+    char *record = NULL;
+    tsk_size_t *record_offset = NULL;
+    tsk_size_t num_rows, timestamp_length, record_length;
+
+    read_table_col_t read_cols[] = {
+        { "provenances/timestamp", (void **) &timestamp, &timestamp_length, 0, KAS_UINT8,
+            0 },
+        { "provenances/timestamp_offset", (void **) &timestamp_offset, &num_rows, 1,
+            KAS_UINT32, 0 },
+        { "provenances/record", (void **) &record, &record_length, 0, KAS_UINT8, 0 },
+        { "provenances/record_offset", (void **) &record_offset, &num_rows, 1,
+            KAS_UINT32, 0 },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if (timestamp_offset[num_rows] != timestamp_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    if (record_offset[num_rows] != record_length) {
+        ret = TSK_ERR_BAD_OFFSET;
+        goto out;
+    }
+    ret = tsk_provenance_table_set_columns(
+        self, num_rows, timestamp, timestamp_offset, record, record_offset);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * sort_tables
+ *************************/
+
+typedef struct {
+    double left;
+    double right;
+    tsk_id_t parent;
+    tsk_id_t child;
+    double time;
+    /* It would be a little bit more convenient to store a pointer to the
+     * metadata here in the struct rather than an offset back into the
+     * original array. However, this would increase the size of the struct
+     * from 40 bytes to 48 and we will allocate very large numbers of these.
+     */
+    tsk_size_t metadata_offset;
+    tsk_size_t metadata_length;
+} edge_sort_t;
+
+static int
+cmp_site(const void *a, const void *b)
+{
+    const tsk_site_t *ia = (const tsk_site_t *) a;
+    const tsk_site_t *ib = (const tsk_site_t *) b;
+    /* Compare sites by position */
+    int ret = (ia->position > ib->position) - (ia->position < ib->position);
+    if (ret == 0) {
+        /* Within a particular position sort by ID.  This ensures that relative
+         * ordering of multiple sites at the same position is maintained; the
+         * redundant sites will get compacted down by clean_tables(), but in the
+         * meantime if the order of the redundant sites changes it will cause the
+         * sort order of mutations to be corrupted, as the mutations will follow
+         * their sites. */
+        ret = (ia->id > ib->id) - (ia->id < ib->id);
+    }
+    return ret;
+}
+
+static int
+cmp_mutation(const void *a, const void *b)
+{
+    const tsk_mutation_t *ia = (const tsk_mutation_t *) a;
+    const tsk_mutation_t *ib = (const tsk_mutation_t *) b;
+    /* Compare mutations by site */
+    int ret = (ia->site > ib->site) - (ia->site < ib->site);
+    /* Within a particular site sort by time if known, then ID. This ensures that
+     * relative ordering within a site is maintained */
+    if (ret == 0 && !tsk_is_unknown_time(ia->time) && !tsk_is_unknown_time(ib->time)) {
+        ret = (ia->time < ib->time) - (ia->time > ib->time);
+    }
+    if (ret == 0) {
+        ret = (ia->id > ib->id) - (ia->id < ib->id);
+    }
+    return ret;
+}
+
+static int
+cmp_edge(const void *a, const void *b)
+{
+    const edge_sort_t *ca = (const edge_sort_t *) a;
+    const edge_sort_t *cb = (const edge_sort_t *) b;
+
+    int ret = (ca->time > cb->time) - (ca->time < cb->time);
+    /* If time values are equal, sort by the parent node */
+    if (ret == 0) {
+        ret = (ca->parent > cb->parent) - (ca->parent < cb->parent);
+        /* If the parent nodes are equal, sort by the child ID. */
+        if (ret == 0) {
+            ret = (ca->child > cb->child) - (ca->child < cb->child);
+            /* If the child nodes are equal, sort by the left coordinate. */
+            if (ret == 0) {
+                ret = (ca->left > cb->left) - (ca->left < cb->left);
+            }
+        }
+    }
+    return ret;
+}
+
+static int
+tsk_table_sorter_sort_edges(tsk_table_sorter_t *self, tsk_size_t start)
+{
+    int ret = 0;
+    const tsk_edge_table_t *edges = &self->tables->edges;
+    const double *restrict node_time = self->tables->nodes.time;
+    edge_sort_t *e;
+    tsk_size_t j, k, metadata_offset;
+    tsk_size_t n = edges->num_rows - start;
+    edge_sort_t *sorted_edges = malloc(n * sizeof(*sorted_edges));
+    char *old_metadata = malloc(edges->metadata_length);
+    bool has_metadata = tsk_edge_table_has_metadata(edges);
+
+    if (sorted_edges == NULL || old_metadata == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(old_metadata, edges->metadata, edges->metadata_length);
+    for (j = 0; j < n; j++) {
+        e = sorted_edges + j;
+        k = start + j;
+        e->left = edges->left[k];
+        e->right = edges->right[k];
+        e->parent = edges->parent[k];
+        e->child = edges->child[k];
+        e->time = node_time[e->parent];
+        if (has_metadata) {
+            e->metadata_offset = edges->metadata_offset[k];
+            e->metadata_length
+                = edges->metadata_offset[k + 1] - edges->metadata_offset[k];
+        }
+    }
+    qsort(sorted_edges, n, sizeof(edge_sort_t), cmp_edge);
+    /* Copy the edges back into the table. */
+    metadata_offset = 0;
+    for (j = 0; j < n; j++) {
+        e = sorted_edges + j;
+        k = start + j;
+        edges->left[k] = e->left;
+        edges->right[k] = e->right;
+        edges->parent[k] = e->parent;
+        edges->child[k] = e->child;
+        if (has_metadata) {
+            memcpy(edges->metadata + metadata_offset, old_metadata + e->metadata_offset,
+                e->metadata_length);
+            edges->metadata_offset[k] = metadata_offset;
+            metadata_offset += e->metadata_length;
+        }
+    }
+out:
+    tsk_safe_free(sorted_edges);
+    tsk_safe_free(old_metadata);
+    return ret;
+}
+
+static int
+tsk_table_sorter_sort_sites(tsk_table_sorter_t *self)
+{
+    int ret = 0;
+    tsk_site_table_t *sites = &self->tables->sites;
+    tsk_site_table_t copy;
+    tsk_size_t j;
+    tsk_size_t num_sites = sites->num_rows;
+    tsk_site_t *sorted_sites = malloc(num_sites * sizeof(*sorted_sites));
+
+    ret = tsk_site_table_copy(sites, &copy, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    if (sorted_sites == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    for (j = 0; j < num_sites; j++) {
+        tsk_site_table_get_row_unsafe(&copy, (tsk_id_t) j, sorted_sites + j);
+    }
+
+    /* Sort the sites by position */
+    qsort(sorted_sites, num_sites, sizeof(*sorted_sites), cmp_site);
+
+    /* Build the mapping from old site IDs to new site IDs and copy back into the
+     * table
+     */
+    tsk_site_table_clear(sites);
+    for (j = 0; j < num_sites; j++) {
+        self->site_id_map[sorted_sites[j].id] = (tsk_id_t) j;
+        ret = tsk_site_table_add_row(sites, sorted_sites[j].position,
+            sorted_sites[j].ancestral_state, sorted_sites[j].ancestral_state_length,
+            sorted_sites[j].metadata, sorted_sites[j].metadata_length);
+        if (ret < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    tsk_safe_free(sorted_sites);
+    tsk_site_table_free(&copy);
+    return ret;
+}
+
+static int
+tsk_table_sorter_sort_mutations(tsk_table_sorter_t *self)
+{
+    int ret = 0;
+    tsk_size_t j;
+    tsk_id_t parent, mapped_parent;
+    tsk_mutation_table_t *mutations = &self->tables->mutations;
+    tsk_size_t num_mutations = mutations->num_rows;
+    tsk_mutation_table_t copy;
+    tsk_mutation_t *sorted_mutations = malloc(num_mutations * sizeof(*sorted_mutations));
+    tsk_id_t *mutation_id_map = malloc(num_mutations * sizeof(*mutation_id_map));
+
+    ret = tsk_mutation_table_copy(mutations, &copy, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    if (mutation_id_map == NULL || sorted_mutations == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    for (j = 0; j < num_mutations; j++) {
+        tsk_mutation_table_get_row_unsafe(&copy, (tsk_id_t) j, sorted_mutations + j);
+        sorted_mutations[j].site = self->site_id_map[sorted_mutations[j].site];
+    }
+    ret = tsk_mutation_table_clear(mutations);
+    if (ret != 0) {
+        goto out;
+    }
+
+    qsort(sorted_mutations, num_mutations, sizeof(*sorted_mutations), cmp_mutation);
+
+    /* Make a first pass through the sorted mutations to build the ID map. */
+    for (j = 0; j < num_mutations; j++) {
+        mutation_id_map[sorted_mutations[j].id] = (tsk_id_t) j;
+    }
+
+    for (j = 0; j < num_mutations; j++) {
+        mapped_parent = TSK_NULL;
+        parent = sorted_mutations[j].parent;
+        if (parent != TSK_NULL) {
+            mapped_parent = mutation_id_map[parent];
+        }
+        ret = tsk_mutation_table_add_row(mutations, sorted_mutations[j].site,
+            sorted_mutations[j].node, mapped_parent, sorted_mutations[j].time,
+            sorted_mutations[j].derived_state, sorted_mutations[j].derived_state_length,
+            sorted_mutations[j].metadata, sorted_mutations[j].metadata_length);
+        if (ret < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+
+out:
+    tsk_safe_free(mutation_id_map);
+    tsk_safe_free(sorted_mutations);
+    tsk_mutation_table_free(&copy);
+    return ret;
+}
+
+int
+tsk_table_sorter_run(tsk_table_sorter_t *self, const tsk_bookmark_t *start)
+{
+    int ret = 0;
+    tsk_size_t edge_start = 0;
+    bool skip_sites = false;
+
+    if (start != NULL) {
+        if (start->edges > self->tables->edges.num_rows) {
+            ret = TSK_ERR_EDGE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        edge_start = start->edges;
+
+        if (start->migrations != 0) {
+            ret = TSK_ERR_MIGRATIONS_NOT_SUPPORTED;
+            goto out;
+        }
+        /* We only allow sites and mutations to be specified as a way to
+         * skip sorting them entirely. Both sites and mutations must be
+         * equal to the number of rows */
+        if (start->sites == self->tables->sites.num_rows
+            && start->mutations == self->tables->mutations.num_rows) {
+            skip_sites = true;
+        } else if (start->sites != 0 || start->mutations != 0) {
+            ret = TSK_ERR_SORT_OFFSET_NOT_SUPPORTED;
+            goto out;
+        }
+    }
+    /* The indexes will be invalidated, so drop them */
+    ret = tsk_table_collection_drop_index(self->tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    if (self->sort_edges != NULL) {
+        ret = self->sort_edges(self, edge_start);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (!skip_sites) {
+        ret = tsk_table_sorter_sort_sites(self);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_table_sorter_sort_mutations(self);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+int
+tsk_table_sorter_init(
+    tsk_table_sorter_t *self, tsk_table_collection_t *tables, tsk_flags_t options)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(tsk_table_sorter_t));
+    if (tables->migrations.num_rows != 0) {
+        ret = TSK_ERR_SORT_MIGRATIONS_NOT_SUPPORTED;
+        goto out;
+    }
+    if (!(options & TSK_NO_CHECK_INTEGRITY)) {
+        ret = tsk_table_collection_check_integrity(tables, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    self->tables = tables;
+
+    self->site_id_map = malloc(self->tables->sites.num_rows * sizeof(tsk_id_t));
+    if (self->site_id_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    /* Set the sort_edges method to the default. */
+    self->sort_edges = tsk_table_sorter_sort_edges;
+out:
+    return ret;
+}
+
+int
+tsk_table_sorter_free(tsk_table_sorter_t *self)
+{
+    tsk_safe_free(self->site_id_map);
+    return 0;
+}
+
+/*************************
+ * segment overlapper
+ *************************/
+
+typedef struct _interval_list_t {
+    double left;
+    double right;
+    struct _interval_list_t *next;
+} interval_list_t;
+
+typedef struct _mutation_id_list_t {
+    tsk_id_t mutation;
+    struct _mutation_id_list_t *next;
+} mutation_id_list_t;
+
+/* segment overlap finding algorithm */
+typedef struct {
+    /* The input segments. This buffer is sorted by the algorithm and we also
+     * assume that there is space for an extra element at the end */
+    tsk_segment_t *segments;
+    size_t num_segments;
+    size_t index;
+    size_t num_overlapping;
+    double left;
+    double right;
+    /* Output buffer */
+    size_t max_overlapping;
+    tsk_segment_t **overlapping;
+} segment_overlapper_t;
+
+typedef struct {
+    tsk_id_t *samples;
+    size_t num_samples;
+    tsk_flags_t options;
+    tsk_table_collection_t *tables;
+    /* Keep a copy of the input tables */
+    tsk_table_collection_t input_tables;
+    /* State for topology */
+    tsk_segment_t **ancestor_map_head;
+    tsk_segment_t **ancestor_map_tail;
+    tsk_id_t *node_id_map;
+    bool *is_sample;
+    /* Segments for a particular parent that are processed together */
+    tsk_segment_t *segment_queue;
+    size_t segment_queue_size;
+    size_t max_segment_queue_size;
+    segment_overlapper_t segment_overlapper;
+    tsk_blkalloc_t segment_heap;
+    /* Buffer for output edges. For each child we keep a linked list of
+     * intervals, and also store the actual children that have been buffered. */
+    tsk_blkalloc_t interval_list_heap;
+    interval_list_t **child_edge_map_head;
+    interval_list_t **child_edge_map_tail;
+    tsk_id_t *buffered_children;
+    size_t num_buffered_children;
+    /* For each mutation, map its output node. */
+    tsk_id_t *mutation_node_map;
+    /* Map of input mutation IDs to output mutation IDs. */
+    tsk_id_t *mutation_id_map;
+    /* Map of input nodes to the list of input mutation IDs */
+    mutation_id_list_t **node_mutation_list_map_head;
+    mutation_id_list_t **node_mutation_list_map_tail;
+    mutation_id_list_t *node_mutation_list_mem;
+    /* When reducing topology, we need a map positions to their corresponding
+     * sites.*/
+    double *position_lookup;
+    int64_t edge_sort_offset;
+} simplifier_t;
+
+static int
+cmp_segment(const void *a, const void *b)
+{
+    const tsk_segment_t *ia = (const tsk_segment_t *) a;
+    const tsk_segment_t *ib = (const tsk_segment_t *) b;
+    int ret = (ia->left > ib->left) - (ia->left < ib->left);
+    /* Break ties using the node */
+    if (ret == 0) {
+        ret = (ia->node > ib->node) - (ia->node < ib->node);
+    }
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+segment_overlapper_alloc(segment_overlapper_t *self)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(*self));
+    self->max_overlapping = 8; /* Making sure we call realloc in tests */
+    self->overlapping = malloc(self->max_overlapping * sizeof(*self->overlapping));
+    if (self->overlapping == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int
+segment_overlapper_free(segment_overlapper_t *self)
+{
+    tsk_safe_free(self->overlapping);
+    return 0;
+}
+
+/* Initialise the segment overlapper for use. Note that the segments
+ * array must have space for num_segments + 1 elements!
+ */
+static int TSK_WARN_UNUSED
+segment_overlapper_start(
+    segment_overlapper_t *self, tsk_segment_t *segments, size_t num_segments)
+{
+    int ret = 0;
+    tsk_segment_t *sentinel;
+    void *p;
+
+    if (self->max_overlapping < num_segments) {
+        self->max_overlapping = num_segments;
+        p = realloc(
+            self->overlapping, self->max_overlapping * sizeof(*self->overlapping));
+        if (p == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->overlapping = p;
+    }
+    self->segments = segments;
+    self->num_segments = num_segments;
+    self->index = 0;
+    self->num_overlapping = 0;
+    self->left = 0;
+    self->right = DBL_MAX;
+
+    /* Sort the segments in the buffer by left coordinate */
+    qsort(self->segments, self->num_segments, sizeof(tsk_segment_t), cmp_segment);
+    /* NOTE! We are assuming that there's space for another element on the end
+     * here. This is to insert a sentinel which simplifies the logic. */
+    sentinel = self->segments + self->num_segments;
+    sentinel->left = DBL_MAX;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+segment_overlapper_next(segment_overlapper_t *self, double *left, double *right,
+    tsk_segment_t ***overlapping, size_t *num_overlapping)
+{
+    int ret = 0;
+    size_t j, k;
+    size_t n = self->num_segments;
+    tsk_segment_t *S = self->segments;
+
+    if (self->index < n) {
+        self->left = self->right;
+        /* Remove any elements of X with right <= left */
+        k = 0;
+        for (j = 0; j < self->num_overlapping; j++) {
+            if (self->overlapping[j]->right > self->left) {
+                self->overlapping[k] = self->overlapping[j];
+                k++;
+            }
+        }
+        self->num_overlapping = k;
+        if (k == 0) {
+            self->left = S[self->index].left;
+        }
+        while (self->index < n && S[self->index].left == self->left) {
+            tsk_bug_assert(self->num_overlapping < self->max_overlapping);
+            self->overlapping[self->num_overlapping] = &S[self->index];
+            self->num_overlapping++;
+            self->index++;
+        }
+        self->index--;
+        self->right = S[self->index + 1].left;
+        for (j = 0; j < self->num_overlapping; j++) {
+            self->right = TSK_MIN(self->right, self->overlapping[j]->right);
+        }
+        tsk_bug_assert(self->left < self->right);
+        self->index++;
+        ret = 1;
+    } else {
+        self->left = self->right;
+        self->right = DBL_MAX;
+        k = 0;
+        for (j = 0; j < self->num_overlapping; j++) {
+            if (self->overlapping[j]->right > self->left) {
+                self->right = TSK_MIN(self->right, self->overlapping[j]->right);
+                self->overlapping[k] = self->overlapping[j];
+                k++;
+            }
+        }
+        self->num_overlapping = k;
+        if (k > 0) {
+            ret = 1;
+        }
+    }
+
+    *left = self->left;
+    *right = self->right;
+    *overlapping = self->overlapping;
+    *num_overlapping = self->num_overlapping;
+    return ret;
+}
+
+static int
+cmp_node_id(const void *a, const void *b)
+{
+    const tsk_id_t *ia = (const tsk_id_t *) a;
+    const tsk_id_t *ib = (const tsk_id_t *) b;
+    return (*ia > *ib) - (*ia < *ib);
+}
+
+/*************************
+ * Ancestor mapper
+ *************************/
+
+/* NOTE: this struct shares a lot with the simplifier_t, mostly in
+ * terms of infrastructure for managing the list of intervals, saving
+ * edges etc. We should try to abstract the common functionality out
+ * into a separate class, which handles this.
+ */
+typedef struct {
+    tsk_id_t *samples;
+    size_t num_samples;
+    tsk_id_t *ancestors;
+    size_t num_ancestors;
+    tsk_table_collection_t *tables;
+    tsk_edge_table_t *result;
+    tsk_segment_t **ancestor_map_head;
+    tsk_segment_t **ancestor_map_tail;
+    bool *is_sample;
+    bool *is_ancestor;
+    tsk_segment_t *segment_queue;
+    size_t segment_queue_size;
+    size_t max_segment_queue_size;
+    segment_overlapper_t segment_overlapper;
+    tsk_blkalloc_t segment_heap;
+    tsk_blkalloc_t interval_list_heap;
+    interval_list_t **child_edge_map_head;
+    interval_list_t **child_edge_map_tail;
+    tsk_id_t *buffered_children;
+    size_t num_buffered_children;
+    double sequence_length;
+} ancestor_mapper_t;
+
+static tsk_segment_t *TSK_WARN_UNUSED
+ancestor_mapper_alloc_segment(
+    ancestor_mapper_t *self, double left, double right, tsk_id_t node)
+{
+    tsk_segment_t *seg = NULL;
+
+    seg = tsk_blkalloc_get(&self->segment_heap, sizeof(*seg));
+    if (seg == NULL) {
+        goto out;
+    }
+    seg->next = NULL;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+out:
+    return seg;
+}
+
+static interval_list_t *TSK_WARN_UNUSED
+ancestor_mapper_alloc_interval_list(ancestor_mapper_t *self, double left, double right)
+{
+    interval_list_t *x = NULL;
+
+    x = tsk_blkalloc_get(&self->interval_list_heap, sizeof(*x));
+    if (x == NULL) {
+        goto out;
+    }
+    x->next = NULL;
+    x->left = left;
+    x->right = right;
+out:
+    return x;
+}
+
+static int
+ancestor_mapper_flush_edges(
+    ancestor_mapper_t *self, tsk_id_t parent, size_t *ret_num_edges)
+{
+    int ret = 0;
+    size_t j;
+    tsk_id_t child;
+    interval_list_t *x;
+    size_t num_edges = 0;
+
+    qsort(self->buffered_children, self->num_buffered_children, sizeof(tsk_id_t),
+        cmp_node_id);
+    for (j = 0; j < self->num_buffered_children; j++) {
+        child = self->buffered_children[j];
+        for (x = self->child_edge_map_head[child]; x != NULL; x = x->next) {
+            // printf("Adding edge %f %f %i %i\n", x->left, x->right, parent, child);
+            ret = tsk_edge_table_add_row(
+                self->result, x->left, x->right, parent, child, NULL, 0);
+            if (ret < 0) {
+                goto out;
+            }
+            num_edges++;
+        }
+        self->child_edge_map_head[child] = NULL;
+        self->child_edge_map_tail[child] = NULL;
+    }
+    self->num_buffered_children = 0;
+    *ret_num_edges = num_edges;
+    ret = tsk_blkalloc_reset(&self->interval_list_heap);
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_record_edge(
+    ancestor_mapper_t *self, double left, double right, tsk_id_t child)
+{
+    int ret = 0;
+    interval_list_t *tail, *x;
+
+    tail = self->child_edge_map_tail[child];
+    if (tail == NULL) {
+        tsk_bug_assert(self->num_buffered_children < self->tables->nodes.num_rows);
+        self->buffered_children[self->num_buffered_children] = child;
+        self->num_buffered_children++;
+        x = ancestor_mapper_alloc_interval_list(self, left, right);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->child_edge_map_head[child] = x;
+        self->child_edge_map_tail[child] = x;
+    } else {
+        if (tail->right == left) {
+            tail->right = right;
+        } else {
+            x = ancestor_mapper_alloc_interval_list(self, left, right);
+            if (x == NULL) {
+                ret = TSK_ERR_NO_MEMORY;
+                goto out;
+            }
+            tail->next = x;
+            self->child_edge_map_tail[child] = x;
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_add_ancestry(ancestor_mapper_t *self, tsk_id_t input_id, double left,
+    double right, tsk_id_t output_id)
+{
+    int ret = 0;
+    tsk_segment_t *tail = self->ancestor_map_tail[input_id];
+    tsk_segment_t *x;
+
+    tsk_bug_assert(left < right);
+    if (tail == NULL) {
+        x = ancestor_mapper_alloc_segment(self, left, right, output_id);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->ancestor_map_head[input_id] = x;
+        self->ancestor_map_tail[input_id] = x;
+    } else {
+        if (tail->right == left && tail->node == output_id) {
+            tail->right = right;
+        } else {
+            x = ancestor_mapper_alloc_segment(self, left, right, output_id);
+            if (x == NULL) {
+                ret = TSK_ERR_NO_MEMORY;
+                goto out;
+            }
+            tail->next = x;
+            self->ancestor_map_tail[input_id] = x;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_init_samples(ancestor_mapper_t *self, tsk_id_t *samples)
+{
+    int ret = 0;
+    size_t j;
+
+    /* Go through the samples to check for errors. */
+    for (j = 0; j < self->num_samples; j++) {
+        if (samples[j] < 0 || samples[j] > (tsk_id_t) self->tables->nodes.num_rows) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (self->is_sample[samples[j]]) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        self->is_sample[samples[j]] = true;
+        ret = ancestor_mapper_add_ancestry(
+            self, samples[j], 0, self->tables->sequence_length, samples[j]);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_init_ancestors(ancestor_mapper_t *self, tsk_id_t *ancestors)
+{
+    int ret = 0;
+    size_t j;
+
+    /* Go through the samples to check for errors. */
+    for (j = 0; j < self->num_ancestors; j++) {
+        if (ancestors[j] < 0 || ancestors[j] > (tsk_id_t) self->tables->nodes.num_rows) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (self->is_ancestor[ancestors[j]]) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        self->is_ancestor[ancestors[j]] = true;
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_init(ancestor_mapper_t *self, tsk_id_t *samples, size_t num_samples,
+    tsk_id_t *ancestors, size_t num_ancestors, tsk_table_collection_t *tables,
+    tsk_edge_table_t *result)
+{
+    int ret = 0;
+    size_t num_nodes_alloc;
+
+    memset(self, 0, sizeof(ancestor_mapper_t));
+    self->num_samples = num_samples;
+    self->num_ancestors = num_ancestors;
+    self->samples = samples;
+    self->ancestors = ancestors;
+    self->tables = tables;
+    self->result = result;
+    self->sequence_length = self->tables->sequence_length;
+
+    if (samples == NULL || num_samples == 0 || ancestors == NULL || num_ancestors == 0) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+
+    /* Allocate the heaps used for small objects-> Assuming 8K is a good chunk size
+     */
+    ret = tsk_blkalloc_init(&self->segment_heap, 8192);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_blkalloc_init(&self->interval_list_heap, 8192);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = segment_overlapper_alloc(&self->segment_overlapper);
+    if (ret != 0) {
+        goto out;
+    }
+
+    /* Need to avoid malloc(0) so make sure we have at least 1. */
+    num_nodes_alloc = 1 + tables->nodes.num_rows;
+    /* Make the maps and set the intial state */
+    self->ancestor_map_head = calloc(num_nodes_alloc, sizeof(tsk_segment_t *));
+    self->ancestor_map_tail = calloc(num_nodes_alloc, sizeof(tsk_segment_t *));
+    self->child_edge_map_head = calloc(num_nodes_alloc, sizeof(interval_list_t *));
+    self->child_edge_map_tail = calloc(num_nodes_alloc, sizeof(interval_list_t *));
+    self->buffered_children = malloc(num_nodes_alloc * sizeof(tsk_id_t));
+    self->is_sample = calloc(num_nodes_alloc, sizeof(bool));
+    self->is_ancestor = calloc(num_nodes_alloc, sizeof(bool));
+    self->max_segment_queue_size = 64;
+    self->segment_queue = malloc(self->max_segment_queue_size * sizeof(tsk_segment_t));
+    if (self->ancestor_map_head == NULL || self->ancestor_map_tail == NULL
+        || self->child_edge_map_head == NULL || self->child_edge_map_tail == NULL
+        || self->is_sample == NULL || self->is_ancestor == NULL
+        || self->segment_queue == NULL || self->buffered_children == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    // Clear memory.
+    ret = ancestor_mapper_init_samples(self, samples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = ancestor_mapper_init_ancestors(self, ancestors);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_clear(self->result);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int
+ancestor_mapper_free(ancestor_mapper_t *self)
+{
+    tsk_blkalloc_free(&self->segment_heap);
+    tsk_blkalloc_free(&self->interval_list_heap);
+    segment_overlapper_free(&self->segment_overlapper);
+    tsk_safe_free(self->ancestor_map_head);
+    tsk_safe_free(self->ancestor_map_tail);
+    tsk_safe_free(self->child_edge_map_head);
+    tsk_safe_free(self->child_edge_map_tail);
+    tsk_safe_free(self->segment_queue);
+    tsk_safe_free(self->is_sample);
+    tsk_safe_free(self->is_ancestor);
+    tsk_safe_free(self->buffered_children);
+    return 0;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_enqueue_segment(
+    ancestor_mapper_t *self, double left, double right, tsk_id_t node)
+{
+    int ret = 0;
+    tsk_segment_t *seg;
+    void *p;
+
+    tsk_bug_assert(left < right);
+    /* Make sure we always have room for one more segment in the queue so we
+     * can put a tail sentinel on it */
+    if (self->segment_queue_size == self->max_segment_queue_size - 1) {
+        self->max_segment_queue_size *= 2;
+        p = realloc(self->segment_queue,
+            self->max_segment_queue_size * sizeof(*self->segment_queue));
+        if (p == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->segment_queue = p;
+    }
+    seg = self->segment_queue + self->segment_queue_size;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+    self->segment_queue_size++;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_merge_ancestors(ancestor_mapper_t *self, tsk_id_t input_id)
+{
+    int ret = 0;
+    tsk_segment_t **X, *x;
+    size_t j, num_overlapping, num_flushed_edges;
+    double left, right, prev_right;
+    bool is_sample = self->is_sample[input_id];
+    bool is_ancestor = self->is_ancestor[input_id];
+
+    if (is_sample) {
+        /* Free up the existing ancestry mapping. */
+        x = self->ancestor_map_tail[input_id];
+        tsk_bug_assert(x->left == 0 && x->right == self->sequence_length);
+        self->ancestor_map_head[input_id] = NULL;
+        self->ancestor_map_tail[input_id] = NULL;
+    }
+    ret = segment_overlapper_start(
+        &self->segment_overlapper, self->segment_queue, self->segment_queue_size);
+    if (ret != 0) {
+        goto out;
+    }
+
+    prev_right = 0;
+    while ((ret = segment_overlapper_next(
+                &self->segment_overlapper, &left, &right, &X, &num_overlapping))
+           == 1) {
+        tsk_bug_assert(left < right);
+        tsk_bug_assert(num_overlapping > 0);
+        if (is_ancestor || is_sample) {
+            for (j = 0; j < num_overlapping; j++) {
+                ret = ancestor_mapper_record_edge(self, left, right, X[j]->node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+            ret = ancestor_mapper_add_ancestry(self, input_id, left, right, input_id);
+            if (ret != 0) {
+                goto out;
+            }
+            if (is_sample && left != prev_right) {
+                /* Fill in any gaps in ancestry for the sample */
+                ret = ancestor_mapper_add_ancestry(
+                    self, input_id, prev_right, left, input_id);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        } else {
+            for (j = 0; j < num_overlapping; j++) {
+                ret = ancestor_mapper_add_ancestry(
+                    self, input_id, left, right, X[j]->node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        }
+        prev_right = right;
+    }
+    if (is_sample && prev_right != self->tables->sequence_length) {
+        /* If a trailing gap exists in the sample ancestry, fill it in. */
+        ret = ancestor_mapper_add_ancestry(
+            self, input_id, prev_right, self->sequence_length, input_id);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (input_id != TSK_NULL) {
+        ret = ancestor_mapper_flush_edges(self, input_id, &num_flushed_edges);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_process_parent_edges(
+    ancestor_mapper_t *self, tsk_id_t parent, size_t start, size_t end)
+{
+    int ret = 0;
+    size_t j;
+    tsk_segment_t *x;
+    const tsk_edge_table_t *input_edges = &self->tables->edges;
+    tsk_id_t child;
+    double left, right;
+
+    /* Go through the edges and queue up ancestry segments for processing. */
+    self->segment_queue_size = 0;
+    for (j = start; j < end; j++) {
+        tsk_bug_assert(parent == input_edges->parent[j]);
+        child = input_edges->child[j];
+        left = input_edges->left[j];
+        right = input_edges->right[j];
+        // printf("C: %i, L: %f, R: %f\n", child, left, right);
+        for (x = self->ancestor_map_head[child]; x != NULL; x = x->next) {
+            if (x->right > left && right > x->left) {
+                ret = ancestor_mapper_enqueue_segment(
+                    self, TSK_MAX(x->left, left), TSK_MIN(x->right, right), x->node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        }
+    }
+    // We can now merge the ancestral segments for the parent
+    ret = ancestor_mapper_merge_ancestors(self, parent);
+    if (ret != 0) {
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+ancestor_mapper_run(ancestor_mapper_t *self)
+{
+    int ret = 0;
+    size_t j, start;
+    tsk_id_t parent, current_parent;
+    const tsk_edge_table_t *input_edges = &self->tables->edges;
+    size_t num_edges = input_edges->num_rows;
+
+    if (num_edges > 0) {
+        start = 0;
+        current_parent = input_edges->parent[0];
+        for (j = 0; j < num_edges; j++) {
+            parent = input_edges->parent[j];
+            if (parent != current_parent) {
+                ret = ancestor_mapper_process_parent_edges(
+                    self, current_parent, start, j);
+                if (ret != 0) {
+                    goto out;
+                }
+                current_parent = parent;
+                start = j;
+            }
+        }
+        ret = ancestor_mapper_process_parent_edges(
+            self, current_parent, start, num_edges);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * IBD finder
+ *************************/
+
+static tsk_segment_t *TSK_WARN_UNUSED
+tsk_ibd_finder_alloc_segment(
+    tsk_ibd_finder_t *self, double left, double right, tsk_id_t node)
+{
+    tsk_segment_t *seg = NULL;
+
+    seg = tsk_blkalloc_get(&self->segment_heap, sizeof(*seg));
+    if (seg == NULL) {
+        goto out;
+    }
+    seg->next = NULL;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+
+out:
+    return seg;
+}
+
+static int TSK_WARN_UNUSED
+tsk_ibd_finder_add_output(
+    tsk_ibd_finder_t *self, double left, double right, tsk_id_t node_id, int pair_num)
+{
+    int ret = 0;
+    tsk_segment_t *tail = self->ibd_segments_tail[pair_num];
+    tsk_segment_t *x;
+
+    tsk_bug_assert(left < right);
+    if (tail == NULL) {
+        x = tsk_ibd_finder_alloc_segment(self, left, right, node_id);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->ibd_segments_head[pair_num] = x;
+        self->ibd_segments_tail[pair_num] = x;
+    } else {
+        x = tsk_ibd_finder_alloc_segment(self, left, right, node_id);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        tail->next = x;
+        self->ibd_segments_tail[pair_num] = x;
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_ibd_finder_add_ancestry(tsk_ibd_finder_t *self, tsk_id_t input_id, double left,
+    double right, tsk_id_t output_id)
+{
+    int ret = 0;
+    tsk_segment_t *tail = self->ancestor_map_tail[input_id];
+    tsk_segment_t *x = NULL;
+
+    tsk_bug_assert(left < right);
+    if (tail == NULL) {
+        x = tsk_ibd_finder_alloc_segment(self, left, right, output_id);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->ancestor_map_head[input_id] = x;
+        self->ancestor_map_tail[input_id] = x;
+    } else {
+        x = tsk_ibd_finder_alloc_segment(self, left, right, output_id);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        tail->next = x;
+        self->ancestor_map_tail[input_id] = x;
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_ibd_finder_init_samples(tsk_ibd_finder_t *self)
+{
+    int ret = 0;
+    size_t j;
+    tsk_id_t u;
+
+    /* Go through the sample pairs to define samples. */
+    for (j = 0; j < 2 * self->num_pairs; j++) {
+        u = self->pairs[j];
+
+        if (u < 0 || u > (tsk_id_t) self->tables->nodes.num_rows) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+
+        if (!self->is_sample[u]) {
+            self->is_sample[u] = true;
+            ret = tsk_ibd_finder_add_ancestry(
+                self, u, 0, self->tables->sequence_length, u);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+    }
+
+out:
+    return ret;
+}
+
+static int
+tsk_ibd_finder_index_samples(tsk_ibd_finder_t *self)
+{
+    int ret = 0;
+    size_t i;
+    tsk_id_t idx;
+
+    self->paired_nodes_index
+        = calloc(self->num_nodes, sizeof(*self->paired_nodes_index));
+
+    if (self->paired_nodes_index == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    for (i = 0; i < self->num_nodes; ++i) {
+        self->paired_nodes_index[i] = -1;
+    }
+
+    for (i = 0; i < 2 * self->num_pairs; ++i) {
+        self->paired_nodes_index[self->pairs[i]] = 1;
+    }
+
+    self->num_unique_nodes_in_pair = 0;
+    idx = 0;
+    for (i = 0; i < self->num_nodes; ++i) {
+        if (self->paired_nodes_index[i] == 1) {
+            ++self->num_unique_nodes_in_pair;
+            self->paired_nodes_index[i] = idx;
+            ++idx;
+        }
+    }
+
+out:
+    return ret;
+}
+
+// NOTE: future travellers may want to refactor
+// this to only allocate the upper triangle of the matrix.
+// Doing so would save a good bit of memory, but would
+// imply trickier indexing here and in
+// tsk_ibd_finder_find_sample_pair_index2.
+static int
+tsk_ibd_finder_build_pair_map(tsk_ibd_finder_t *self)
+{
+    int ret = 0;
+    size_t i;
+    tsk_id_t sample0, sample1;
+    tsk_id_t row, col;
+    size_t matrix_size = self->num_unique_nodes_in_pair * self->num_unique_nodes_in_pair;
+
+    self->pair_map = calloc(matrix_size, sizeof(*self->pair_map));
+    if (self->pair_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    for (i = 0; i < matrix_size; ++i) {
+        self->pair_map[i] = -1;
+    }
+
+    for (i = 0; i < self->num_pairs; ++i) {
+        sample0 = self->pairs[2 * i];
+        sample1 = self->pairs[2 * i + 1];
+
+        row = TSK_MIN(
+            self->paired_nodes_index[sample0], self->paired_nodes_index[sample1]);
+        col = TSK_MAX(
+            self->paired_nodes_index[sample0], self->paired_nodes_index[sample1]);
+
+        tsk_bug_assert(row >= 0);
+        tsk_bug_assert(col >= 0);
+
+        if (self->pair_map[(size_t) row * self->num_unique_nodes_in_pair + (size_t) col]
+            != -1) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE_PAIRS;
+            goto out;
+        }
+
+        self->pair_map[(size_t) row * self->num_unique_nodes_in_pair + (size_t) col]
+            = (int64_t) i;
+    }
+
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_ibd_finder_init(tsk_ibd_finder_t *self, tsk_table_collection_t *tables,
+    tsk_id_t *pairs, tsk_size_t num_pairs)
+{
+    int ret = 0;
+    size_t num_nodes_alloc;
+
+    memset(self, 0, sizeof(tsk_ibd_finder_t));
+    self->pairs = pairs;
+    self->num_pairs = num_pairs;
+    self->sequence_length = tables->sequence_length;
+    self->num_nodes = tables->nodes.num_rows;
+    self->tables = tables;
+    self->max_time = DBL_MAX;
+    self->min_length = 0;
+
+    if (pairs == NULL || num_pairs < 1) {
+        ret = TSK_ERR_NO_SAMPLE_PAIRS;
+        goto out;
+    }
+
+    // Allocate the heaps used for small objects.
+    ret = tsk_blkalloc_init(&self->segment_heap, 8192);
+    if (ret != 0) {
+        goto out;
+    }
+
+    // Mallocing and callocing.
+    num_nodes_alloc = 1 + tables->nodes.num_rows;
+    self->ancestor_map_head = calloc(num_nodes_alloc, sizeof(*self->ancestor_map_head));
+    self->ancestor_map_tail = calloc(num_nodes_alloc, sizeof(*self->ancestor_map_tail));
+    self->ibd_segments_head = calloc(self->num_pairs, sizeof(*self->ibd_segments_head));
+    self->ibd_segments_tail = calloc(self->num_pairs, sizeof(*self->ibd_segments_tail));
+    self->is_sample = calloc(num_nodes_alloc, sizeof(*self->is_sample));
+    self->segment_queue_size = 0;
+    self->max_segment_queue_size = 64;
+    self->segment_queue
+        = malloc(self->max_segment_queue_size * sizeof(*self->segment_queue));
+    if (self->ancestor_map_head == NULL || self->ancestor_map_tail == NULL
+        || self->ibd_segments_head == NULL || self->ibd_segments_tail == NULL
+        || self->is_sample == NULL || self->segment_queue == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    ret = tsk_ibd_finder_init_samples(self);
+    if (ret != 0) {
+        goto out;
+    }
+
+    ret = tsk_ibd_finder_index_samples(self);
+    if (ret != 0) {
+        goto out;
+    }
+
+    ret = tsk_ibd_finder_build_pair_map(self);
+    if (ret != 0) {
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_ibd_finder_set_min_length(tsk_ibd_finder_t *self, double min_length)
+{
+    int ret = 0;
+
+    if (min_length < 0) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+    }
+    self->min_length = min_length;
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_ibd_finder_set_max_time(tsk_ibd_finder_t *self, double max_time)
+{
+    int ret = 0;
+
+    if (max_time < 0) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+    }
+    self->max_time = max_time;
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_ibd_finder_enqueue_segment(
+    tsk_ibd_finder_t *self, double left, double right, tsk_id_t node)
+{
+    int ret = 0;
+    tsk_segment_t *seg;
+    void *p;
+
+    tsk_bug_assert(left < right);
+    /* Make sure we always have room for one more segment in the queue so we
+     * can put a tail sentinel on it */
+    if (self->segment_queue_size == self->max_segment_queue_size - 1) {
+        self->max_segment_queue_size *= 2;
+        p = realloc(self->segment_queue,
+            self->max_segment_queue_size * sizeof(*self->segment_queue));
+        if (p == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->segment_queue = p;
+    }
+    seg = self->segment_queue + self->segment_queue_size;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+    self->segment_queue_size++;
+out:
+    return ret;
+}
+
+static int
+tsk_ibd_finder_find_sample_pair_index2(
+    tsk_ibd_finder_t *self, tsk_id_t sample0, tsk_id_t sample1)
+{
+    int ret = -1;
+    tsk_id_t s0, s1;
+    size_t row, col;
+
+    s0 = self->paired_nodes_index[sample0];
+    s1 = self->paired_nodes_index[sample1];
+
+    if (s0 < 0 || s1 < 0) {
+        goto out;
+    }
+
+    row = TSK_MIN((size_t) s0, (size_t) s1);
+    col = TSK_MAX((size_t) s0, (size_t) s1);
+
+    ret = (int) self->pair_map[row * self->num_unique_nodes_in_pair + col];
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_ibd_finder_calculate_ibd(tsk_ibd_finder_t *self, tsk_id_t current_parent)
+{
+    int ret = 0;
+    int j, pair_index;
+    tsk_segment_t *seg, *seg0, *seg1;
+    double left, right;
+
+    if (self->ancestor_map_head[current_parent] == NULL) {
+        for (j = 0; j != (int) self->segment_queue_size; j++) {
+            seg = &self->segment_queue[j];
+            ret = tsk_ibd_finder_add_ancestry(
+                self, current_parent, seg->left, seg->right, seg->node);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+    } else {
+        for (seg0 = self->ancestor_map_head[current_parent]; seg0 != NULL;
+             seg0 = seg0->next) {
+            for (j = 0; j != (int) self->segment_queue_size; j++) {
+                seg1 = &self->segment_queue[j];
+                if (seg0->node == seg1->node) {
+                    continue;
+                }
+                ret = tsk_ibd_finder_find_sample_pair_index2(
+                    self, seg0->node, seg1->node);
+                if (ret < 0) {
+                    continue;
+                }
+                pair_index = ret;
+
+                if (seg0->left > seg1->left) {
+                    left = seg0->left;
+                } else {
+                    left = seg1->left;
+                }
+                if (seg0->right < seg1->right) {
+                    right = seg0->right;
+                } else {
+                    right = seg1->right;
+                }
+
+                if (left < right) {
+                    if (right - left > self->min_length) {
+                        ret = tsk_ibd_finder_add_output(
+                            self, left, right, current_parent, pair_index);
+                        if (ret != 0) {
+                            goto out;
+                        }
+                    }
+                }
+            }
+        }
+        for (j = 0; j != (int) self->segment_queue_size; j++) {
+            seg = &self->segment_queue[j];
+            ret = tsk_ibd_finder_add_ancestry(
+                self, current_parent, seg->left, seg->right, seg->node);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+    }
+    self->segment_queue_size = 0;
+
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_ibd_finder_get_ibd_segments(
+    tsk_ibd_finder_t *self, tsk_id_t pair_index, tsk_segment_t **ret_ibd_segments_head)
+{
+    int ret = 0;
+
+    if (((pair_index < 0) || (pair_index >= (tsk_id_t) self->num_pairs))) {
+        ret = TSK_ERR_NO_SAMPLE_PAIRS;
+        goto out;
+    }
+    if (self->ibd_segments_head[pair_index] != NULL) {
+        *ret_ibd_segments_head = self->ibd_segments_head[pair_index];
+    } else {
+        ret = -1;
+    }
+out:
+    return ret;
+}
+
+void
+tsk_ibd_finder_print_state(tsk_ibd_finder_t *self, FILE *out)
+{
+    size_t j;
+    tsk_segment_t *u = NULL;
+
+    fprintf(out, "--ibd-finder stats--\n");
+    fprintf(out, "===\nEdge table\n==\n");
+    for (j = 0; j < self->tables->edges.num_rows; j++) {
+        fprintf(out, "L:%f, R:%f, P:%d, C:%d\n", self->tables->edges.left[j],
+            self->tables->edges.right[j], self->tables->edges.parent[j],
+            self->tables->edges.child[j]);
+    }
+    fprintf(out, "===\nNode table\n==\n");
+    for (j = 0; j < self->tables->nodes.num_rows; j++) {
+        fprintf(out, "ID:%f, Time:%f, Flag:%d\n", (double) j,
+            self->tables->nodes.time[j], self->tables->nodes.flags[j]);
+    }
+    fprintf(out, "==\nSample pairs\n==\n");
+    for (j = 0; j < 2 * self->num_pairs; j++) {
+        fprintf(out, "%i ", (int) self->pairs[j]);
+        if (j % 2 != 0) {
+            fprintf(out, "\n");
+        }
+    }
+    fprintf(out, "===\nAncestral map\n==\n");
+    for (j = 0; j < self->tables->nodes.num_rows; j++) {
+        fprintf(out, "Node %d: ", (int) j);
+        for (u = self->ancestor_map_head[j]; u != NULL; u = u->next) {
+            fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+        }
+        fprintf(out, "\n");
+    }
+    fprintf(out, "===\nIBD segments\n===\n");
+    for (j = 0; j < self->num_pairs; j++) {
+        fprintf(out, "Pair (%i, %i)\n", (int) self->pairs[2 * j],
+            (int) self->pairs[2 * j + 1]);
+        for (u = self->ibd_segments_head[j]; u != NULL; u = u->next) {
+            fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+        }
+        fprintf(out, "\n");
+    }
+}
+
+int TSK_WARN_UNUSED
+tsk_ibd_finder_run(tsk_ibd_finder_t *self)
+{
+    const tsk_edge_table_t *input_edges = &self->tables->edges;
+    int ret = 0;
+    size_t j;
+    tsk_id_t u;
+    tsk_id_t current_parent = -1;
+    size_t num_edges = input_edges->num_rows;
+    tsk_segment_t *seg;
+    tsk_segment_t *s;
+    double intvl_l, intvl_r, current_time;
+    bool parent_should_be_added = true;
+
+    for (j = 0; j < num_edges; j++) {
+
+        if (current_parent >= 0 && current_parent != input_edges->parent[j]) {
+            parent_should_be_added = true;
+        }
+
+        // Stop if the processed node's time exceeds the max time.
+        current_parent = input_edges->parent[j];
+        current_time = self->tables->nodes.time[current_parent];
+        if (current_time > self->max_time) {
+            goto out;
+        }
+
+        // Extract segment.
+        seg = tsk_ibd_finder_alloc_segment(
+            self, input_edges->left[j], input_edges->right[j], input_edges->child[j]);
+        // Create a SegmentList holding all of the sample segments descending from
+        // seg.
+        u = seg->node;
+        if (self->is_sample[u]) {
+            ret = tsk_ibd_finder_enqueue_segment(self, seg->left, seg->right, seg->node);
+            if (ret != 0) {
+                goto out;
+            }
+        } else {
+            for (s = self->ancestor_map_head[u]; s != NULL; s = s->next) {
+                if (seg->left > s->left) {
+                    intvl_l = seg->left;
+                } else {
+                    intvl_l = s->left;
+                }
+                if (seg->right < s->right) {
+                    intvl_r = seg->right;
+                } else {
+                    intvl_r = s->right;
+                }
+                // Add to the segment queue.
+                if (intvl_r - intvl_l > 0) {
+                    ret = tsk_ibd_finder_enqueue_segment(
+                        self, intvl_l, intvl_r, s->node);
+                    if (ret != 0) {
+                        goto out;
+                    }
+                }
+            }
+        }
+
+        // Calculate new ibd segments descending from the current parent.
+        if (self->segment_queue_size > 0) {
+            ret = tsk_ibd_finder_calculate_ibd(self, current_parent);
+        }
+        if (ret != 0) {
+            goto out;
+        }
+
+        // For samples that appear in the parent column of the edge table
+        if (self->is_sample[current_parent] && parent_should_be_added) {
+            parent_should_be_added = false;
+        }
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_ibd_finder_free(tsk_ibd_finder_t *self)
+{
+    tsk_safe_free(self->ibd_segments_head);
+    tsk_safe_free(self->ibd_segments_tail);
+    tsk_blkalloc_free(&self->segment_heap);
+    tsk_safe_free(self->is_sample);
+    tsk_safe_free(self->paired_nodes_index);
+    tsk_safe_free(self->ancestor_map_head);
+    tsk_safe_free(self->ancestor_map_tail);
+    tsk_safe_free(self->segment_queue);
+    tsk_safe_free(self->pair_map);
+    return 0;
+}
+
+/*************************
+ * simplifier
+ *************************/
+
+static void
+simplifier_check_state(simplifier_t *self)
+{
+    size_t j, k;
+    tsk_segment_t *u;
+    mutation_id_list_t *list_node;
+    tsk_id_t site;
+    interval_list_t *int_list;
+    tsk_id_t child;
+    double position, last_position;
+    bool found;
+    size_t num_intervals;
+
+    for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
+        tsk_bug_assert((self->ancestor_map_head[j] == NULL)
+                       == (self->ancestor_map_tail[j] == NULL));
+        for (u = self->ancestor_map_head[j]; u != NULL; u = u->next) {
+            tsk_bug_assert(u->left < u->right);
+            if (u->next != NULL) {
+                tsk_bug_assert(u->right <= u->next->left);
+                if (u->right == u->next->left) {
+                    tsk_bug_assert(u->node != u->next->node);
+                }
+            } else {
+                tsk_bug_assert(u == self->ancestor_map_tail[j]);
+            }
+        }
+    }
+
+    for (j = 0; j < self->segment_queue_size; j++) {
+        tsk_bug_assert(self->segment_queue[j].left < self->segment_queue[j].right);
+    }
+
+    for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
+        last_position = -1;
+        for (list_node = self->node_mutation_list_map_head[j]; list_node != NULL;
+             list_node = list_node->next) {
+            tsk_bug_assert(
+                self->input_tables.mutations.node[list_node->mutation] == (tsk_id_t) j);
+            site = self->input_tables.mutations.site[list_node->mutation];
+            position = self->input_tables.sites.position[site];
+            tsk_bug_assert(last_position <= position);
+            last_position = position;
+        }
+    }
+
+    /* check the buffered edges */
+    for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
+        tsk_bug_assert((self->child_edge_map_head[j] == NULL)
+                       == (self->child_edge_map_tail[j] == NULL));
+        if (self->child_edge_map_head[j] != NULL) {
+            /* Make sure that the child is in our list */
+            found = false;
+            for (k = 0; k < self->num_buffered_children; k++) {
+                if (self->buffered_children[k] == (tsk_id_t) j) {
+                    found = true;
+                    break;
+                }
+            }
+            tsk_bug_assert(found);
+        }
+    }
+    num_intervals = 0;
+    for (j = 0; j < self->num_buffered_children; j++) {
+        child = self->buffered_children[j];
+        tsk_bug_assert(self->child_edge_map_head[child] != NULL);
+        for (int_list = self->child_edge_map_head[child]; int_list != NULL;
+             int_list = int_list->next) {
+            tsk_bug_assert(int_list->left < int_list->right);
+            if (int_list->next != NULL) {
+                tsk_bug_assert(int_list->right < int_list->next->left);
+            }
+            num_intervals++;
+        }
+    }
+    tsk_bug_assert(
+        num_intervals
+        == self->interval_list_heap.total_allocated / (sizeof(interval_list_t)));
+}
+
+static void
+print_segment_chain(tsk_segment_t *head, FILE *out)
+{
+    tsk_segment_t *u;
+
+    for (u = head; u != NULL; u = u->next) {
+        fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+    }
+}
+
+static void
+simplifier_print_state(simplifier_t *self, FILE *out)
+{
+    size_t j;
+    tsk_segment_t *u;
+    mutation_id_list_t *list_node;
+    interval_list_t *int_list;
+    tsk_id_t child;
+
+    fprintf(out, "--simplifier state--\n");
+    fprintf(out, "options:\n");
+    fprintf(out, "\tfilter_unreferenced_sites   : %d\n",
+        !!(self->options & TSK_FILTER_SITES));
+    fprintf(out, "\treduce_to_site_topology : %d\n",
+        !!(self->options & TSK_REDUCE_TO_SITE_TOPOLOGY));
+    fprintf(out, "\tkeep_unary              : %d\n", !!(self->options & TSK_KEEP_UNARY));
+    fprintf(out, "\tkeep_input_roots        : %d\n",
+        !!(self->options & TSK_KEEP_INPUT_ROOTS));
+
+    fprintf(out, "===\nInput tables\n==\n");
+    tsk_table_collection_print_state(&self->input_tables, out);
+    fprintf(out, "===\nOutput tables\n==\n");
+    tsk_table_collection_print_state(self->tables, out);
+    fprintf(out, "===\nmemory heaps\n==\n");
+    fprintf(out, "segment_heap:\n");
+    tsk_blkalloc_print_state(&self->segment_heap, out);
+    fprintf(out, "interval_list_heap:\n");
+    tsk_blkalloc_print_state(&self->interval_list_heap, out);
+    fprintf(out, "===\nancestors\n==\n");
+    for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
+        fprintf(out, "%d:\t", (int) j);
+        print_segment_chain(self->ancestor_map_head[j], out);
+        fprintf(out, "\n");
+    }
+    fprintf(out, "===\nnode_id map (input->output)\n==\n");
+    for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
+        if (self->node_id_map[j] != TSK_NULL) {
+            fprintf(out, "%d->%d\n", (int) j, self->node_id_map[j]);
+        }
+    }
+    fprintf(out, "===\nsegment queue\n==\n");
+    for (j = 0; j < self->segment_queue_size; j++) {
+        u = &self->segment_queue[j];
+        fprintf(out, "(%f,%f->%d)", u->left, u->right, u->node);
+        fprintf(out, "\n");
+    }
+    fprintf(out, "===\nbuffered children\n==\n");
+    for (j = 0; j < self->num_buffered_children; j++) {
+        child = self->buffered_children[j];
+        fprintf(out, "%d -> ", (int) j);
+        for (int_list = self->child_edge_map_head[child]; int_list != NULL;
+             int_list = int_list->next) {
+            fprintf(out, "(%f, %f), ", int_list->left, int_list->right);
+        }
+        fprintf(out, "\n");
+    }
+    fprintf(out, "===\nmutation node map\n==\n");
+    for (j = 0; j < self->input_tables.mutations.num_rows; j++) {
+        fprintf(out, "%d\t-> %d\n", (int) j, self->mutation_node_map[j]);
+    }
+    fprintf(out, "===\nnode mutation id list map\n==\n");
+    for (j = 0; j < self->input_tables.nodes.num_rows; j++) {
+        if (self->node_mutation_list_map_head[j] != NULL) {
+            fprintf(out, "%d\t-> [", (int) j);
+            for (list_node = self->node_mutation_list_map_head[j]; list_node != NULL;
+                 list_node = list_node->next) {
+                fprintf(out, "%d,", list_node->mutation);
+            }
+            fprintf(out, "]\n");
+        }
+    }
+    if (!!(self->options & TSK_REDUCE_TO_SITE_TOPOLOGY)) {
+        fprintf(out, "===\nposition_lookup\n==\n");
+        for (j = 0; j < self->input_tables.sites.num_rows + 2; j++) {
+            fprintf(out, "%d\t-> %f\n", (int) j, self->position_lookup[j]);
+        }
+    }
+    simplifier_check_state(self);
+}
+
+static tsk_segment_t *TSK_WARN_UNUSED
+simplifier_alloc_segment(simplifier_t *self, double left, double right, tsk_id_t node)
+{
+    tsk_segment_t *seg = NULL;
+
+    seg = tsk_blkalloc_get(&self->segment_heap, sizeof(*seg));
+    if (seg == NULL) {
+        goto out;
+    }
+    seg->next = NULL;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+out:
+    return seg;
+}
+
+static interval_list_t *TSK_WARN_UNUSED
+simplifier_alloc_interval_list(simplifier_t *self, double left, double right)
+{
+    interval_list_t *x = NULL;
+
+    x = tsk_blkalloc_get(&self->interval_list_heap, sizeof(*x));
+    if (x == NULL) {
+        goto out;
+    }
+    x->next = NULL;
+    x->left = left;
+    x->right = right;
+out:
+    return x;
+}
+
+/* Add a new node to the output node table corresponding to the specified input id.
+ * Returns the new ID. */
+static int TSK_WARN_UNUSED
+simplifier_record_node(simplifier_t *self, tsk_id_t input_id, bool is_sample)
+{
+    int ret = 0;
+    tsk_node_t node;
+    tsk_flags_t flags;
+
+    tsk_node_table_get_row_unsafe(&self->input_tables.nodes, (tsk_id_t) input_id, &node);
+    /* Zero out the sample bit */
+    flags = node.flags & (tsk_flags_t) ~TSK_NODE_IS_SAMPLE;
+    if (is_sample) {
+        flags |= TSK_NODE_IS_SAMPLE;
+    }
+    self->node_id_map[input_id] = (tsk_id_t) self->tables->nodes.num_rows;
+    ret = tsk_node_table_add_row(&self->tables->nodes, flags, node.time, node.population,
+        node.individual, node.metadata, node.metadata_length);
+    return ret;
+}
+
+/* Remove the mapping for the last recorded node. */
+static int
+simplifier_rewind_node(simplifier_t *self, tsk_id_t input_id, tsk_id_t output_id)
+{
+    self->node_id_map[input_id] = TSK_NULL;
+    return tsk_node_table_truncate(&self->tables->nodes, (tsk_size_t) output_id);
+}
+
+static int
+simplifier_flush_edges(simplifier_t *self, tsk_id_t parent, size_t *ret_num_edges)
+{
+    int ret = 0;
+    size_t j;
+    tsk_id_t child;
+    interval_list_t *x;
+    size_t num_edges = 0;
+
+    qsort(self->buffered_children, self->num_buffered_children, sizeof(tsk_id_t),
+        cmp_node_id);
+    for (j = 0; j < self->num_buffered_children; j++) {
+        child = self->buffered_children[j];
+        for (x = self->child_edge_map_head[child]; x != NULL; x = x->next) {
+            ret = tsk_edge_table_add_row(
+                &self->tables->edges, x->left, x->right, parent, child, NULL, 0);
+            if (ret < 0) {
+                goto out;
+            }
+            num_edges++;
+        }
+        self->child_edge_map_head[child] = NULL;
+        self->child_edge_map_tail[child] = NULL;
+    }
+    self->num_buffered_children = 0;
+    *ret_num_edges = num_edges;
+    ret = tsk_blkalloc_reset(&self->interval_list_heap);
+out:
+    return ret;
+}
+
+/* When we are reducing topology down to what is visible at the sites we need a
+ * lookup table to find the closest site position for each edge. We do this with
+ * a sorted array and binary search */
+static int
+simplifier_init_position_lookup(simplifier_t *self)
+{
+    int ret = 0;
+    size_t num_sites = self->input_tables.sites.num_rows;
+
+    self->position_lookup = malloc((num_sites + 2) * sizeof(*self->position_lookup));
+    if (self->position_lookup == NULL) {
+        goto out;
+    }
+    self->position_lookup[0] = 0;
+    self->position_lookup[num_sites + 1] = self->tables->sequence_length;
+    memcpy(self->position_lookup + 1, self->input_tables.sites.position,
+        num_sites * sizeof(double));
+out:
+    return ret;
+}
+/*
+ * Find the smallest site position index greater than or equal to left
+ * and right, i.e., slide each endpoint of an interval to the right
+ * until they hit a site position. If both left and right map to the
+ * the same position then we discard this edge. We also discard an
+ * edge if left = 0 and right is less than the first site position.
+ */
+static bool
+simplifier_map_reduced_coordinates(simplifier_t *self, double *left, double *right)
+{
+    double *X = self->position_lookup;
+    size_t N = self->input_tables.sites.num_rows + 2;
+    size_t left_index, right_index;
+    bool skip = false;
+
+    left_index = tsk_search_sorted(X, N, *left);
+    right_index = tsk_search_sorted(X, N, *right);
+    if (left_index == right_index || (left_index == 0 && right_index == 1)) {
+        skip = true;
+    } else {
+        /* Remap back to zero if the left end maps to the first site. */
+        if (left_index == 1) {
+            left_index = 0;
+        }
+        *left = X[left_index];
+        *right = X[right_index];
+    }
+    return skip;
+}
+
+/* Records the specified edge for the current parent by buffering it */
+static int
+simplifier_record_edge(simplifier_t *self, double left, double right, tsk_id_t child)
+{
+    int ret = 0;
+    interval_list_t *tail, *x;
+    bool skip;
+
+    if (!!(self->options & TSK_REDUCE_TO_SITE_TOPOLOGY)) {
+        skip = simplifier_map_reduced_coordinates(self, &left, &right);
+        /* NOTE: we exit early here when reduce_coordindates has told us to
+         * skip this edge, as it is not visible in the reduced tree sequence */
+        if (skip) {
+            goto out;
+        }
+    }
+
+    tail = self->child_edge_map_tail[child];
+    if (tail == NULL) {
+        tsk_bug_assert(self->num_buffered_children < self->input_tables.nodes.num_rows);
+        self->buffered_children[self->num_buffered_children] = child;
+        self->num_buffered_children++;
+        x = simplifier_alloc_interval_list(self, left, right);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->child_edge_map_head[child] = x;
+        self->child_edge_map_tail[child] = x;
+    } else {
+        if (tail->right == left) {
+            tail->right = right;
+        } else {
+            x = simplifier_alloc_interval_list(self, left, right);
+            if (x == NULL) {
+                ret = TSK_ERR_NO_MEMORY;
+                goto out;
+            }
+            tail->next = x;
+            self->child_edge_map_tail[child] = x;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+simplifier_init_sites(simplifier_t *self)
+{
+    int ret = 0;
+    tsk_id_t node;
+    mutation_id_list_t *list_node;
+    size_t j;
+
+    self->mutation_id_map
+        = calloc(self->input_tables.mutations.num_rows, sizeof(tsk_id_t));
+    self->mutation_node_map
+        = calloc(self->input_tables.mutations.num_rows, sizeof(tsk_id_t));
+    self->node_mutation_list_mem
+        = malloc(self->input_tables.mutations.num_rows * sizeof(mutation_id_list_t));
+    self->node_mutation_list_map_head
+        = calloc(self->input_tables.nodes.num_rows, sizeof(mutation_id_list_t *));
+    self->node_mutation_list_map_tail
+        = calloc(self->input_tables.nodes.num_rows, sizeof(mutation_id_list_t *));
+    if (self->mutation_id_map == NULL || self->mutation_node_map == NULL
+        || self->node_mutation_list_mem == NULL
+        || self->node_mutation_list_map_head == NULL
+        || self->node_mutation_list_map_tail == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(self->mutation_id_map, 0xff,
+        self->input_tables.mutations.num_rows * sizeof(tsk_id_t));
+    memset(self->mutation_node_map, 0xff,
+        self->input_tables.mutations.num_rows * sizeof(tsk_id_t));
+
+    for (j = 0; j < self->input_tables.mutations.num_rows; j++) {
+        node = self->input_tables.mutations.node[j];
+        list_node = self->node_mutation_list_mem + j;
+        list_node->mutation = (tsk_id_t) j;
+        list_node->next = NULL;
+        if (self->node_mutation_list_map_head[node] == NULL) {
+            self->node_mutation_list_map_head[node] = list_node;
+        } else {
+            self->node_mutation_list_map_tail[node]->next = list_node;
+        }
+        self->node_mutation_list_map_tail[node] = list_node;
+    }
+out:
+    return ret;
+}
+
+static void
+simplifier_map_mutations(
+    simplifier_t *self, tsk_id_t input_id, double left, double right, tsk_id_t output_id)
+{
+    mutation_id_list_t *m_node;
+    double position;
+    tsk_id_t site;
+
+    m_node = self->node_mutation_list_map_head[input_id];
+    while (m_node != NULL) {
+        site = self->input_tables.mutations.site[m_node->mutation];
+        position = self->input_tables.sites.position[site];
+        if (left <= position && position < right) {
+            self->mutation_node_map[m_node->mutation] = output_id;
+        }
+        m_node = m_node->next;
+    }
+}
+
+static int TSK_WARN_UNUSED
+simplifier_add_ancestry(
+    simplifier_t *self, tsk_id_t input_id, double left, double right, tsk_id_t output_id)
+{
+    int ret = 0;
+    tsk_segment_t *tail = self->ancestor_map_tail[input_id];
+    tsk_segment_t *x;
+
+    tsk_bug_assert(left < right);
+    if (tail == NULL) {
+        x = simplifier_alloc_segment(self, left, right, output_id);
+        if (x == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->ancestor_map_head[input_id] = x;
+        self->ancestor_map_tail[input_id] = x;
+    } else {
+        if (tail->right == left && tail->node == output_id) {
+            tail->right = right;
+        } else {
+            x = simplifier_alloc_segment(self, left, right, output_id);
+            if (x == NULL) {
+                ret = TSK_ERR_NO_MEMORY;
+                goto out;
+            }
+            tail->next = x;
+            self->ancestor_map_tail[input_id] = x;
+        }
+    }
+    simplifier_map_mutations(self, input_id, left, right, output_id);
+out:
+    return ret;
+}
+
+static int
+simplifier_init_samples(simplifier_t *self, const tsk_id_t *samples)
+{
+    int ret = 0;
+    size_t j;
+
+    /* Go through the samples to check for errors. */
+    for (j = 0; j < self->num_samples; j++) {
+        if (samples[j] < 0
+            || samples[j] > (tsk_id_t) self->input_tables.nodes.num_rows) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (self->is_sample[samples[j]]) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        self->is_sample[samples[j]] = true;
+        ret = simplifier_record_node(self, samples[j], true);
+        if (ret < 0) {
+            goto out;
+        }
+        ret = simplifier_add_ancestry(
+            self, samples[j], 0, self->tables->sequence_length, (tsk_id_t) ret);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+simplifier_init(simplifier_t *self, const tsk_id_t *samples, size_t num_samples,
+    tsk_table_collection_t *tables, tsk_flags_t options)
+{
+    int ret = 0;
+    size_t num_nodes_alloc;
+
+    memset(self, 0, sizeof(simplifier_t));
+    self->num_samples = num_samples;
+    self->options = options;
+    self->tables = tables;
+
+    /* TODO we can add a flag to skip these checks for when we know they are
+     * unnecessary */
+    /* TODO Current unit tests require TSK_CHECK_SITE_DUPLICATES but it's
+     * debateable whether we need it. If we remove, we definitely need explicit
+     * tests to ensure we're doing sensible things with duplicate sites.
+     * (Particularly, re TSK_REDUCE_TO_SITE_TOPOLOGY.) */
+    ret = tsk_table_collection_check_integrity(tables,
+        TSK_CHECK_EDGE_ORDERING | TSK_CHECK_SITE_ORDERING | TSK_CHECK_SITE_DUPLICATES);
+    if (ret != 0) {
+        goto out;
+    }
+
+    ret = tsk_table_collection_copy(self->tables, &self->input_tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+
+    /* Take a copy of the input samples */
+    self->samples = malloc(num_samples * sizeof(tsk_id_t));
+    if (self->samples == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(self->samples, samples, num_samples * sizeof(tsk_id_t));
+
+    /* Allocate the heaps used for small objects-> Assuming 8K is a good chunk size
+     */
+    ret = tsk_blkalloc_init(&self->segment_heap, 8192);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_blkalloc_init(&self->interval_list_heap, 8192);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = segment_overlapper_alloc(&self->segment_overlapper);
+    if (ret != 0) {
+        goto out;
+    }
+    /* Need to avoid malloc(0) so make sure we have at least 1. */
+    num_nodes_alloc = 1 + tables->nodes.num_rows;
+    /* Make the maps and set the intial state */
+    self->ancestor_map_head = calloc(num_nodes_alloc, sizeof(tsk_segment_t *));
+    self->ancestor_map_tail = calloc(num_nodes_alloc, sizeof(tsk_segment_t *));
+    self->child_edge_map_head = calloc(num_nodes_alloc, sizeof(interval_list_t *));
+    self->child_edge_map_tail = calloc(num_nodes_alloc, sizeof(interval_list_t *));
+    self->node_id_map = malloc(num_nodes_alloc * sizeof(tsk_id_t));
+    self->buffered_children = malloc(num_nodes_alloc * sizeof(tsk_id_t));
+    self->is_sample = calloc(num_nodes_alloc, sizeof(bool));
+    self->max_segment_queue_size = 64;
+    self->segment_queue = malloc(self->max_segment_queue_size * sizeof(tsk_segment_t));
+    if (self->ancestor_map_head == NULL || self->ancestor_map_tail == NULL
+        || self->child_edge_map_head == NULL || self->child_edge_map_tail == NULL
+        || self->node_id_map == NULL || self->is_sample == NULL
+        || self->segment_queue == NULL || self->buffered_children == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    ret = tsk_table_collection_clear(self->tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    memset(
+        self->node_id_map, 0xff, self->input_tables.nodes.num_rows * sizeof(tsk_id_t));
+    ret = simplifier_init_sites(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = simplifier_init_samples(self, samples);
+    if (ret != 0) {
+        goto out;
+    }
+    if (!!(self->options & TSK_REDUCE_TO_SITE_TOPOLOGY)) {
+        ret = simplifier_init_position_lookup(self);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    self->edge_sort_offset = TSK_NULL;
+out:
+    return ret;
+}
+
+static int
+simplifier_free(simplifier_t *self)
+{
+    tsk_table_collection_free(&self->input_tables);
+    tsk_blkalloc_free(&self->segment_heap);
+    tsk_blkalloc_free(&self->interval_list_heap);
+    segment_overlapper_free(&self->segment_overlapper);
+    tsk_safe_free(self->samples);
+    tsk_safe_free(self->ancestor_map_head);
+    tsk_safe_free(self->ancestor_map_tail);
+    tsk_safe_free(self->child_edge_map_head);
+    tsk_safe_free(self->child_edge_map_tail);
+    tsk_safe_free(self->node_id_map);
+    tsk_safe_free(self->segment_queue);
+    tsk_safe_free(self->is_sample);
+    tsk_safe_free(self->mutation_id_map);
+    tsk_safe_free(self->mutation_node_map);
+    tsk_safe_free(self->node_mutation_list_mem);
+    tsk_safe_free(self->node_mutation_list_map_head);
+    tsk_safe_free(self->node_mutation_list_map_tail);
+    tsk_safe_free(self->buffered_children);
+    tsk_safe_free(self->position_lookup);
+    return 0;
+}
+
+static int TSK_WARN_UNUSED
+simplifier_enqueue_segment(simplifier_t *self, double left, double right, tsk_id_t node)
+{
+    int ret = 0;
+    tsk_segment_t *seg;
+    void *p;
+
+    tsk_bug_assert(left < right);
+    /* Make sure we always have room for one more segment in the queue so we
+     * can put a tail sentinel on it */
+    if (self->segment_queue_size == self->max_segment_queue_size - 1) {
+        self->max_segment_queue_size *= 2;
+        p = realloc(self->segment_queue,
+            self->max_segment_queue_size * sizeof(*self->segment_queue));
+        if (p == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        self->segment_queue = p;
+    }
+    seg = self->segment_queue + self->segment_queue_size;
+    seg->left = left;
+    seg->right = right;
+    seg->node = node;
+    self->segment_queue_size++;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+simplifier_merge_ancestors(simplifier_t *self, tsk_id_t input_id)
+{
+    int ret = 0;
+    tsk_segment_t **X, *x;
+    size_t j, num_overlapping, num_flushed_edges;
+    double left, right, prev_right;
+    tsk_id_t ancestry_node;
+    tsk_id_t output_id = self->node_id_map[input_id];
+    bool is_sample = output_id != TSK_NULL;
+    bool keep_unary = !!(self->options & TSK_KEEP_UNARY);
+
+    if (is_sample) {
+        /* Free up the existing ancestry mapping. */
+        x = self->ancestor_map_tail[input_id];
+        tsk_bug_assert(x->left == 0 && x->right == self->tables->sequence_length);
+        self->ancestor_map_head[input_id] = NULL;
+        self->ancestor_map_tail[input_id] = NULL;
+    }
+
+    ret = segment_overlapper_start(
+        &self->segment_overlapper, self->segment_queue, self->segment_queue_size);
+    if (ret != 0) {
+        goto out;
+    }
+    prev_right = 0;
+    while ((ret = segment_overlapper_next(
+                &self->segment_overlapper, &left, &right, &X, &num_overlapping))
+           == 1) {
+        tsk_bug_assert(left < right);
+        tsk_bug_assert(num_overlapping > 0);
+        if (num_overlapping == 1) {
+            ancestry_node = X[0]->node;
+            if (is_sample) {
+                ret = simplifier_record_edge(self, left, right, ancestry_node);
+                if (ret != 0) {
+                    goto out;
+                }
+                ancestry_node = output_id;
+            } else if (keep_unary) {
+                if (output_id == TSK_NULL) {
+                    output_id = simplifier_record_node(self, input_id, false);
+                }
+                ret = simplifier_record_edge(self, left, right, ancestry_node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        } else {
+            if (output_id == TSK_NULL) {
+                ret = simplifier_record_node(self, input_id, false);
+                if (ret < 0) {
+                    goto out;
+                }
+                output_id = (tsk_id_t) ret;
+            }
+            ancestry_node = output_id;
+            for (j = 0; j < num_overlapping; j++) {
+                ret = simplifier_record_edge(self, left, right, X[j]->node);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        }
+        if (is_sample && left != prev_right) {
+            /* Fill in any gaps in ancestry for the sample */
+            ret = simplifier_add_ancestry(self, input_id, prev_right, left, output_id);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+        if (keep_unary) {
+            ancestry_node = output_id;
+        }
+        ret = simplifier_add_ancestry(self, input_id, left, right, ancestry_node);
+        if (ret != 0) {
+            goto out;
+        }
+        prev_right = right;
+    }
+    /* Check for errors occuring in the loop condition */
+    if (ret != 0) {
+        goto out;
+    }
+    if (is_sample && prev_right != self->tables->sequence_length) {
+        /* If a trailing gap exists in the sample ancestry, fill it in. */
+        ret = simplifier_add_ancestry(
+            self, input_id, prev_right, self->tables->sequence_length, output_id);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (output_id != TSK_NULL) {
+        ret = simplifier_flush_edges(self, output_id, &num_flushed_edges);
+        if (ret != 0) {
+            goto out;
+        }
+        if (num_flushed_edges == 0 && !is_sample) {
+            ret = simplifier_rewind_node(self, input_id, output_id);
+        }
+    }
+out:
+    return ret;
+}
+
+/* Extract the ancestry for the specified input node over the specified
+ * interval and queue it up for merging.
+ */
+static int TSK_WARN_UNUSED
+simplifier_extract_ancestry(
+    simplifier_t *self, double left, double right, tsk_id_t input_id)
+{
+    int ret = 0;
+    tsk_segment_t *x = self->ancestor_map_head[input_id];
+    tsk_segment_t y; /* y is the segment that has been removed */
+    tsk_segment_t *x_head, *x_prev, *seg_left, *seg_right;
+
+    x_head = NULL;
+    x_prev = NULL;
+    while (x != NULL) {
+        if (x->right > left && right > x->left) {
+            y.left = TSK_MAX(x->left, left);
+            y.right = TSK_MIN(x->right, right);
+            y.node = x->node;
+            ret = simplifier_enqueue_segment(self, y.left, y.right, y.node);
+            if (ret != 0) {
+                goto out;
+            }
+            seg_left = NULL;
+            seg_right = NULL;
+            if (x->left != y.left) {
+                seg_left = simplifier_alloc_segment(self, x->left, y.left, x->node);
+                if (seg_left == NULL) {
+                    ret = TSK_ERR_NO_MEMORY;
+                    goto out;
+                }
+                if (x_prev == NULL) {
+                    x_head = seg_left;
+                } else {
+                    x_prev->next = seg_left;
+                }
+                x_prev = seg_left;
+            }
+            if (x->right != y.right) {
+                x->left = y.right;
+                seg_right = x;
+            } else {
+                seg_right = x->next;
+                // TODO free x
+            }
+            if (x_prev == NULL) {
+                x_head = seg_right;
+            } else {
+                x_prev->next = seg_right;
+            }
+            x = seg_right;
+        } else {
+            if (x_prev == NULL) {
+                x_head = x;
+            }
+            x_prev = x;
+            x = x->next;
+        }
+    }
+
+    self->ancestor_map_head[input_id] = x_head;
+    self->ancestor_map_tail[input_id] = x_prev;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+simplifier_process_parent_edges(
+    simplifier_t *self, tsk_id_t parent, size_t start, size_t end)
+{
+    int ret = 0;
+    size_t j;
+    const tsk_edge_table_t *input_edges = &self->input_tables.edges;
+    tsk_id_t child;
+    double left, right;
+
+    /* Go through the edges and queue up ancestry segments for processing. */
+    self->segment_queue_size = 0;
+    for (j = start; j < end; j++) {
+        tsk_bug_assert(parent == input_edges->parent[j]);
+        child = input_edges->child[j];
+        left = input_edges->left[j];
+        right = input_edges->right[j];
+        ret = simplifier_extract_ancestry(self, left, right, child);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    /* We can now merge the ancestral segments for the parent */
+    ret = simplifier_merge_ancestors(self, parent);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+simplifier_output_sites(simplifier_t *self)
+{
+    int ret = 0;
+    tsk_id_t input_site;
+    tsk_id_t input_mutation, mapped_parent, site_start, site_end;
+    tsk_id_t num_input_sites = (tsk_id_t) self->input_tables.sites.num_rows;
+    tsk_id_t num_input_mutations = (tsk_id_t) self->input_tables.mutations.num_rows;
+    tsk_id_t input_parent, num_output_mutations, num_output_site_mutations;
+    tsk_id_t mapped_node;
+    bool keep_site;
+    bool filter_sites = !!(self->options & TSK_FILTER_SITES);
+    tsk_site_t site;
+    tsk_mutation_t mutation;
+
+    input_mutation = 0;
+    num_output_mutations = 0;
+    for (input_site = 0; input_site < num_input_sites; input_site++) {
+        tsk_site_table_get_row_unsafe(
+            &self->input_tables.sites, (tsk_id_t) input_site, &site);
+        site_start = input_mutation;
+        num_output_site_mutations = 0;
+        while (input_mutation < num_input_mutations
+               && self->input_tables.mutations.site[input_mutation] == site.id) {
+            mapped_node = self->mutation_node_map[input_mutation];
+            if (mapped_node != TSK_NULL) {
+                input_parent = self->input_tables.mutations.parent[input_mutation];
+                mapped_parent = TSK_NULL;
+                if (input_parent != TSK_NULL) {
+                    mapped_parent = self->mutation_id_map[input_parent];
+                }
+                self->mutation_id_map[input_mutation] = num_output_mutations;
+                num_output_mutations++;
+                num_output_site_mutations++;
+            }
+            input_mutation++;
+        }
+        site_end = input_mutation;
+
+        keep_site = true;
+        if (filter_sites && num_output_site_mutations == 0) {
+            keep_site = false;
+        }
+        if (keep_site) {
+            for (input_mutation = site_start; input_mutation < site_end;
+                 input_mutation++) {
+                if (self->mutation_id_map[input_mutation] != TSK_NULL) {
+                    tsk_bug_assert(self->tables->mutations.num_rows
+                                   == (size_t) self->mutation_id_map[input_mutation]);
+                    mapped_node = self->mutation_node_map[input_mutation];
+                    tsk_bug_assert(mapped_node != TSK_NULL);
+                    mapped_parent = self->input_tables.mutations.parent[input_mutation];
+                    if (mapped_parent != TSK_NULL) {
+                        mapped_parent = self->mutation_id_map[mapped_parent];
+                    }
+                    tsk_mutation_table_get_row_unsafe(&self->input_tables.mutations,
+                        (tsk_id_t) input_mutation, &mutation);
+                    ret = tsk_mutation_table_add_row(&self->tables->mutations,
+                        (tsk_id_t) self->tables->sites.num_rows, mapped_node,
+                        mapped_parent, mutation.time, mutation.derived_state,
+                        mutation.derived_state_length, mutation.metadata,
+                        mutation.metadata_length);
+                    if (ret < 0) {
+                        goto out;
+                    }
+                }
+            }
+            ret = tsk_site_table_add_row(&self->tables->sites, site.position,
+                site.ancestral_state, site.ancestral_state_length, site.metadata,
+                site.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+        }
+        tsk_bug_assert(
+            num_output_mutations == (tsk_id_t) self->tables->mutations.num_rows);
+        input_mutation = site_end;
+    }
+    tsk_bug_assert(input_mutation == num_input_mutations);
+    ret = 0;
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+simplifier_finalise_references(simplifier_t *self)
+{
+    int ret = 0;
+    tsk_size_t j;
+    bool keep;
+    tsk_size_t num_nodes = self->tables->nodes.num_rows;
+
+    tsk_population_t pop;
+    tsk_id_t pop_id;
+    tsk_size_t num_populations = self->input_tables.populations.num_rows;
+    tsk_id_t *node_population = self->tables->nodes.population;
+    bool *population_referenced
+        = calloc(num_populations, sizeof(*population_referenced));
+    tsk_id_t *population_id_map = malloc(num_populations * sizeof(*population_id_map));
+    bool filter_populations = !!(self->options & TSK_FILTER_POPULATIONS);
+
+    tsk_individual_t ind;
+    tsk_id_t ind_id;
+    tsk_size_t num_individuals = self->input_tables.individuals.num_rows;
+    tsk_id_t *node_individual = self->tables->nodes.individual;
+    bool *individual_referenced
+        = calloc(num_individuals, sizeof(*individual_referenced));
+    tsk_id_t *individual_id_map = malloc(num_individuals * sizeof(*individual_id_map));
+    bool filter_individuals = !!(self->options & TSK_FILTER_INDIVIDUALS);
+
+    if (population_referenced == NULL || population_id_map == NULL
+        || individual_referenced == NULL || individual_id_map == NULL) {
+        goto out;
+    }
+
+    /* TODO Migrations fit reasonably neatly into the pattern that we have here. We
+     * can consider references to populations from migration objects in the same way
+     * as from nodes, so that we only remove a population if its referenced by
+     * neither. Mapping the population IDs in migrations is then easy. In principle
+     * nodes are similar, but the semantics are slightly different because we've
+     * already allocated all the nodes by their references from edges. We then
+     * need to decide whether we remove migrations that reference unmapped nodes
+     * or whether to add these nodes back in (probably the former is the correct
+     * approach).*/
+    if (self->input_tables.migrations.num_rows != 0) {
+        ret = TSK_ERR_SIMPLIFY_MIGRATIONS_NOT_SUPPORTED;
+        goto out;
+    }
+
+    for (j = 0; j < num_nodes; j++) {
+        pop_id = node_population[j];
+        if (pop_id != TSK_NULL) {
+            population_referenced[pop_id] = true;
+        }
+        ind_id = node_individual[j];
+        if (ind_id != TSK_NULL) {
+            individual_referenced[ind_id] = true;
+        }
+    }
+    for (j = 0; j < num_populations; j++) {
+        tsk_population_table_get_row_unsafe(
+            &self->input_tables.populations, (tsk_id_t) j, &pop);
+        keep = true;
+        if (filter_populations && !population_referenced[j]) {
+            keep = false;
+        }
+        population_id_map[j] = TSK_NULL;
+        if (keep) {
+            ret = tsk_population_table_add_row(
+                &self->tables->populations, pop.metadata, pop.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+            population_id_map[j] = (tsk_id_t) ret;
+        }
+    }
+
+    for (j = 0; j < num_individuals; j++) {
+        tsk_individual_table_get_row_unsafe(
+            &self->input_tables.individuals, (tsk_id_t) j, &ind);
+        keep = true;
+        if (filter_individuals && !individual_referenced[j]) {
+            keep = false;
+        }
+        individual_id_map[j] = TSK_NULL;
+        if (keep) {
+            ret = tsk_individual_table_add_row(&self->tables->individuals, ind.flags,
+                ind.location, ind.location_length, ind.metadata, ind.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+            individual_id_map[j] = (tsk_id_t) ret;
+        }
+    }
+
+    /* Remap node IDs referencing the above */
+    for (j = 0; j < num_nodes; j++) {
+        pop_id = node_population[j];
+        if (pop_id != TSK_NULL) {
+            node_population[j] = population_id_map[pop_id];
+        }
+        ind_id = node_individual[j];
+        if (ind_id != TSK_NULL) {
+            node_individual[j] = individual_id_map[ind_id];
+        }
+    }
+
+    ret = 0;
+out:
+    tsk_safe_free(population_referenced);
+    tsk_safe_free(individual_referenced);
+    tsk_safe_free(population_id_map);
+    tsk_safe_free(individual_id_map);
+    return ret;
+}
+
+static void
+simplifier_set_edge_sort_offset(simplifier_t *self, double youngest_root_time)
+{
+    const tsk_edge_table_t edges = self->tables->edges;
+    const double *node_time = self->tables->nodes.time;
+    tsk_size_t offset;
+
+    for (offset = 0; offset < edges.num_rows; offset++) {
+        if (node_time[edges.parent[offset]] >= youngest_root_time) {
+            break;
+        }
+    }
+    self->edge_sort_offset = offset;
+}
+
+static int TSK_WARN_UNUSED
+simplifier_sort_edges(simplifier_t *self)
+{
+    /* designated initialisers are guaranteed to set any missing fields to
+     * zero, so we don't need to set the rest of them. */
+    tsk_bookmark_t bookmark = {
+        .edges = (tsk_size_t) self->edge_sort_offset,
+        .sites = self->tables->sites.num_rows,
+        .mutations = self->tables->mutations.num_rows,
+    };
+    tsk_bug_assert(self->edge_sort_offset >= 0);
+    return tsk_table_collection_sort(self->tables, &bookmark, 0);
+}
+
+static int TSK_WARN_UNUSED
+simplifier_insert_input_roots(simplifier_t *self)
+{
+    int ret = 0;
+    tsk_id_t input_id, output_id;
+    tsk_segment_t *x;
+    size_t num_flushed_edges;
+    double youngest_root_time = DBL_MAX;
+    const double *node_time = self->tables->nodes.time;
+
+    for (input_id = 0; input_id < (tsk_id_t) self->input_tables.nodes.num_rows;
+         input_id++) {
+        x = self->ancestor_map_head[input_id];
+        if (x != NULL) {
+            output_id = self->node_id_map[input_id];
+            if (output_id == TSK_NULL) {
+                ret = simplifier_record_node(self, input_id, false);
+                if (ret < 0) {
+                    goto out;
+                }
+                output_id = ret;
+            }
+            youngest_root_time = TSK_MIN(youngest_root_time, node_time[output_id]);
+            while (x != NULL) {
+                if (x->node != output_id) {
+                    ret = simplifier_record_edge(self, x->left, x->right, x->node);
+                    if (ret != 0) {
+                        goto out;
+                    }
+                    simplifier_map_mutations(
+                        self, input_id, x->left, x->right, output_id);
+                }
+                x = x->next;
+            }
+            ret = simplifier_flush_edges(self, output_id, &num_flushed_edges);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+    }
+    if (youngest_root_time != DBL_MAX) {
+        simplifier_set_edge_sort_offset(self, youngest_root_time);
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+simplifier_run(simplifier_t *self, tsk_id_t *node_map)
+{
+    int ret = 0;
+    size_t j, start;
+    tsk_id_t parent, current_parent;
+    const tsk_edge_table_t *input_edges = &self->input_tables.edges;
+    size_t num_edges = input_edges->num_rows;
+
+    if (num_edges > 0) {
+        start = 0;
+        current_parent = input_edges->parent[0];
+        for (j = 0; j < num_edges; j++) {
+            parent = input_edges->parent[j];
+            if (parent != current_parent) {
+                ret = simplifier_process_parent_edges(self, current_parent, start, j);
+                if (ret != 0) {
+                    goto out;
+                }
+                current_parent = parent;
+                start = j;
+            }
+        }
+        ret = simplifier_process_parent_edges(self, current_parent, start, num_edges);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (self->options & TSK_KEEP_INPUT_ROOTS) {
+        ret = simplifier_insert_input_roots(self);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = simplifier_output_sites(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = simplifier_finalise_references(self);
+    if (ret != 0) {
+        goto out;
+    }
+    if (node_map != NULL) {
+        /* Finally, output the new IDs for the nodes, if required. */
+        memcpy(node_map, self->node_id_map,
+            self->input_tables.nodes.num_rows * sizeof(tsk_id_t));
+    }
+    if (self->edge_sort_offset != TSK_NULL) {
+        tsk_bug_assert(self->options & TSK_KEEP_INPUT_ROOTS);
+        ret = simplifier_sort_edges(self);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+/*************************
+ * table_collection
+ *************************/
+
+typedef struct {
+    tsk_id_t index;
+    /* These are the sort keys in order */
+    double first;
+    double second;
+    tsk_id_t third;
+    tsk_id_t fourth;
+} index_sort_t;
+
+static int
+cmp_index_sort(const void *a, const void *b)
+{
+    const index_sort_t *ca = (const index_sort_t *) a;
+    const index_sort_t *cb = (const index_sort_t *) b;
+    int ret = (ca->first > cb->first) - (ca->first < cb->first);
+    if (ret == 0) {
+        ret = (ca->second > cb->second) - (ca->second < cb->second);
+        if (ret == 0) {
+            ret = (ca->third > cb->third) - (ca->third < cb->third);
+            if (ret == 0) {
+                ret = (ca->fourth > cb->fourth) - (ca->fourth < cb->fourth);
+            }
+        }
+    }
+    return ret;
+}
+
+static int
+tsk_table_collection_check_offsets(const tsk_table_collection_t *self)
+{
+    int ret = 0;
+
+    ret = check_offsets(self->nodes.num_rows, self->nodes.metadata_offset,
+        self->nodes.metadata_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = check_offsets(self->sites.num_rows, self->sites.ancestral_state_offset,
+        self->sites.ancestral_state_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = check_offsets(self->sites.num_rows, self->sites.metadata_offset,
+        self->sites.metadata_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = check_offsets(self->mutations.num_rows, self->mutations.derived_state_offset,
+        self->mutations.derived_state_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = check_offsets(self->mutations.num_rows, self->mutations.metadata_offset,
+        self->mutations.metadata_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = check_offsets(self->individuals.num_rows, self->individuals.metadata_offset,
+        self->individuals.metadata_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = check_offsets(self->provenances.num_rows, self->provenances.timestamp_offset,
+        self->provenances.timestamp_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = check_offsets(self->provenances.num_rows, self->provenances.record_offset,
+        self->provenances.record_length, true);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+tsk_table_collection_check_node_integrity(
+    const tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_size_t j;
+    double node_time;
+    tsk_id_t population, individual;
+    tsk_id_t num_populations = (tsk_id_t) self->populations.num_rows;
+    tsk_id_t num_individuals = (tsk_id_t) self->individuals.num_rows;
+    const bool check_population_refs = !(options & TSK_NO_CHECK_POPULATION_REFS);
+
+    for (j = 0; j < self->nodes.num_rows; j++) {
+        node_time = self->nodes.time[j];
+        if (!isfinite(node_time)) {
+            ret = TSK_ERR_TIME_NONFINITE;
+            goto out;
+        }
+        if (check_population_refs) {
+            population = self->nodes.population[j];
+            if (population < TSK_NULL || population >= num_populations) {
+                ret = TSK_ERR_POPULATION_OUT_OF_BOUNDS;
+                goto out;
+            }
+        }
+        individual = self->nodes.individual[j];
+        if (individual < TSK_NULL || individual >= num_individuals) {
+            ret = TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_table_collection_check_edge_integrity(
+    const tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_size_t j;
+    tsk_id_t parent, last_parent, child, last_child;
+    double left, last_left, right;
+    const double *time = self->nodes.time;
+    const double L = self->sequence_length;
+    const tsk_edge_table_t edges = self->edges;
+    const tsk_id_t num_nodes = (tsk_id_t) self->nodes.num_rows;
+    const bool check_ordering = !!(options & TSK_CHECK_EDGE_ORDERING);
+    bool *parent_seen = NULL;
+
+    if (check_ordering) {
+        parent_seen = calloc((size_t) num_nodes, sizeof(*parent_seen));
+        if (parent_seen == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+    }
+
+    /* Just keeping compiler happy; these values don't matter. */
+    last_left = 0;
+    last_parent = 0;
+    last_child = 0;
+    for (j = 0; j < edges.num_rows; j++) {
+        parent = edges.parent[j];
+        child = edges.child[j];
+        left = edges.left[j];
+        right = edges.right[j];
+        /* Node ID integrity */
+        if (parent == TSK_NULL) {
+            ret = TSK_ERR_NULL_PARENT;
+            goto out;
+        }
+        if (parent < 0 || parent >= num_nodes) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (child == TSK_NULL) {
+            ret = TSK_ERR_NULL_CHILD;
+            goto out;
+        }
+        if (child < 0 || child >= num_nodes) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        /* Spatial requirements for edges */
+        if (!(isfinite(left) && isfinite(right))) {
+            ret = TSK_ERR_GENOME_COORDS_NONFINITE;
+            goto out;
+        }
+        if (left < 0) {
+            ret = TSK_ERR_LEFT_LESS_ZERO;
+            goto out;
+        }
+        if (right > L) {
+            ret = TSK_ERR_RIGHT_GREATER_SEQ_LENGTH;
+            goto out;
+        }
+        if (left >= right) {
+            ret = TSK_ERR_BAD_EDGE_INTERVAL;
+            goto out;
+        }
+        /* time[child] must be < time[parent] */
+        if (time[child] >= time[parent]) {
+            ret = TSK_ERR_BAD_NODE_TIME_ORDERING;
+            goto out;
+        }
+
+        if (check_ordering) {
+            if (parent_seen[parent]) {
+                ret = TSK_ERR_EDGES_NONCONTIGUOUS_PARENTS;
+                goto out;
+            }
+            if (j > 0) {
+                /* Input data must sorted by (time[parent], parent, child, left). */
+                if (time[parent] < time[last_parent]) {
+                    ret = TSK_ERR_EDGES_NOT_SORTED_PARENT_TIME;
+                    goto out;
+                }
+                if (time[parent] == time[last_parent]) {
+                    if (parent == last_parent) {
+                        if (child < last_child) {
+                            ret = TSK_ERR_EDGES_NOT_SORTED_CHILD;
+                            goto out;
+                        }
+                        if (child == last_child) {
+                            if (left == last_left) {
+                                ret = TSK_ERR_DUPLICATE_EDGES;
+                                goto out;
+                            } else if (left < last_left) {
+                                ret = TSK_ERR_EDGES_NOT_SORTED_LEFT;
+                                goto out;
+                            }
+                        }
+                    } else {
+                        parent_seen[last_parent] = true;
+                    }
+                }
+            }
+            last_parent = parent;
+            last_child = child;
+            last_left = left;
+        }
+    }
+out:
+    tsk_safe_free(parent_seen);
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_check_site_integrity(
+    const tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_size_t j;
+    double position;
+    const double L = self->sequence_length;
+    const tsk_site_table_t sites = self->sites;
+    const bool check_site_ordering = !!(options & TSK_CHECK_SITE_ORDERING);
+    const bool check_site_duplicates = !!(options & TSK_CHECK_SITE_DUPLICATES);
+
+    for (j = 0; j < sites.num_rows; j++) {
+        position = sites.position[j];
+        /* Spatial requirements */
+        if (!isfinite(position)) {
+            ret = TSK_ERR_BAD_SITE_POSITION;
+            goto out;
+        }
+        if (position < 0 || position >= L) {
+            ret = TSK_ERR_BAD_SITE_POSITION;
+            goto out;
+        }
+        if (j > 0) {
+            if (check_site_duplicates && sites.position[j - 1] == position) {
+                ret = TSK_ERR_DUPLICATE_SITE_POSITION;
+                goto out;
+            }
+            if (check_site_ordering && sites.position[j - 1] > position) {
+                ret = TSK_ERR_UNSORTED_SITES;
+                goto out;
+            }
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_check_mutation_integrity(
+    const tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_size_t j;
+    tsk_id_t parent_mut;
+    double mutation_time;
+    double last_known_time = INFINITY;
+    const tsk_mutation_table_t mutations = self->mutations;
+    const tsk_id_t num_nodes = (tsk_id_t) self->nodes.num_rows;
+    const tsk_id_t num_sites = (tsk_id_t) self->sites.num_rows;
+    const tsk_id_t num_mutations = (tsk_id_t) self->mutations.num_rows;
+    const double *node_time = self->nodes.time;
+    const bool check_mutation_ordering = !!(options & TSK_CHECK_MUTATION_ORDERING);
+    bool unknown_time;
+    bool unknown_times_seen = false;
+
+    for (j = 0; j < mutations.num_rows; j++) {
+        /* Basic reference integrity */
+        if (mutations.site[j] < 0 || mutations.site[j] >= num_sites) {
+            ret = TSK_ERR_SITE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (mutations.node[j] < 0 || mutations.node[j] >= num_nodes) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        /* Integrity check for mutation parent */
+        parent_mut = mutations.parent[j];
+        if (parent_mut < TSK_NULL || parent_mut >= num_mutations) {
+            ret = TSK_ERR_MUTATION_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (parent_mut == (tsk_id_t) j) {
+            ret = TSK_ERR_MUTATION_PARENT_EQUAL;
+            goto out;
+        }
+        /* Check if time is nonfinite */
+        mutation_time = mutations.time[j];
+        unknown_time = tsk_is_unknown_time(mutation_time);
+        if (!unknown_time) {
+            if (!isfinite(mutation_time)) {
+                ret = TSK_ERR_TIME_NONFINITE;
+                goto out;
+            }
+        }
+
+        if (check_mutation_ordering) {
+            /* Check site ordering and reset time check if needed*/
+            if (j > 0) {
+                if (mutations.site[j - 1] > mutations.site[j]) {
+                    ret = TSK_ERR_UNSORTED_MUTATIONS;
+                    goto out;
+                }
+                if (mutations.site[j - 1] != mutations.site[j]) {
+                    last_known_time = INFINITY;
+                    unknown_times_seen = false;
+                }
+            }
+
+            /* Check known/unknown times are not both present on a site*/
+            if (unknown_time) {
+                unknown_times_seen = true;
+            } else if (unknown_times_seen) {
+                ret = TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN;
+                goto out;
+            }
+
+            /* Check the mutation parents for ordering */
+            /* We can only check parent properties if it is non-null */
+            if (parent_mut != TSK_NULL) {
+                /* Parents must be listed before their children */
+                if (parent_mut > (tsk_id_t) j) {
+                    ret = TSK_ERR_MUTATION_PARENT_AFTER_CHILD;
+                    goto out;
+                }
+                if (mutations.site[parent_mut] != mutations.site[j]) {
+                    ret = TSK_ERR_MUTATION_PARENT_DIFFERENT_SITE;
+                    goto out;
+                }
+            }
+
+            /* Check time value ordering */
+            if (!unknown_time) {
+                if (mutation_time < node_time[mutations.node[j]]) {
+                    ret = TSK_ERR_MUTATION_TIME_YOUNGER_THAN_NODE;
+                    goto out;
+                }
+                /* If this mutation time is known, then the parent time
+                 * must also be as the
+                 * TSK_ERR_MUTATION_TIME_HAS_BOTH_KNOWN_AND_UNKNOWN check
+                 * above would otherwise fail. */
+                if (parent_mut != TSK_NULL
+                    && mutation_time > mutations.time[parent_mut]) {
+                    ret = TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_MUTATION;
+                    goto out;
+                }
+                /* Check time ordering, we do this after the time checks above, so
+                that more specific errors trigger first */
+                if (mutation_time > last_known_time) {
+                    ret = TSK_ERR_UNSORTED_MUTATIONS;
+                    goto out;
+                }
+                last_known_time = mutation_time;
+            }
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_check_migration_integrity(
+    const tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_size_t j;
+    double left, right;
+    const double L = self->sequence_length;
+    const tsk_migration_table_t migrations = self->migrations;
+    const tsk_id_t num_nodes = (tsk_id_t) self->nodes.num_rows;
+    const tsk_id_t num_populations = (tsk_id_t) self->populations.num_rows;
+    const bool check_population_refs = !(options & TSK_NO_CHECK_POPULATION_REFS);
+
+    for (j = 0; j < migrations.num_rows; j++) {
+        if (migrations.node[j] < 0 || migrations.node[j] >= num_nodes) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (check_population_refs) {
+            if (migrations.source[j] < 0 || migrations.source[j] >= num_populations) {
+                ret = TSK_ERR_POPULATION_OUT_OF_BOUNDS;
+                goto out;
+            }
+            if (migrations.dest[j] < 0 || migrations.dest[j] >= num_populations) {
+                ret = TSK_ERR_POPULATION_OUT_OF_BOUNDS;
+                goto out;
+            }
+        }
+        if (!isfinite(migrations.time[j])) {
+            ret = TSK_ERR_TIME_NONFINITE;
+            goto out;
+        }
+        left = migrations.left[j];
+        right = migrations.right[j];
+        /* Spatial requirements */
+        /* TODO it's a bit misleading to use the edge-specific errors here. */
+        if (!(isfinite(left) && isfinite(right))) {
+            ret = TSK_ERR_GENOME_COORDS_NONFINITE;
+            goto out;
+        }
+        if (left < 0) {
+            ret = TSK_ERR_LEFT_LESS_ZERO;
+            goto out;
+        }
+        if (right > L) {
+            ret = TSK_ERR_RIGHT_GREATER_SEQ_LENGTH;
+            goto out;
+        }
+        if (left >= right) {
+            ret = TSK_ERR_BAD_EDGE_INTERVAL;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static tsk_id_t TSK_WARN_UNUSED
+tsk_table_collection_check_tree_integrity(const tsk_table_collection_t *self)
+{
+    tsk_id_t ret = 0;
+    size_t j, k;
+    tsk_id_t u, site, mutation;
+    double tree_left, tree_right;
+    const double sequence_length = self->sequence_length;
+    const tsk_id_t num_sites = (tsk_id_t) self->sites.num_rows;
+    const tsk_id_t num_mutations = (tsk_id_t) self->mutations.num_rows;
+    const size_t num_edges = self->edges.num_rows;
+    const double *restrict site_position = self->sites.position;
+    const tsk_id_t *restrict mutation_site = self->mutations.site;
+    const tsk_id_t *restrict mutation_node = self->mutations.node;
+    const double *restrict mutation_time = self->mutations.time;
+    const double *restrict node_time = self->nodes.time;
+    const tsk_id_t *restrict I = self->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->indexes.edge_removal_order;
+    const double *restrict edge_right = self->edges.right;
+    const double *restrict edge_left = self->edges.left;
+    const tsk_id_t *restrict edge_child = self->edges.child;
+    const tsk_id_t *restrict edge_parent = self->edges.parent;
+    tsk_id_t *restrict parent = NULL;
+    tsk_id_t num_trees = 0;
+
+    parent = malloc(self->nodes.num_rows * sizeof(*parent));
+    if (parent == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, self->nodes.num_rows * sizeof(*parent));
+
+    tree_left = 0;
+    tree_right = sequence_length;
+    num_trees = 0;
+    j = 0;
+    k = 0;
+    site = 0;
+    mutation = 0;
+    tsk_bug_assert(I != NULL && O != NULL);
+
+    while (j < num_edges || tree_left < sequence_length) {
+        while (k < num_edges && edge_right[O[k]] == tree_left) {
+            parent[edge_child[O[k]]] = TSK_NULL;
+            k++;
+        }
+        while (j < num_edges && edge_left[I[j]] == tree_left) {
+            u = edge_child[I[j]];
+            if (parent[u] != TSK_NULL) {
+                ret = TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN;
+                goto out;
+            }
+            parent[u] = edge_parent[I[j]];
+            j++;
+        }
+        tree_right = sequence_length;
+        if (j < num_edges) {
+            tree_right = TSK_MIN(tree_right, edge_left[I[j]]);
+        }
+        if (k < num_edges) {
+            tree_right = TSK_MIN(tree_right, edge_right[O[k]]);
+        }
+        while (site < num_sites && site_position[site] < tree_right) {
+            while (mutation < num_mutations && mutation_site[mutation] == site) {
+                if (!tsk_is_unknown_time(mutation_time[mutation])
+                    && parent[mutation_node[mutation]] != TSK_NULL
+                    && node_time[parent[mutation_node[mutation]]]
+                           <= mutation_time[mutation]) {
+                    ret = TSK_ERR_MUTATION_TIME_OLDER_THAN_PARENT_NODE;
+                    goto out;
+                }
+                mutation++;
+            }
+            site++;
+        }
+        tree_left = tree_right;
+        /* This is technically possible; if we have 2**31 edges each defining
+         * a single tree, and there's a gap between each of these edges we
+         * would overflow this counter. */
+        if (num_trees == INT32_MAX) {
+            ret = TSK_ERR_TREE_OVERFLOW;
+            goto out;
+        }
+        num_trees++;
+    }
+    ret = num_trees;
+out:
+    /* Can't use tsk_safe_free because of restrict*/
+    if (parent != NULL) {
+        free(parent);
+    }
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_check_index_integrity(const tsk_table_collection_t *self)
+{
+    int ret = 0;
+    tsk_id_t j;
+    const tsk_id_t num_edges = (tsk_id_t) self->edges.num_rows;
+    const tsk_id_t *edge_insertion_order = self->indexes.edge_insertion_order;
+    const tsk_id_t *edge_removal_order = self->indexes.edge_removal_order;
+
+    if (!tsk_table_collection_has_index(self, 0)) {
+        ret = TSK_ERR_TABLES_NOT_INDEXED;
+        goto out;
+    }
+    for (j = 0; j < num_edges; j++) {
+        if (edge_insertion_order[j] < 0 || edge_insertion_order[j] >= num_edges) {
+            ret = TSK_ERR_EDGE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (edge_removal_order[j] < 0 || edge_removal_order[j] >= num_edges) {
+            ret = TSK_ERR_EDGE_OUT_OF_BOUNDS;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+tsk_id_t TSK_WARN_UNUSED
+tsk_table_collection_check_integrity(
+    const tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (options & TSK_CHECK_TREES) {
+        /* Checking the trees implies all the other checks */
+        options |= TSK_CHECK_EDGE_ORDERING | TSK_CHECK_SITE_ORDERING
+                   | TSK_CHECK_SITE_DUPLICATES | TSK_CHECK_MUTATION_ORDERING
+                   | TSK_CHECK_INDEXES;
+    }
+
+    if (self->sequence_length <= 0) {
+        ret = TSK_ERR_BAD_SEQUENCE_LENGTH;
+        goto out;
+    }
+    ret = tsk_table_collection_check_offsets(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_node_integrity(self, options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_edge_integrity(self, options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_site_integrity(self, options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_mutation_integrity(self, options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_migration_integrity(self, options);
+    if (ret != 0) {
+        goto out;
+    }
+    if (options & TSK_CHECK_INDEXES) {
+        ret = tsk_table_collection_check_index_integrity(self);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (options & TSK_CHECK_TREES) {
+        ret = tsk_table_collection_check_tree_integrity(self);
+        if (ret < 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+void
+tsk_table_collection_print_state(const tsk_table_collection_t *self, FILE *out)
+{
+    fprintf(out, "Table collection state\n");
+    fprintf(out, "sequence_length = %f\n", self->sequence_length);
+
+    write_metadata_schema_header(
+        out, self->metadata_schema, self->metadata_schema_length);
+    fprintf(out, "#metadata#\n");
+    fprintf(out, "%.*s\n", self->metadata_length, self->metadata);
+    fprintf(out, "#end#metadata\n");
+    tsk_individual_table_print_state(&self->individuals, out);
+    tsk_node_table_print_state(&self->nodes, out);
+    tsk_edge_table_print_state(&self->edges, out);
+    tsk_migration_table_print_state(&self->migrations, out);
+    tsk_site_table_print_state(&self->sites, out);
+    tsk_mutation_table_print_state(&self->mutations, out);
+    tsk_population_table_print_state(&self->populations, out);
+    tsk_provenance_table_print_state(&self->provenances, out);
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_init(tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_flags_t edge_options = 0;
+
+    memset(self, 0, sizeof(*self));
+    if (options & TSK_NO_EDGE_METADATA) {
+        edge_options |= TSK_NO_METADATA;
+    }
+    ret = tsk_node_table_init(&self->nodes, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_init(&self->edges, edge_options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_init(&self->migrations, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_init(&self->sites, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_init(&self->mutations, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_init(&self->individuals, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_init(&self->populations, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_init(&self->provenances, 0);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_table_collection_free(tsk_table_collection_t *self)
+{
+    tsk_individual_table_free(&self->individuals);
+    tsk_node_table_free(&self->nodes);
+    tsk_edge_table_free(&self->edges);
+    tsk_migration_table_free(&self->migrations);
+    tsk_site_table_free(&self->sites);
+    tsk_mutation_table_free(&self->mutations);
+    tsk_population_table_free(&self->populations);
+    tsk_provenance_table_free(&self->provenances);
+    tsk_safe_free(self->indexes.edge_insertion_order);
+    tsk_safe_free(self->indexes.edge_removal_order);
+    tsk_safe_free(self->file_uuid);
+    tsk_safe_free(self->metadata);
+    tsk_safe_free(self->metadata_schema);
+    return 0;
+}
+
+bool
+tsk_table_collection_equals(const tsk_table_collection_t *self,
+    const tsk_table_collection_t *other, tsk_flags_t options)
+{
+    bool ret
+        = self->sequence_length == other->sequence_length
+          && tsk_individual_table_equals(
+                 &self->individuals, &other->individuals, options)
+          && tsk_node_table_equals(&self->nodes, &other->nodes, options)
+          && tsk_edge_table_equals(&self->edges, &other->edges, options)
+          && tsk_migration_table_equals(&self->migrations, &other->migrations, options)
+          && tsk_site_table_equals(&self->sites, &other->sites, options)
+          && tsk_mutation_table_equals(&self->mutations, &other->mutations, options)
+          && tsk_population_table_equals(
+                 &self->populations, &other->populations, options);
+
+    /* TSK_CMP_IGNORE_TS_METADATA is implied by TSK_CMP_IGNORE_METADATA */
+    if (options & TSK_CMP_IGNORE_METADATA) {
+        options |= TSK_CMP_IGNORE_TS_METADATA;
+    }
+    if (!(options & TSK_CMP_IGNORE_TS_METADATA)) {
+        ret = ret
+              && (self->metadata_length == other->metadata_length
+                     && self->metadata_schema_length == other->metadata_schema_length
+                     && memcmp(self->metadata, other->metadata,
+                            self->metadata_length * sizeof(char))
+                            == 0
+                     && memcmp(self->metadata_schema, other->metadata_schema,
+                            self->metadata_schema_length * sizeof(char))
+                            == 0);
+    }
+    if (!(options & TSK_CMP_IGNORE_PROVENANCE)) {
+        ret = ret
+              && tsk_provenance_table_equals(
+                     &self->provenances, &other->provenances, options);
+    }
+    return ret;
+}
+
+int
+tsk_table_collection_set_metadata(
+    tsk_table_collection_t *self, const char *metadata, tsk_size_t metadata_length)
+{
+    return replace_string(
+        &self->metadata, &self->metadata_length, metadata, metadata_length);
+}
+
+int
+tsk_table_collection_set_metadata_schema(tsk_table_collection_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length)
+{
+    return replace_string(&self->metadata_schema, &self->metadata_schema_length,
+        metadata_schema, metadata_schema_length);
+}
+
+int
+tsk_table_collection_set_indexes(tsk_table_collection_t *self,
+    tsk_id_t *edge_insertion_order, tsk_id_t *edge_removal_order)
+{
+    int ret = 0;
+    size_t index_size = self->edges.num_rows * sizeof(tsk_id_t);
+
+    tsk_table_collection_drop_index(self, 0);
+    self->indexes.edge_insertion_order = malloc(index_size);
+    self->indexes.edge_removal_order = malloc(index_size);
+    if (self->indexes.edge_insertion_order == NULL
+        || self->indexes.edge_removal_order == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(self->indexes.edge_insertion_order, edge_insertion_order, index_size);
+    memcpy(self->indexes.edge_removal_order, edge_removal_order, index_size);
+    self->indexes.num_edges = self->edges.num_rows;
+out:
+    return ret;
+}
+
+bool
+tsk_table_collection_has_index(
+    const tsk_table_collection_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    return self->indexes.edge_insertion_order != NULL
+           && self->indexes.edge_removal_order != NULL
+           && self->indexes.num_edges == self->edges.num_rows;
+}
+
+int
+tsk_table_collection_drop_index(
+    tsk_table_collection_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    tsk_safe_free(self->indexes.edge_insertion_order);
+    tsk_safe_free(self->indexes.edge_removal_order);
+    self->indexes.edge_insertion_order = NULL;
+    self->indexes.edge_removal_order = NULL;
+    self->indexes.num_edges = 0;
+    return 0;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_build_index(
+    tsk_table_collection_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = TSK_ERR_GENERIC;
+    size_t j;
+    double *time = self->nodes.time;
+    index_sort_t *sort_buff = NULL;
+    tsk_id_t parent;
+
+    /* For build indexes to make sense we must have referential integrity and
+     * sorted edges */
+    ret = tsk_table_collection_check_integrity(self, TSK_CHECK_EDGE_ORDERING);
+    if (ret != 0) {
+        goto out;
+    }
+
+    tsk_table_collection_drop_index(self, 0);
+    self->indexes.edge_insertion_order = malloc(self->edges.num_rows * sizeof(tsk_id_t));
+    self->indexes.edge_removal_order = malloc(self->edges.num_rows * sizeof(tsk_id_t));
+    sort_buff = malloc(self->edges.num_rows * sizeof(index_sort_t));
+    if (self->indexes.edge_insertion_order == NULL
+        || self->indexes.edge_removal_order == NULL || sort_buff == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    /* sort by left and increasing time to give us the order in which
+     * records should be inserted */
+    for (j = 0; j < self->edges.num_rows; j++) {
+        sort_buff[j].index = (tsk_id_t) j;
+        sort_buff[j].first = self->edges.left[j];
+        parent = self->edges.parent[j];
+        sort_buff[j].second = time[parent];
+        sort_buff[j].third = parent;
+        sort_buff[j].fourth = self->edges.child[j];
+    }
+    qsort(sort_buff, self->edges.num_rows, sizeof(index_sort_t), cmp_index_sort);
+    for (j = 0; j < self->edges.num_rows; j++) {
+        self->indexes.edge_insertion_order[j] = sort_buff[j].index;
+    }
+    /* sort by right and decreasing parent time to give us the order in which
+     * records should be removed. */
+    for (j = 0; j < self->edges.num_rows; j++) {
+        sort_buff[j].index = (tsk_id_t) j;
+        sort_buff[j].first = self->edges.right[j];
+        parent = self->edges.parent[j];
+        sort_buff[j].second = -time[parent];
+        sort_buff[j].third = -parent;
+        sort_buff[j].fourth = -self->edges.child[j];
+    }
+    qsort(sort_buff, self->edges.num_rows, sizeof(index_sort_t), cmp_index_sort);
+    for (j = 0; j < self->edges.num_rows; j++) {
+        self->indexes.edge_removal_order[j] = sort_buff[j].index;
+    }
+    self->indexes.num_edges = self->edges.num_rows;
+    ret = 0;
+out:
+    tsk_safe_free(sort_buff);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_copy(const tsk_table_collection_t *self,
+    tsk_table_collection_t *dest, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_table_collection_init(dest, options);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_node_table_copy(&self->nodes, &dest->nodes, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_copy(&self->edges, &dest->edges, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_copy(&self->migrations, &dest->migrations, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_copy(&self->sites, &dest->sites, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_copy(&self->mutations, &dest->mutations, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_copy(&self->individuals, &dest->individuals, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_copy(&self->populations, &dest->populations, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_copy(&self->provenances, &dest->provenances, TSK_NO_INIT);
+    if (ret != 0) {
+        goto out;
+    }
+    dest->sequence_length = self->sequence_length;
+    if (tsk_table_collection_has_index(self, 0)) {
+        ret = tsk_table_collection_set_indexes(
+            dest, self->indexes.edge_insertion_order, self->indexes.edge_removal_order);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_table_collection_set_metadata(dest, self->metadata, self->metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_set_metadata_schema(
+        dest, self->metadata_schema, self->metadata_schema_length);
+    if (ret != 0) {
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_read_format_data(tsk_table_collection_t *self, kastore_t *store)
+{
+    int ret = 0;
+    size_t len;
+    uint32_t *version;
+    int8_t *format_name, *uuid;
+    double *L;
+
+    char *metadata = NULL;
+    char *metadata_schema = NULL;
+    size_t metadata_length, metadata_schema_length;
+
+    ret = kastore_gets_int8(store, "format/name", &format_name, &len);
+    if (ret != 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+    if (len != TSK_FILE_FORMAT_NAME_LENGTH) {
+        ret = TSK_ERR_FILE_FORMAT;
+        goto out;
+    }
+    if (memcmp(TSK_FILE_FORMAT_NAME, format_name, TSK_FILE_FORMAT_NAME_LENGTH) != 0) {
+        ret = TSK_ERR_FILE_FORMAT;
+        goto out;
+    }
+
+    ret = kastore_gets_uint32(store, "format/version", &version, &len);
+    if (ret != 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+    if (len != 2) {
+        ret = TSK_ERR_FILE_FORMAT;
+        goto out;
+    }
+    if (version[0] < TSK_FILE_FORMAT_VERSION_MAJOR) {
+        ret = TSK_ERR_FILE_VERSION_TOO_OLD;
+        goto out;
+    }
+    if (version[0] > TSK_FILE_FORMAT_VERSION_MAJOR) {
+        ret = TSK_ERR_FILE_VERSION_TOO_NEW;
+        goto out;
+    }
+
+    ret = kastore_gets_float64(store, "sequence_length", &L, &len);
+    if (ret != 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+    if (len != 1) {
+        ret = TSK_ERR_FILE_FORMAT;
+        goto out;
+    }
+    if (L[0] <= 0.0) {
+        ret = TSK_ERR_BAD_SEQUENCE_LENGTH;
+        goto out;
+    }
+    self->sequence_length = L[0];
+
+    ret = kastore_gets_int8(store, "uuid", &uuid, &len);
+    if (ret != 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+    if (len != TSK_UUID_SIZE) {
+        ret = TSK_ERR_FILE_FORMAT;
+        goto out;
+    }
+    /* This is safe because either we are in a case where TSK_NO_INIT has been set
+     * and there is a valid pointer, or this is a fresh table collection where all
+     * all pointers have been set to zero */
+    tsk_safe_free(self->file_uuid);
+    /* Allow space for \0 so we can print it as a string */
+    self->file_uuid = malloc(TSK_UUID_SIZE + 1);
+    if (self->file_uuid == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(self->file_uuid, uuid, TSK_UUID_SIZE);
+    self->file_uuid[TSK_UUID_SIZE] = '\0';
+
+    ret = kastore_containss(store, "metadata");
+    if (ret < 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+    if (ret == 1) {
+        ret = kastore_gets_int8(
+            store, "metadata", (int8_t **) &metadata, (size_t *) &metadata_length);
+        if (ret != 0) {
+            ret = tsk_set_kas_error(ret);
+            goto out;
+        }
+        ret = tsk_table_collection_set_metadata(
+            self, metadata, (tsk_size_t) metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    ret = kastore_containss(store, "metadata_schema");
+    if (ret < 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+    if (ret == 1) {
+        ret = kastore_gets_int8(store, "metadata_schema", (int8_t **) &metadata_schema,
+            (size_t *) &metadata_schema_length);
+        if (ret != 0) {
+            ret = tsk_set_kas_error(ret);
+            goto out;
+        }
+        ret = tsk_table_collection_set_metadata_schema(
+            self, metadata_schema, (tsk_size_t) metadata_schema_length);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+out:
+    if ((ret ^ (1 << TSK_KAS_ERR_BIT)) == KAS_ERR_KEY_NOT_FOUND) {
+        ret = TSK_ERR_REQUIRED_COL_NOT_FOUND;
+    }
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_dump_indexes(const tsk_table_collection_t *self, kastore_t *store)
+{
+    int ret = 0;
+    write_table_col_t write_cols[] = {
+        { "indexes/edge_insertion_order", NULL, self->indexes.num_edges, KAS_INT32 },
+        { "indexes/edge_removal_order", NULL, self->indexes.num_edges, KAS_INT32 },
+    };
+
+    if (tsk_table_collection_has_index(self, 0)) {
+        write_cols[0].array = self->indexes.edge_insertion_order;
+        write_cols[1].array = self->indexes.edge_removal_order;
+        ret = write_table_cols(
+            store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+    }
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_load_indexes(tsk_table_collection_t *self, kastore_t *store)
+{
+    int ret = 0;
+    tsk_id_t *edge_insertion_order = NULL;
+    tsk_id_t *edge_removal_order = NULL;
+    tsk_size_t num_rows;
+
+    read_table_col_t read_cols[] = {
+        { "indexes/edge_insertion_order", (void **) &edge_insertion_order, &num_rows, 0,
+            KAS_INT32, TSK_COL_OPTIONAL },
+        { "indexes/edge_removal_order", (void **) &edge_removal_order, &num_rows, 0,
+            KAS_INT32, TSK_COL_OPTIONAL },
+    };
+
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+    if (ret != 0) {
+        goto out;
+    }
+    if ((edge_insertion_order == NULL) != (edge_removal_order == NULL)) {
+        ret = TSK_ERR_BOTH_COLUMNS_REQUIRED;
+        goto out;
+    }
+    if (edge_insertion_order != NULL) {
+        if (num_rows != self->edges.num_rows) {
+            ret = TSK_ERR_FILE_FORMAT;
+            goto out;
+        }
+        ret = tsk_table_collection_set_indexes(
+            self, edge_insertion_order, edge_removal_order);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_loadf_inited(tsk_table_collection_t *self, FILE *file)
+{
+    int ret = 0;
+    kastore_t store;
+
+    ret = kastore_openf(&store, file, "r", KAS_READ_ALL);
+    if (ret != 0) {
+        if (ret == KAS_ERR_EOF) {
+            /* KAS_ERR_EOF means that we tried to read a store from the stream
+             * and we hit EOF immediately without reading any bytes. We signal
+             * this back to the client, which allows it to read an indefinite
+             * number of stores from a stream */
+            ret = TSK_ERR_EOF;
+        } else {
+            ret = tsk_set_kas_error(ret);
+        }
+        goto out;
+    }
+    ret = tsk_table_collection_read_format_data(self, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_load(&self->nodes, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_load(&self->edges, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_load(&self->sites, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_load(&self->mutations, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_load(&self->migrations, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_load(&self->individuals, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_load(&self->populations, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_load(&self->provenances, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_load_indexes(self, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = kastore_close(&store);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    /* If we're exiting on an error, we ignore any further errors that might come
+     * from kastore. In the nominal case, closing an already-closed store is a
+     * safe noop */
+    kastore_close(&store);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_loadf(tsk_table_collection_t *self, FILE *file, tsk_flags_t options)
+{
+    int ret = 0;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_table_collection_init(self, options);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_table_collection_loadf_inited(self, file);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_load(
+    tsk_table_collection_t *self, const char *filename, tsk_flags_t options)
+{
+    int ret = 0;
+    FILE *file = NULL;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_table_collection_init(self, options);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    file = fopen(filename, "rb");
+    if (file == NULL) {
+        ret = TSK_ERR_IO;
+        goto out;
+    }
+    ret = tsk_table_collection_loadf_inited(self, file);
+    if (ret != 0) {
+        goto out;
+    }
+    if (fclose(file) != 0) {
+        ret = TSK_ERR_IO;
+        goto out;
+    }
+    file = NULL;
+out:
+    if (file != NULL) {
+        /* Ignore any additional errors we might get when closing the file
+         * in error conditions */
+        fclose(file);
+    }
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_table_collection_write_format_data(tsk_table_collection_t *self, kastore_t *store)
+{
+    int ret = 0;
+    char format_name[TSK_FILE_FORMAT_NAME_LENGTH];
+    char uuid[TSK_UUID_SIZE + 1]; // Must include space for trailing null.
+    uint32_t version[2]
+        = { TSK_FILE_FORMAT_VERSION_MAJOR, TSK_FILE_FORMAT_VERSION_MINOR };
+    write_table_col_t write_cols[] = {
+        { "format/name", (void *) format_name, sizeof(format_name), KAS_INT8 },
+        { "format/version", (void *) version, 2, KAS_UINT32 },
+        { "sequence_length", (void *) &self->sequence_length, 1, KAS_FLOAT64 },
+        { "uuid", (void *) uuid, TSK_UUID_SIZE, KAS_INT8 },
+        { "metadata", (void *) self->metadata, self->metadata_length, KAS_INT8 },
+        { "metadata_schema", (void *) self->metadata_schema,
+            self->metadata_schema_length, KAS_INT8 },
+    };
+
+    ret = tsk_generate_uuid(uuid, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    /* This stupid dance is to workaround the fact that compilers won't allow
+     * casts to discard the 'const' qualifier. */
+    memcpy(format_name, TSK_FILE_FORMAT_NAME, sizeof(format_name));
+    ret = write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_dump(
+    tsk_table_collection_t *self, const char *filename, tsk_flags_t options)
+{
+    int ret = 0;
+    FILE *file = fopen(filename, "wb");
+
+    if (file == NULL) {
+        ret = TSK_ERR_IO;
+        goto out;
+    }
+    ret = tsk_table_collection_dumpf(self, file, options);
+    if (ret != 0) {
+        goto out;
+    }
+    if (fclose(file) != 0) {
+        ret = TSK_ERR_IO;
+        goto out;
+    }
+    file = NULL;
+out:
+    if (file != NULL) {
+        /* Ignore any additional errors we might get when closing the file
+         * in error conditions */
+        fclose(file);
+        /* If an error occurred make sure that the filename is removed */
+        remove(filename);
+    }
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_dumpf(tsk_table_collection_t *self, FILE *file, tsk_flags_t options)
+{
+    int ret = 0;
+    kastore_t store;
+
+    memset(&store, 0, sizeof(store));
+
+    /* By default we build indexes, if they are needed. Note that this will fail if
+     * the tables aren't sorted. */
+    if ((!(options & TSK_NO_BUILD_INDEXES))
+        && (!tsk_table_collection_has_index(self, 0))) {
+        ret = tsk_table_collection_build_index(self, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    ret = kastore_openf(&store, file, "w", 0);
+    if (ret != 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+
+    /* All of these functions will set the kas_error internally, so we don't have
+     * to modify the return value. */
+    ret = tsk_table_collection_write_format_data(self, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_dump(&self->nodes, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_dump(&self->edges, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_dump(&self->sites, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_dump(&self->migrations, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_dump(&self->mutations, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_dump(&self->individuals, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_dump(&self->populations, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_dump(&self->provenances, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_dump_indexes(self, &store);
+    if (ret != 0) {
+        goto out;
+    }
+
+    ret = kastore_close(&store);
+    if (ret != 0) {
+        ret = tsk_set_kas_error(ret);
+        goto out;
+    }
+out:
+    /* It's safe to close a kastore twice. */
+    if (ret != 0) {
+        kastore_close(&store);
+    }
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_simplify(tsk_table_collection_t *self, const tsk_id_t *samples,
+    tsk_size_t num_samples, tsk_flags_t options, tsk_id_t *node_map)
+{
+    int ret = 0;
+    simplifier_t simplifier;
+    tsk_id_t *local_samples = NULL;
+    tsk_id_t u;
+
+    /* Avoid calling to simplifier_free with uninit'd memory on error branches */
+    memset(&simplifier, 0, sizeof(simplifier_t));
+
+    /* For now we don't bother with edge metadata, but it can easily be
+     * implemented. */
+    if (self->edges.metadata_length > 0) {
+        ret = TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA;
+        goto out;
+    }
+
+    if (samples == NULL) {
+        /* Avoid issue with mallocing zero bytes */
+        local_samples = malloc((1 + self->nodes.num_rows) * sizeof(*local_samples));
+        if (local_samples == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        num_samples = 0;
+        for (u = 0; u < (tsk_id_t) self->nodes.num_rows; u++) {
+            if (!!(self->nodes.flags[u] & TSK_NODE_IS_SAMPLE)) {
+                local_samples[num_samples] = u;
+                num_samples++;
+            }
+        }
+        samples = local_samples;
+    }
+
+    ret = simplifier_init(&simplifier, samples, (size_t) num_samples, self, options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = simplifier_run(&simplifier, node_map);
+    if (ret != 0) {
+        goto out;
+    }
+    if (!!(options & TSK_DEBUG)) {
+        simplifier_print_state(&simplifier, stdout);
+    }
+    /* The indexes are invalidated now so drop them */
+    ret = tsk_table_collection_drop_index(self, 0);
+out:
+    simplifier_free(&simplifier);
+    tsk_safe_free(local_samples);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_link_ancestors(tsk_table_collection_t *self, tsk_id_t *samples,
+    tsk_size_t num_samples, tsk_id_t *ancestors, tsk_size_t num_ancestors,
+    tsk_flags_t TSK_UNUSED(options), tsk_edge_table_t *result)
+{
+    int ret = 0;
+    ancestor_mapper_t ancestor_mapper;
+
+    memset(&ancestor_mapper, 0, sizeof(ancestor_mapper_t));
+
+    if (self->edges.metadata_length > 0) {
+        ret = TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA;
+        goto out;
+    }
+
+    ret = ancestor_mapper_init(&ancestor_mapper, samples, (size_t) num_samples,
+        ancestors, (size_t) num_ancestors, self, result);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = ancestor_mapper_run(&ancestor_mapper);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    ancestor_mapper_free(&ancestor_mapper);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_sort(
+    tsk_table_collection_t *self, const tsk_bookmark_t *start, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_table_sorter_t sorter;
+
+    ret = tsk_table_sorter_init(&sorter, self, options);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_sorter_run(&sorter, start);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    tsk_table_sorter_free(&sorter);
+    return ret;
+}
+
+/*
+ * Remove any sites with duplicate positions, retaining only the *first*
+ * one. Assumes the tables have been sorted, throwing an error if not.
+ */
+int TSK_WARN_UNUSED
+tsk_table_collection_deduplicate_sites(
+    tsk_table_collection_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_size_t j;
+    /* Map of old site IDs to new site IDs. */
+    tsk_id_t *site_id_map = NULL;
+    tsk_site_table_t copy;
+    tsk_site_t row, last_row;
+
+    /* Early exit if there's 0 rows. We don't exit early for one row because
+     * we would then skip error checking, making the semantics inconsistent. */
+    if (self->sites.num_rows == 0) {
+        return 0;
+    }
+
+    /* Must allocate the site table first for tsk_site_table_free to be safe */
+    ret = tsk_site_table_copy(&self->sites, &copy, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_integrity(self, TSK_CHECK_SITE_ORDERING);
+
+    if (ret != 0) {
+        goto out;
+    }
+
+    site_id_map = malloc(copy.num_rows * sizeof(*site_id_map));
+    if (site_id_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    ret = tsk_site_table_clear(&self->sites);
+    if (ret != 0) {
+        goto out;
+    }
+
+    last_row.position = -1;
+    site_id_map[0] = 0;
+    for (j = 0; j < copy.num_rows; j++) {
+        tsk_site_table_get_row_unsafe(&copy, (tsk_id_t) j, &row);
+        if (row.position != last_row.position) {
+            ret = tsk_site_table_add_row(&self->sites, row.position, row.ancestral_state,
+                row.ancestral_state_length, row.metadata, row.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+        }
+        site_id_map[j] = (tsk_id_t) self->sites.num_rows - 1;
+        last_row = row;
+    }
+
+    if (self->sites.num_rows < copy.num_rows) {
+        // Remap sites in the mutation table
+        // (but only if there's been any changed sites)
+        for (j = 0; j < self->mutations.num_rows; j++) {
+            self->mutations.site[j] = site_id_map[self->mutations.site[j]];
+        }
+    }
+    ret = 0;
+out:
+    tsk_site_table_free(&copy);
+    tsk_safe_free(site_id_map);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_compute_mutation_parents(
+    tsk_table_collection_t *self, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_id_t num_trees;
+    const tsk_id_t *I, *O;
+    const tsk_edge_table_t edges = self->edges;
+    const tsk_node_table_t nodes = self->nodes;
+    const tsk_site_table_t sites = self->sites;
+    const tsk_mutation_table_t mutations = self->mutations;
+    const tsk_id_t M = (tsk_id_t) edges.num_rows;
+    tsk_id_t tj, tk;
+    tsk_id_t *parent = NULL;
+    tsk_id_t *bottom_mutation = NULL;
+    tsk_id_t u;
+    double left, right;
+    tsk_id_t site;
+    /* Using unsigned values here avoids potentially undefined behaviour */
+    tsk_size_t j, mutation, first_mutation;
+
+    /* Set the mutation parent to TSK_NULL so that we don't check the
+     * parent values we are about to write over. */
+    memset(mutations.parent, 0xff, mutations.num_rows * sizeof(*mutations.parent));
+    num_trees = tsk_table_collection_check_integrity(self, TSK_CHECK_TREES);
+    if (num_trees < 0) {
+        ret = num_trees;
+        goto out;
+    }
+    parent = malloc(nodes.num_rows * sizeof(*parent));
+    bottom_mutation = malloc(nodes.num_rows * sizeof(*bottom_mutation));
+    if (parent == NULL || bottom_mutation == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, nodes.num_rows * sizeof(*parent));
+    memset(bottom_mutation, 0xff, nodes.num_rows * sizeof(*bottom_mutation));
+    memset(mutations.parent, 0xff, self->mutations.num_rows * sizeof(tsk_id_t));
+
+    I = self->indexes.edge_insertion_order;
+    O = self->indexes.edge_removal_order;
+    tj = 0;
+    tk = 0;
+    site = 0;
+    mutation = 0;
+    left = 0;
+    while (tj < M || left < self->sequence_length) {
+        while (tk < M && edges.right[O[tk]] == left) {
+            parent[edges.child[O[tk]]] = TSK_NULL;
+            tk++;
+        }
+        while (tj < M && edges.left[I[tj]] == left) {
+            parent[edges.child[I[tj]]] = edges.parent[I[tj]];
+            tj++;
+        }
+        right = self->sequence_length;
+        if (tj < M) {
+            right = TSK_MIN(right, edges.left[I[tj]]);
+        }
+        if (tk < M) {
+            right = TSK_MIN(right, edges.right[O[tk]]);
+        }
+
+        /* Tree is now ready. We look at each site on this tree in turn */
+        while (site < (tsk_id_t) sites.num_rows && sites.position[site] < right) {
+            /* Create a mapping from mutations to nodes. If we see more than one
+             * mutation at a node, the previously seen one must be the parent
+             * of the current since we assume they are in order. */
+            first_mutation = mutation;
+            while (mutation < mutations.num_rows && mutations.site[mutation] == site) {
+                u = mutations.node[mutation];
+                if (bottom_mutation[u] != TSK_NULL) {
+                    mutations.parent[mutation] = bottom_mutation[u];
+                }
+                bottom_mutation[u] = (tsk_id_t) mutation;
+                mutation++;
+            }
+            /* Make the common case of 1 mutation fast */
+            if (mutation > first_mutation + 1) {
+                /* If we have more than one mutation, compute the parent for each
+                 * one by traversing up the tree until we find a node that has a
+                 * mutation. */
+                for (j = first_mutation; j < mutation; j++) {
+                    if (mutations.parent[j] == TSK_NULL) {
+                        u = parent[mutations.node[j]];
+                        while (u != TSK_NULL && bottom_mutation[u] == TSK_NULL) {
+                            u = parent[u];
+                        }
+                        if (u != TSK_NULL) {
+                            mutations.parent[j] = bottom_mutation[u];
+                        }
+                    }
+                }
+            }
+            /* Reset the mapping for the next site */
+            for (j = first_mutation; j < mutation; j++) {
+                u = mutations.node[j];
+                bottom_mutation[u] = TSK_NULL;
+                /* Check that we haven't violated the sortedness property */
+                if (mutations.parent[j] > (tsk_id_t) j) {
+                    ret = TSK_ERR_MUTATION_PARENT_AFTER_CHILD;
+                    goto out;
+                }
+            }
+            site++;
+        }
+        /* Move on to the next tree */
+        left = right;
+    }
+
+out:
+    tsk_safe_free(parent);
+    tsk_safe_free(bottom_mutation);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_compute_mutation_times(
+    tsk_table_collection_t *self, double *random, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_id_t num_trees;
+    const tsk_id_t *restrict I = self->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->indexes.edge_removal_order;
+    const tsk_edge_table_t edges = self->edges;
+    const tsk_node_table_t nodes = self->nodes;
+    const tsk_site_table_t sites = self->sites;
+    const tsk_mutation_table_t mutations = self->mutations;
+    const tsk_id_t M = (tsk_id_t) edges.num_rows;
+    tsk_id_t tj, tk;
+    tsk_id_t *parent = NULL;
+    tsk_size_t *numerator = NULL;
+    tsk_size_t *denominator = NULL;
+    tsk_id_t u;
+    double left, right, parent_time;
+    tsk_id_t site;
+    /* Using unsigned values here avoids potentially undefined behaviour */
+    tsk_size_t j, mutation, first_mutation;
+    tsk_bookmark_t skip_edges = { 0, 0, self->edges.num_rows, 0, 0, 0, 0, 0 };
+
+    /* The random param is for future usage */
+    if (random != NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+
+    /* First set the times to TSK_UNKNOWN_TIME so that check will succeed */
+    for (j = 0; j < mutations.num_rows; j++) {
+        mutations.time[j] = TSK_UNKNOWN_TIME;
+    }
+    num_trees = tsk_table_collection_check_integrity(self, TSK_CHECK_TREES);
+    if (num_trees < 0) {
+        ret = num_trees;
+        goto out;
+    }
+    parent = malloc(nodes.num_rows * sizeof(*parent));
+    numerator = malloc(nodes.num_rows * sizeof(*numerator));
+    denominator = malloc(nodes.num_rows * sizeof(*denominator));
+    if (parent == NULL || numerator == NULL || denominator == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, nodes.num_rows * sizeof(*parent));
+    memset(numerator, 0, nodes.num_rows * sizeof(*numerator));
+    memset(denominator, 0, nodes.num_rows * sizeof(*denominator));
+
+    tj = 0;
+    tk = 0;
+    site = 0;
+    mutation = 0;
+    left = 0;
+    while (tj < M || left < self->sequence_length) {
+        while (tk < M && edges.right[O[tk]] == left) {
+            parent[edges.child[O[tk]]] = TSK_NULL;
+            tk++;
+        }
+        while (tj < M && edges.left[I[tj]] == left) {
+            parent[edges.child[I[tj]]] = edges.parent[I[tj]];
+            tj++;
+        }
+        right = self->sequence_length;
+        if (tj < M) {
+            right = TSK_MIN(right, edges.left[I[tj]]);
+        }
+        if (tk < M) {
+            right = TSK_MIN(right, edges.right[O[tk]]);
+        }
+
+        /* Tree is now ready. We look at each site on this tree in turn */
+        while (site < (tsk_id_t) sites.num_rows && sites.position[site] < right) {
+            first_mutation = mutation;
+            /* Count how many mutations each edge has to get our
+               denominator */
+            while (mutation < mutations.num_rows && mutations.site[mutation] == site) {
+                denominator[mutations.node[mutation]]++;
+                mutation++;
+            }
+            /* Go over the mutations again assigning times. As the sorting
+               requirements guarantee that parents are before children, we assign
+               oldest first */
+            for (j = first_mutation; j < mutation; j++) {
+                u = mutations.node[j];
+                numerator[u]++;
+                if (parent[u] == TSK_NULL) {
+                    /* This mutation is above a root */
+                    mutations.time[j] = nodes.time[u];
+                } else {
+                    parent_time = nodes.time[parent[u]];
+                    mutations.time[j] = parent_time
+                                        - (parent_time - nodes.time[u]) * numerator[u]
+                                              / (denominator[u] + 1);
+                }
+            }
+            /* Reset the book-keeping for the next site */
+            for (j = first_mutation; j < mutation; j++) {
+                u = mutations.node[j];
+                numerator[u] = 0;
+                denominator[u] = 0;
+            }
+            site++;
+        }
+        /* Move on to the next tree */
+        left = right;
+    }
+
+    /* Now that mutations have times their sort order may have been invalidated, so
+     * re-sort */
+    ret = tsk_table_collection_check_integrity(self, TSK_CHECK_MUTATION_ORDERING);
+    if (ret == TSK_ERR_UNSORTED_MUTATIONS) {
+        ret = tsk_table_collection_sort(self, &skip_edges, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    } else if (ret < 0) {
+        goto out;
+    }
+
+out:
+    tsk_safe_free(parent);
+    tsk_safe_free(numerator);
+    tsk_safe_free(denominator);
+    return ret;
+}
+
+int
+tsk_table_collection_record_num_rows(
+    const tsk_table_collection_t *self, tsk_bookmark_t *position)
+{
+    position->individuals = self->individuals.num_rows;
+    position->nodes = self->nodes.num_rows;
+    position->edges = self->edges.num_rows;
+    position->migrations = self->migrations.num_rows;
+    position->sites = self->sites.num_rows;
+    position->mutations = self->mutations.num_rows;
+    position->populations = self->populations.num_rows;
+    position->provenances = self->provenances.num_rows;
+    return 0;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_truncate(tsk_table_collection_t *tables, tsk_bookmark_t *position)
+{
+    int ret = 0;
+
+    ret = tsk_table_collection_drop_index(tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_individual_table_truncate(&tables->individuals, position->individuals);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_node_table_truncate(&tables->nodes, position->nodes);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_edge_table_truncate(&tables->edges, position->edges);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_migration_table_truncate(&tables->migrations, position->migrations);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_site_table_truncate(&tables->sites, position->sites);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_mutation_table_truncate(&tables->mutations, position->mutations);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_population_table_truncate(&tables->populations, position->populations);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_provenance_table_truncate(&tables->provenances, position->provenances);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_clear(tsk_table_collection_t *self, tsk_flags_t options)
+{
+    int ret = 0;
+    bool clear_provenance = !!(options & TSK_CLEAR_PROVENANCE);
+    bool clear_metadata_schemas = !!(options & TSK_CLEAR_METADATA_SCHEMAS);
+    bool clear_ts_metadata = !!(options & TSK_CLEAR_TS_METADATA_AND_SCHEMA);
+    tsk_bookmark_t rows_to_retain
+        = { .provenances = clear_provenance ? 0 : self->provenances.num_rows };
+
+    ret = tsk_table_collection_truncate(self, &rows_to_retain);
+    if (ret != 0) {
+        goto out;
+    }
+
+    if (clear_metadata_schemas) {
+        ret = tsk_individual_table_set_metadata_schema(&self->individuals, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_node_table_set_metadata_schema(&self->nodes, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_edge_table_set_metadata_schema(&self->edges, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_migration_table_set_metadata_schema(&self->migrations, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_site_table_set_metadata_schema(&self->sites, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_mutation_table_set_metadata_schema(&self->mutations, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_population_table_set_metadata_schema(&self->populations, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    if (clear_ts_metadata) {
+        ret = tsk_table_collection_set_metadata(self, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_table_collection_set_metadata_schema(self, "", 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_table_collection_add_and_remap_node(tsk_table_collection_t *self,
+    const tsk_table_collection_t *other, tsk_id_t node_id, tsk_id_t *individual_map,
+    tsk_id_t *population_map, tsk_id_t *node_map, bool add_populations)
+{
+    int ret = 0;
+    tsk_id_t new_ind, new_pop;
+    tsk_node_t node;
+    tsk_individual_t ind;
+    tsk_population_t pop;
+
+    ret = tsk_node_table_get_row(&other->nodes, node_id, &node);
+    if (ret < 0) {
+        goto out;
+    }
+    new_ind = TSK_NULL;
+    if (node.individual != TSK_NULL) {
+        if (individual_map[node.individual] == TSK_NULL) {
+            ret = tsk_individual_table_get_row(
+                &other->individuals, node.individual, &ind);
+            if (ret < 0) {
+                goto out;
+            }
+            ret = tsk_individual_table_add_row(&self->individuals, ind.flags,
+                ind.location, ind.location_length, ind.metadata, ind.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+            individual_map[node.individual] = ret;
+        }
+        new_ind = individual_map[node.individual];
+    }
+    new_pop = TSK_NULL;
+    if (node.population != TSK_NULL) {
+        // keep same pops if add_populations is False
+        if (!add_populations) {
+            population_map[node.population] = node.population;
+        }
+        if (population_map[node.population] == TSK_NULL) {
+            ret = tsk_population_table_get_row(
+                &other->populations, node.population, &pop);
+            if (ret < 0) {
+                goto out;
+            }
+            ret = tsk_population_table_add_row(
+                &self->populations, pop.metadata, pop.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+            population_map[node.population] = ret;
+        }
+        new_pop = population_map[node.population];
+    }
+    ret = tsk_node_table_add_row(&self->nodes, node.flags, node.time, new_pop, new_ind,
+        node.metadata, node.metadata_length);
+    if (ret < 0) {
+        goto out;
+    }
+    node_map[node.id] = ret;
+
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_subset(
+    tsk_table_collection_t *self, const tsk_id_t *nodes, tsk_size_t num_nodes)
+{
+    int ret = 0;
+    tsk_id_t k, i, new_parent, new_child, new_node;
+    tsk_edge_t edge;
+    tsk_mutation_t mut;
+    tsk_site_t site;
+    tsk_id_t *node_map = NULL;
+    tsk_id_t *individual_map = NULL;
+    tsk_id_t *population_map = NULL;
+    tsk_id_t *site_map = NULL;
+    tsk_id_t *mutation_map = NULL;
+    tsk_table_collection_t tables;
+
+    ret = tsk_table_collection_copy(self, &tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_integrity(self, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_clear(self, 0);
+    if (ret != 0) {
+        goto out;
+    }
+
+    node_map = malloc(tables.nodes.num_rows * sizeof(*node_map));
+    individual_map = malloc(tables.individuals.num_rows * sizeof(*individual_map));
+    population_map = malloc(tables.populations.num_rows * sizeof(*population_map));
+    site_map = malloc(tables.sites.num_rows * sizeof(*site_map));
+    mutation_map = malloc(tables.mutations.num_rows * sizeof(*mutation_map));
+    if (node_map == NULL || individual_map == NULL || population_map == NULL
+        || site_map == NULL || mutation_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(node_map, 0xff, tables.nodes.num_rows * sizeof(*node_map));
+    memset(individual_map, 0xff, tables.individuals.num_rows * sizeof(*individual_map));
+    memset(population_map, 0xff, tables.populations.num_rows * sizeof(*population_map));
+    memset(site_map, 0xff, tables.sites.num_rows * sizeof(*site_map));
+    memset(mutation_map, 0xff, tables.mutations.num_rows * sizeof(*mutation_map));
+
+    // nodes, individuals, populations
+    for (k = 0; k < (tsk_id_t) num_nodes; k++) {
+        ret = tsk_table_collection_add_and_remap_node(
+            self, &tables, nodes[k], individual_map, population_map, node_map, true);
+        if (ret < 0) {
+            goto out;
+        }
+    }
+
+    // edges
+    for (k = 0; k < (tsk_id_t) tables.edges.num_rows; k++) {
+        tsk_edge_table_get_row_unsafe(&tables.edges, k, &edge);
+        new_parent = node_map[edge.parent];
+        new_child = node_map[edge.child];
+        if ((new_parent != TSK_NULL) && (new_child != TSK_NULL)) {
+            ret = tsk_edge_table_add_row(&self->edges, edge.left, edge.right, new_parent,
+                new_child, edge.metadata, edge.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+        }
+    }
+
+    // mutations and sites
+    i = 0;
+    for (k = 0; k < (tsk_id_t) tables.sites.num_rows; k++) {
+        tsk_site_table_get_row_unsafe(&tables.sites, k, &site);
+        while ((i < (tsk_id_t) tables.mutations.num_rows)
+               && (tables.mutations.site[i] == site.id)) {
+            tsk_mutation_table_get_row_unsafe(&tables.mutations, i, &mut);
+            new_node = node_map[mut.node];
+            if (new_node != TSK_NULL) {
+                if (site_map[site.id] == TSK_NULL) {
+                    ret = tsk_site_table_add_row(&self->sites, site.position,
+                        site.ancestral_state, site.ancestral_state_length, site.metadata,
+                        site.metadata_length);
+                    if (ret < 0) {
+                        goto out;
+                    }
+                    site_map[site.id] = ret;
+                }
+                new_parent = TSK_NULL;
+                if (mut.parent != TSK_NULL) {
+                    new_parent = mutation_map[mut.parent];
+                }
+                ret = tsk_mutation_table_add_row(&self->mutations, site_map[site.id],
+                    new_node, new_parent, mut.time, mut.derived_state,
+                    mut.derived_state_length, mut.metadata, mut.metadata_length);
+                if (ret < 0) {
+                    goto out;
+                }
+                mutation_map[mut.id] = ret;
+            }
+            i++;
+        }
+    }
+
+    /* TODO: Subset of the Migrations Table. The way to do this properly is not
+     * well-defined, mostly because migrations might contain events from/to
+     * populations that have not been kept in after the subset. */
+    if (tables.migrations.num_rows != 0) {
+        ret = TSK_ERR_MIGRATIONS_NOT_SUPPORTED;
+        goto out;
+    }
+    ret = 0;
+
+out:
+    tsk_safe_free(node_map);
+    tsk_safe_free(individual_map);
+    tsk_safe_free(population_map);
+    tsk_safe_free(site_map);
+    tsk_safe_free(mutation_map);
+    tsk_table_collection_free(&tables);
+    return ret;
+}
+
+static int
+tsk_check_subset_equality(tsk_table_collection_t *self,
+    const tsk_table_collection_t *other, const tsk_id_t *other_node_mapping,
+    tsk_size_t num_shared_nodes)
+{
+    int ret = 0;
+    tsk_id_t k, i;
+    tsk_id_t *self_nodes = NULL;
+    tsk_id_t *other_nodes = NULL;
+    tsk_table_collection_t self_copy;
+    tsk_table_collection_t other_copy;
+
+    memset(&self_copy, 0, sizeof(self_copy));
+    memset(&other_copy, 0, sizeof(other_copy));
+    self_nodes = malloc(num_shared_nodes * sizeof(*self_nodes));
+    other_nodes = malloc(num_shared_nodes * sizeof(*other_nodes));
+    if (self_nodes == NULL || other_nodes == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    i = 0;
+    for (k = 0; k < (tsk_id_t) other->nodes.num_rows; k++) {
+        if (other_node_mapping[k] != TSK_NULL) {
+            self_nodes[i] = other_node_mapping[k];
+            other_nodes[i] = k;
+            i++;
+        }
+    }
+
+    // TODO: strict sort before checking equality
+    ret = tsk_table_collection_copy(self, &self_copy, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_copy(other, &other_copy, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_subset(&self_copy, self_nodes, num_shared_nodes);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_subset(&other_copy, other_nodes, num_shared_nodes);
+    if (ret != 0) {
+        goto out;
+    }
+    if (!tsk_table_collection_equals(&self_copy, &other_copy,
+            TSK_CMP_IGNORE_TS_METADATA | TSK_CMP_IGNORE_PROVENANCE)) {
+        ret = TSK_ERR_UNION_DIFF_HISTORIES;
+        goto out;
+    }
+
+out:
+    tsk_table_collection_free(&self_copy);
+    tsk_table_collection_free(&other_copy);
+    tsk_safe_free(other_nodes);
+    tsk_safe_free(self_nodes);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_table_collection_union(tsk_table_collection_t *self,
+    const tsk_table_collection_t *other, const tsk_id_t *other_node_mapping,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_id_t k, i, new_parent, new_child;
+    tsk_size_t num_shared_nodes = 0;
+    tsk_edge_t edge;
+    tsk_mutation_t mut;
+    tsk_site_t site;
+    tsk_id_t *node_map = NULL;
+    tsk_id_t *individual_map = NULL;
+    tsk_id_t *population_map = NULL;
+    tsk_id_t *site_map = NULL;
+    bool add_populations = !(options & TSK_UNION_NO_ADD_POP);
+    bool check_shared_portion = !(options & TSK_UNION_NO_CHECK_SHARED);
+
+    ret = tsk_table_collection_check_integrity(self, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_check_integrity(other, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    for (k = 0; k < (tsk_id_t) other->nodes.num_rows; k++) {
+        if (other_node_mapping[k] >= (tsk_id_t) self->nodes.num_rows
+            || other_node_mapping[k] < TSK_NULL) {
+            ret = TSK_ERR_UNION_BAD_MAP;
+            goto out;
+        }
+        if (other_node_mapping[k] != TSK_NULL) {
+            num_shared_nodes++;
+        }
+    }
+
+    if (check_shared_portion) {
+        ret = tsk_check_subset_equality(
+            self, other, other_node_mapping, num_shared_nodes);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    // Maps relating the IDs in other to the new IDs in self.
+    node_map = malloc(other->nodes.num_rows * sizeof(*node_map));
+    individual_map = malloc(other->individuals.num_rows * sizeof(*individual_map));
+    population_map = malloc(other->populations.num_rows * sizeof(*population_map));
+    site_map = malloc(other->sites.num_rows * sizeof(*site_map));
+    if (node_map == NULL || individual_map == NULL || population_map == NULL
+        || site_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(node_map, 0xff, other->nodes.num_rows * sizeof(*node_map));
+    memset(individual_map, 0xff, other->individuals.num_rows * sizeof(*individual_map));
+    memset(population_map, 0xff, other->populations.num_rows * sizeof(*population_map));
+    memset(site_map, 0xff, other->sites.num_rows * sizeof(*site_map));
+
+    // nodes, individuals, populations
+    for (k = 0; k < (tsk_id_t) other->nodes.num_rows; k++) {
+        if (other_node_mapping[k] != TSK_NULL) {
+            node_map[k] = other_node_mapping[k];
+        } else {
+            ret = tsk_table_collection_add_and_remap_node(self, other, k, individual_map,
+                population_map, node_map, add_populations);
+            if (ret < 0) {
+                goto out;
+            }
+        }
+    }
+
+    // edges
+    for (k = 0; k < (tsk_id_t) other->edges.num_rows; k++) {
+        tsk_edge_table_get_row_unsafe(&other->edges, k, &edge);
+        if ((other_node_mapping[edge.parent] == TSK_NULL)
+            || (other_node_mapping[edge.child] == TSK_NULL)) {
+            /* TODO: union does not support case where non-shared bits of
+             * other are above the shared bits of self and other. This will be
+             * resolved when the Mutation Table has a time attribute and
+             * the Mutation Table is sorted on time. */
+            if (other_node_mapping[edge.parent] == TSK_NULL
+                && other_node_mapping[edge.child] != TSK_NULL) {
+                ret = TSK_ERR_UNION_NOT_SUPPORTED;
+                goto out;
+            }
+            new_parent = node_map[edge.parent];
+            new_child = node_map[edge.child];
+            ret = tsk_edge_table_add_row(&self->edges, edge.left, edge.right, new_parent,
+                new_child, edge.metadata, edge.metadata_length);
+            if (ret < 0) {
+                goto out;
+            }
+        }
+    }
+
+    // mutations and sites
+    i = 0;
+    for (k = 0; k < (tsk_id_t) other->sites.num_rows; k++) {
+        tsk_site_table_get_row_unsafe(&other->sites, k, &site);
+        while ((i < (tsk_id_t) other->mutations.num_rows)
+               && (other->mutations.site[i] == site.id)) {
+            tsk_mutation_table_get_row_unsafe(&other->mutations, i, &mut);
+            if (other_node_mapping[mut.node] == TSK_NULL) {
+                if (site_map[site.id] == TSK_NULL) {
+                    ret = tsk_site_table_add_row(&self->sites, site.position,
+                        site.ancestral_state, site.ancestral_state_length, site.metadata,
+                        site.metadata_length);
+                    if (ret < 0) {
+                        goto out;
+                    }
+                    site_map[site.id] = ret;
+                }
+                // the parents will be recomputed later
+                new_parent = TSK_NULL;
+                ret = tsk_mutation_table_add_row(&self->mutations, site_map[site.id],
+                    node_map[mut.node], new_parent, mut.time, mut.derived_state,
+                    mut.derived_state_length, mut.metadata, mut.metadata_length);
+                if (ret < 0) {
+                    goto out;
+                }
+            }
+            i++;
+        }
+    }
+
+    /* TODO: Union of the Migrations Table. The only hindrance to performing the
+     * union operation on Migrations Tables is that tsk_table_collection_sort
+     * does not sort migrations by time, and instead throws an error. */
+    if (self->migrations.num_rows != 0 || other->migrations.num_rows != 0) {
+        ret = TSK_ERR_MIGRATIONS_NOT_SUPPORTED;
+        goto out;
+    }
+
+    // provenance (new record is added in python)
+
+    // deduplicating, sorting, and computing parents
+    ret = tsk_table_collection_sort(self, 0, 0);
+    if (ret < 0) {
+        goto out;
+    }
+
+    ret = tsk_table_collection_deduplicate_sites(self, 0);
+    if (ret < 0) {
+        goto out;
+    }
+
+    ret = tsk_table_collection_build_index(self, 0);
+    if (ret < 0) {
+        goto out;
+    }
+
+    ret = tsk_table_collection_compute_mutation_parents(self, 0);
+    if (ret < 0) {
+        goto out;
+    }
+
+out:
+    tsk_safe_free(node_map);
+    tsk_safe_free(individual_map);
+    tsk_safe_free(population_map);
+    tsk_safe_free(site_map);
+    return ret;
+}
+
+static int
+cmp_edge_cl(const void *a, const void *b)
+{
+    const tsk_edge_t *ia = (const tsk_edge_t *) a;
+    const tsk_edge_t *ib = (const tsk_edge_t *) b;
+    int ret = (ia->parent > ib->parent) - (ia->parent < ib->parent);
+    if (ret == 0) {
+        ret = (ia->child > ib->child) - (ia->child < ib->child);
+        if (ret == 0) {
+            ret = (ia->left > ib->left) - (ia->left < ib->left);
+        }
+    }
+    return ret;
+}
+
+/* Squash the edges in the specified array in place. The output edges will
+ * be sorted by (child_id, left).
+ */
+
+int TSK_WARN_UNUSED
+tsk_squash_edges(tsk_edge_t *edges, tsk_size_t num_edges, tsk_size_t *num_output_edges)
+{
+    int ret = 0;
+    size_t j, k, l;
+
+    if (num_edges < 2) {
+        *num_output_edges = num_edges;
+        return ret;
+    }
+
+    qsort(edges, num_edges, sizeof(tsk_edge_t), cmp_edge_cl);
+    j = 0;
+    l = 0;
+    for (k = 1; k < num_edges; k++) {
+        if (edges[k - 1].metadata_length > 0) {
+            ret = TSK_ERR_CANT_PROCESS_EDGES_WITH_METADATA;
+            goto out;
+        }
+
+        /* Check for overlapping edges. */
+        if (edges[k - 1].parent == edges[k].parent
+            && edges[k - 1].child == edges[k].child
+            && edges[k - 1].right > edges[k].left) {
+            ret = TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN;
+            goto out;
+        }
+
+        /* Add squashed edge. */
+        if (edges[k - 1].parent != edges[k].parent || edges[k - 1].right != edges[k].left
+            || edges[j].child != edges[k].child) {
+
+            edges[l].left = edges[j].left;
+            edges[l].right = edges[k - 1].right;
+            edges[l].parent = edges[j].parent;
+            edges[l].child = edges[j].child;
+
+            j = k;
+            l++;
+        }
+    }
+    edges[l].left = edges[j].left;
+    edges[l].right = edges[k - 1].right;
+    edges[l].parent = edges[j].parent;
+    edges[l].child = edges[j].child;
+
+    *num_output_edges = (tsk_size_t) l + 1;
+
+out:
+    return ret;
+}

--- a/subprojects/tskit/tskit/tables.h
+++ b/subprojects/tskit/tskit/tables.h
@@ -1,0 +1,3063 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2017-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file tables.h
+ * @brief Tskit Tables API.
+ */
+#ifndef TSK_TABLES_H
+#define TSK_TABLES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <kastore.h>
+
+#include <tskit/core.h>
+
+/**
+@brief Tskit Object IDs.
+
+@rst
+All objects in tskit are referred to by integer IDs corresponding to the
+row they occupy in the relevant table. The ``tsk_id_t`` type should be used
+when manipulating these ID values. The reserved value ``TSK_NULL`` (-1) defines
+missing data.
+@endrst
+*/
+typedef int32_t tsk_id_t;
+
+/**
+@brief Tskit sizes.
+
+@rst
+Sizes in tskit are defined by the ``tsk_size_t`` type.
+@endrst
+*/
+typedef uint32_t tsk_size_t;
+
+/**
+@brief Container for bitwise flags.
+
+@rst
+Bitwise flags are used in tskit as a column type and also as a way to
+specify options to API functions.
+@endrst
+*/
+typedef uint32_t tsk_flags_t;
+
+/****************************************************************************/
+/* Definitions for the basic objects */
+/****************************************************************************/
+
+/**
+@brief A single individual defined by a row in the individual table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+an individual and its properties.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief Bitwise flags. */
+    tsk_flags_t flags;
+    /** @brief Spatial location. The number of dimensions is defined by
+     * ``location_length``. */
+    const double *location;
+    /** @brief Number of spatial dimensions. */
+    tsk_size_t location_length;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Size of the metadata in bytes. */
+    tsk_size_t metadata_length;
+    const tsk_id_t *nodes;
+    tsk_size_t nodes_length;
+} tsk_individual_t;
+
+/**
+@brief A single node defined by a row in the node table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+a node and its properties.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief Bitwise flags. */
+    tsk_flags_t flags;
+    /** @brief Time. */
+    double time;
+    /** @brief Population ID. */
+    tsk_id_t population;
+    /** @brief Individual ID. */
+    tsk_id_t individual;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Size of the metadata in bytes. */
+    tsk_size_t metadata_length;
+} tsk_node_t;
+
+/**
+@brief A single edge defined by a row in the edge table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+an edge and its properties.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief Parent node ID. */
+    tsk_id_t parent;
+    /** @brief Child node ID. */
+    tsk_id_t child;
+    /** @brief Left coordinate. */
+    double left;
+    /** @brief Right coordinate. */
+    double right;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Size of the metadata in bytes. */
+    tsk_size_t metadata_length;
+} tsk_edge_t;
+
+/**
+@brief A single mutation defined by a row in the mutation table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+a mutation and its properties.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief Site ID. */
+    tsk_id_t site;
+    /** @brief Node ID. */
+    tsk_id_t node;
+    /** @brief Parent mutation ID. */
+    tsk_id_t parent;
+    /** @brief Mutation time. */
+    double time;
+    /** @brief Derived state. */
+    const char *derived_state;
+    /** @brief Size of the derived state in bytes. */
+    tsk_size_t derived_state_length;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Size of the metadata in bytes. */
+    tsk_size_t metadata_length;
+} tsk_mutation_t;
+
+/**
+@brief A single site defined by a row in the site table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+a site and its properties.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief Position coordinate. */
+    double position;
+    /** @brief Ancestral state. */
+    const char *ancestral_state;
+    /** @brief Ancestral state length in bytes. */
+    tsk_size_t ancestral_state_length;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Metadata length in bytes. */
+    tsk_size_t metadata_length;
+    const tsk_mutation_t *mutations;
+    tsk_size_t mutations_length;
+} tsk_site_t;
+
+/**
+@brief A single migration defined by a row in the migration table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+a migration and its properties.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief Source population ID. */
+    tsk_id_t source;
+    /** @brief Destination population ID. */
+    tsk_id_t dest;
+    /** @brief Node ID. */
+    tsk_id_t node;
+    /** @brief Left coordinate. */
+    double left;
+    /** @brief Right coordinate. */
+    double right;
+    /** @brief Time. */
+    double time;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Size of the metadata in bytes. */
+    tsk_size_t metadata_length;
+
+} tsk_migration_t;
+
+/**
+@brief A single population defined by a row in the population table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+a population and its properties.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief Metadata. */
+    const char *metadata;
+    /** @brief Metadata length in bytes. */
+    tsk_size_t metadata_length;
+} tsk_population_t;
+
+/**
+@brief A single provenance defined by a row in the provenance table.
+
+@rst
+See the :ref:`data model <sec_data_model_definitions>` section for the definition of
+a provenance object and its properties. See the :ref:`sec_provenance` section
+for more information on how provenance records should be structured.
+@endrst
+*/
+typedef struct {
+    /** @brief Non-negative ID value corresponding to table row. */
+    tsk_id_t id;
+    /** @brief The timestamp. */
+    const char *timestamp;
+    /** @brief The timestamp length in bytes. */
+    tsk_size_t timestamp_length;
+    /** @brief The record. */
+    const char *record;
+    /** @brief The record length in bytes. */
+    tsk_size_t record_length;
+} tsk_provenance_t;
+
+/****************************************************************************/
+/* Table definitions */
+/****************************************************************************/
+
+/**
+@brief The individual table.
+
+@rst
+See the individual :ref:`table definition <sec_individual_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    /** @brief The total length of the location column. */
+    tsk_size_t location_length;
+    tsk_size_t max_location_length;
+    tsk_size_t max_location_length_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
+    /** @brief The flags column. */
+    tsk_flags_t *flags;
+    /** @brief The location column. */
+    double *location;
+    /** @brief The location_offset column. */
+    tsk_size_t *location_offset;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+} tsk_individual_table_t;
+
+/**
+@brief The node table.
+
+@rst
+See the node :ref:`table definition <sec_node_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
+    /** @brief The flags column. */
+    tsk_flags_t *flags;
+    /** @brief The time column. */
+    double *time;
+    /** @brief The population column. */
+    tsk_id_t *population;
+    /** @brief The individual column. */
+    tsk_id_t *individual;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+} tsk_node_table_t;
+
+/**
+@brief The edge table.
+
+@rst
+See the edge :ref:`table definition <sec_edge_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
+    /** @brief The left column. */
+    double *left;
+    /** @brief The right column. */
+    double *right;
+    /** @brief The parent column. */
+    tsk_id_t *parent;
+    /** @brief The child column. */
+    tsk_id_t *child;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+    /** @brief Flags for this table */
+    tsk_flags_t options;
+} tsk_edge_table_t;
+
+/**
+@brief The migration table.
+
+@rst
+See the migration :ref:`table definition <sec_migration_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
+    /** @brief The source column. */
+    tsk_id_t *source;
+    /** @brief The dest column. */
+    tsk_id_t *dest;
+    /** @brief The node column. */
+    tsk_id_t *node;
+    /** @brief The left column. */
+    double *left;
+    /** @brief The right column. */
+    double *right;
+    /** @brief The time column. */
+    double *time;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+} tsk_migration_table_t;
+
+/**
+@brief The site table.
+
+@rst
+See the site :ref:`table definition <sec_site_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    tsk_size_t ancestral_state_length;
+    tsk_size_t max_ancestral_state_length;
+    tsk_size_t max_ancestral_state_length_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
+    /** @brief The position column. */
+    double *position;
+    /** @brief The ancestral_state column. */
+    char *ancestral_state;
+    /** @brief The ancestral_state_offset column. */
+    tsk_size_t *ancestral_state_offset;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+} tsk_site_table_t;
+
+/**
+@brief The mutation table.
+
+@rst
+See the mutation :ref:`table definition <sec_mutation_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    tsk_size_t derived_state_length;
+    tsk_size_t max_derived_state_length;
+    tsk_size_t max_derived_state_length_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
+    /** @brief The node column. */
+    tsk_id_t *node;
+    /** @brief The site column. */
+    tsk_id_t *site;
+    /** @brief The parent column. */
+    tsk_id_t *parent;
+    /** @brief The time column. */
+    double *time;
+    /** @brief The derived_state column. */
+    char *derived_state;
+    /** @brief The derived_state_offset column. */
+    tsk_size_t *derived_state_offset;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+} tsk_mutation_table_t;
+
+/**
+@brief The population table.
+
+@rst
+See the population :ref:`table definition <sec_population_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    /** @brief The total length of the metadata column. */
+    tsk_size_t metadata_length;
+    tsk_size_t max_metadata_length;
+    tsk_size_t max_metadata_length_increment;
+    tsk_size_t metadata_schema_length;
+    /** @brief The metadata column. */
+    char *metadata;
+    /** @brief The metadata_offset column. */
+    tsk_size_t *metadata_offset;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+} tsk_population_table_t;
+
+/**
+@brief The provenance table.
+
+@rst
+See the provenance :ref:`table definition <sec_provenance_table_definition>` for
+details of the columns in this table.
+@endrst
+*/
+typedef struct {
+    /** @brief The number of rows in this table. */
+    tsk_size_t num_rows;
+    tsk_size_t max_rows;
+    tsk_size_t max_rows_increment;
+    /** @brief The total length of the timestamp column. */
+    tsk_size_t timestamp_length;
+    tsk_size_t max_timestamp_length;
+    tsk_size_t max_timestamp_length_increment;
+    /** @brief The total length of the record column. */
+    tsk_size_t record_length;
+    tsk_size_t max_record_length;
+    tsk_size_t max_record_length_increment;
+    /** @brief The timestamp column. */
+    char *timestamp;
+    /** @brief The timestamp_offset column. */
+    tsk_size_t *timestamp_offset;
+    /** @brief The record column. */
+    char *record;
+    /** @brief The record_offset column. */
+    tsk_size_t *record_offset;
+} tsk_provenance_table_t;
+
+/**
+@brief A collection of tables defining the data for a tree sequence.
+*/
+typedef struct {
+    /** @brief The sequence length defining the tree sequence's coordinate space */
+    double sequence_length;
+    char *file_uuid;
+    /** @brief The tree-sequence metadata */
+    char *metadata;
+    tsk_size_t metadata_length;
+    /** @brief The metadata schema */
+    char *metadata_schema;
+    tsk_size_t metadata_schema_length;
+    /** @brief The individual table */
+    tsk_individual_table_t individuals;
+    /** @brief The node table */
+    tsk_node_table_t nodes;
+    /** @brief The edge table */
+    tsk_edge_table_t edges;
+    /** @brief The migration table */
+    tsk_migration_table_t migrations;
+    /** @brief The site table */
+    tsk_site_table_t sites;
+    /** @brief The mutation table */
+    tsk_mutation_table_t mutations;
+    /** @brief The population table */
+    tsk_population_table_t populations;
+    /** @brief The provenance table */
+    tsk_provenance_table_t provenances;
+    struct {
+        tsk_id_t *edge_insertion_order;
+        tsk_id_t *edge_removal_order;
+        tsk_size_t num_edges;
+    } indexes;
+} tsk_table_collection_t;
+
+/**
+@brief A bookmark recording the position of all the tables in a table collection.
+*/
+typedef struct {
+    /** @brief The position in the individual table. */
+    tsk_size_t individuals;
+    /** @brief The position in the node table. */
+    tsk_size_t nodes;
+    /** @brief The position in the edge table. */
+    tsk_size_t edges;
+    /** @brief The position in the migration table. */
+    tsk_size_t migrations;
+    /** @brief The position in the site table. */
+    tsk_size_t sites;
+    /** @brief The position in the mutation table. */
+    tsk_size_t mutations;
+    /** @brief The position in the population table. */
+    tsk_size_t populations;
+    /** @brief The position in the provenance table. */
+    tsk_size_t provenances;
+} tsk_bookmark_t;
+
+/**
+@brief Low-level table sorting method.
+*/
+typedef struct _tsk_table_sorter_t {
+    /** @brief The input tables that are being sorted. */
+    tsk_table_collection_t *tables;
+    /** @brief The edge sorting function. If set to NULL, edges are not sorted. */
+    int (*sort_edges)(struct _tsk_table_sorter_t *self, tsk_size_t start);
+    /** @brief An opaque pointer for use by client code */
+    void *user_data;
+    /** @brief Mapping from input site IDs to output site IDs */
+    tsk_id_t *site_id_map;
+} tsk_table_sorter_t;
+
+/* Structs for IBD finding.
+ * TODO: document properly
+ * */
+
+typedef struct _tsk_segment_t {
+    double left;
+    double right;
+    struct _tsk_segment_t *next;
+    tsk_id_t node;
+} tsk_segment_t;
+
+typedef struct {
+    tsk_id_t *pairs;
+    size_t num_pairs;
+    size_t num_nodes;
+    size_t num_unique_nodes_in_pair;
+    int64_t *pair_map;
+    double sequence_length;
+    tsk_table_collection_t *tables;
+    tsk_segment_t **ibd_segments_head;
+    tsk_segment_t **ibd_segments_tail;
+    tsk_blkalloc_t segment_heap;
+    bool *is_sample;
+    tsk_id_t *paired_nodes_index;
+    double min_length;
+    double max_time;
+    tsk_segment_t **ancestor_map_head;
+    tsk_segment_t **ancestor_map_tail;
+    tsk_segment_t *segment_queue;
+    size_t segment_queue_size;
+    size_t max_segment_queue_size;
+} tsk_ibd_finder_t;
+
+/****************************************************************************/
+/* Common function options */
+/****************************************************************************/
+
+/**
+@defgroup TABLES_API_FUNCTION_OPTIONS Common function options in tables API
+@{
+*/
+
+/* Start the commmon options at the top of the space; this way we can start
+ * options for individual functions at the bottom without worrying about
+ * clashing with the common options */
+
+/** @brief Turn on debugging output. Not supported by all functions. */
+#define TSK_DEBUG (1u << 31)
+
+/** @brief Do not initialise the parameter object. */
+#define TSK_NO_INIT (1u << 30)
+
+/** @brief Do not run integrity checks before performing an operation. */
+#define TSK_NO_CHECK_INTEGRITY (1u << 29)
+
+/**@} */
+
+/* Flags for simplify() */
+#define TSK_FILTER_SITES (1 << 0)
+#define TSK_FILTER_POPULATIONS (1 << 1)
+#define TSK_FILTER_INDIVIDUALS (1 << 2)
+#define TSK_REDUCE_TO_SITE_TOPOLOGY (1 << 3)
+#define TSK_KEEP_UNARY (1 << 4)
+#define TSK_KEEP_INPUT_ROOTS (1 << 5)
+
+/* Flags for check_integrity */
+#define TSK_CHECK_EDGE_ORDERING (1 << 0)
+#define TSK_CHECK_SITE_ORDERING (1 << 1)
+#define TSK_CHECK_SITE_DUPLICATES (1 << 2)
+#define TSK_CHECK_MUTATION_ORDERING (1 << 3)
+#define TSK_CHECK_INDEXES (1 << 4)
+#define TSK_CHECK_TREES (1 << 5)
+
+/* Leave room for more positive check flags */
+#define TSK_NO_CHECK_POPULATION_REFS (1 << 10)
+
+/* Flags for dump tables */
+#define TSK_NO_BUILD_INDEXES (1 << 0)
+
+/* Flags for load tables */
+#define TSK_BUILD_INDEXES (1 << 0)
+
+/* Flags for table collection init */
+#define TSK_NO_EDGE_METADATA (1 << 0)
+
+/* Flags for table init. */
+#define TSK_NO_METADATA (1 << 0)
+
+/* Flags for union() */
+#define TSK_UNION_NO_CHECK_SHARED (1 << 0)
+#define TSK_UNION_NO_ADD_POP (1 << 1)
+
+/* Flags for table collection equals */
+#define TSK_CMP_IGNORE_TS_METADATA (1 << 0)
+#define TSK_CMP_IGNORE_PROVENANCE (1 << 1)
+#define TSK_CMP_IGNORE_METADATA (1 << 2)
+#define TSK_CMP_IGNORE_TIMESTAMPS (1 << 3)
+
+/* Flags for tables collection clear */
+#define TSK_CLEAR_METADATA_SCHEMAS (1 << 0)
+#define TSK_CLEAR_TS_METADATA_AND_SCHEMA (1 << 1)
+#define TSK_CLEAR_PROVENANCE (1 << 2)
+
+/****************************************************************************/
+/* Function signatures */
+/****************************************************************************/
+
+/**
+@defgroup INDIVIDUAL_TABLE_API_GROUP Individual table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+@endrst
+
+@param self A pointer to an uninitialised tsk_individual_table_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_individual_table_init(tsk_individual_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_individual_table_t object.
+@return Always returns 0.
+*/
+int tsk_individual_table_free(tsk_individual_table_t *self);
+
+/**
+@brief Adds a row to this individual table.
+
+@rst
+Add a new individual with the specified ``flags``, ``location`` and ``metadata``
+to the table. Copies of the ``location`` and ``metadata`` parameters are taken
+immediately.
+See the :ref:`table definition <sec_individual_table_definition>` for details
+of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param flags The bitwise flags for the new individual.
+@param location A pointer to a double array representing the spatial location
+    of the new individual. Can be ``NULL`` if ``location_length`` is 0.
+@param location_length The number of dimensions in the locations position.
+    Note this the number of elements in the corresponding double array
+    not the number of bytes.
+@param metadata The metadata to be associated with the new individual. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+@return Return the ID of the newly added individual on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_individual_table_add_row(tsk_individual_table_t *self, tsk_flags_t flags,
+    const double *location, tsk_size_t location_length, const char *metadata,
+    tsk_size_t metadata_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_individual_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_individual_table_clear(tsk_individual_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_individual_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_individual_table_truncate(tsk_individual_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns,
+and their metadata schemas are byte-wise identical.
+
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata or metadata schemas in the comparison.
+
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param other A pointer to a tsk_individual_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_individual_table_equals(const tsk_individual_table_t *self,
+    const tsk_individual_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+
+Indexes that are present are also copied to the destination table.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param dest A pointer to a tsk_individual_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised individual table. If not, it must
+    be an uninitialised individual table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_individual_table_copy(const tsk_individual_table_t *self,
+    tsk_individual_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified individual struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_individual_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_individual_table_get_row(
+    const tsk_individual_table_t *self, tsk_id_t index, tsk_individual_t *row);
+
+/**
+@brief Set the metadata schema
+
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_individual_table_set_metadata_schema(tsk_individual_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_individual_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_individual_table_print_state(const tsk_individual_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_individual_table_set_columns(tsk_individual_table_t *self, tsk_size_t num_rows,
+    const tsk_flags_t *flags, const double *location, const tsk_size_t *location_length,
+    const char *metadata, const tsk_size_t *metadata_length);
+int tsk_individual_table_append_columns(tsk_individual_table_t *self,
+    tsk_size_t num_rows, const tsk_flags_t *flags, const double *location,
+    const tsk_size_t *location_length, const char *metadata,
+    const tsk_size_t *metadata_length);
+int tsk_individual_table_dump_text(const tsk_individual_table_t *self, FILE *out);
+int tsk_individual_table_set_max_rows_increment(
+    tsk_individual_table_t *self, tsk_size_t max_rows_increment);
+int tsk_individual_table_set_max_metadata_length_increment(
+    tsk_individual_table_t *self, tsk_size_t max_metadata_length_increment);
+int tsk_individual_table_set_max_location_length_increment(
+    tsk_individual_table_t *self, tsk_size_t max_location_length_increment);
+
+/**
+@defgroup NODE_TABLE_API_GROUP Node table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+@endrst
+
+@param self A pointer to an uninitialised tsk_node_table_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_node_table_init(tsk_node_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_node_table_t object.
+@return Always returns 0.
+*/
+int tsk_node_table_free(tsk_node_table_t *self);
+
+/**
+@brief Adds a row to this node table.
+
+@rst
+Add a new node with the specified ``flags``, ``time``, ``population``,
+``individual`` and ``metadata`` to the table. A copy of the ``metadata`` parameter
+is taken immediately. See the :ref:`table definition <sec_node_table_definition>`
+for details of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_node_table_t object.
+@param flags The bitwise flags for the new node.
+@param time The time for the new node.
+@param population The population for the new node. Set to TSK_NULL if not known.
+@param individual The individual for the new node. Set to TSK_NULL if not known.
+@param metadata The metadata to be associated with the new node. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+@return Return the ID of the newly added node on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_node_table_add_row(tsk_node_table_t *self, tsk_flags_t flags, double time,
+    tsk_id_t population, tsk_id_t individual, const char *metadata,
+    tsk_size_t metadata_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_node_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
+@endrst
+
+@param self A pointer to a tsk_node_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_node_table_clear(tsk_node_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_node_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_node_table_truncate(tsk_node_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns,
+and their metadata schemas are byte-wise identical.
+
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata or metadata schemas in the comparison.
+
+@endrst
+
+@param self A pointer to a tsk_node_table_t object.
+@param other A pointer to a tsk_node_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_node_table_equals(
+    const tsk_node_table_t *self, const tsk_node_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_node_table_t object.
+@param dest A pointer to a tsk_node_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised node table. If not, it must
+    be an uninitialised node table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_node_table_copy(
+    const tsk_node_table_t *self, tsk_node_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified node struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_node_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_node_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_node_table_get_row(
+    const tsk_node_table_t *self, tsk_id_t index, tsk_node_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_node_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_node_table_set_metadata_schema(tsk_node_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_node_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_node_table_print_state(const tsk_node_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_node_table_set_max_rows_increment(
+    tsk_node_table_t *self, tsk_size_t max_rows_increment);
+int tsk_node_table_set_max_metadata_length_increment(
+    tsk_node_table_t *self, tsk_size_t max_metadata_length_increment);
+int tsk_node_table_set_columns(tsk_node_table_t *self, tsk_size_t num_rows,
+    const tsk_flags_t *flags, const double *time, const tsk_id_t *population,
+    const tsk_id_t *individual, const char *metadata, const tsk_size_t *metadata_length);
+int tsk_node_table_append_columns(tsk_node_table_t *self, tsk_size_t num_rows,
+    const tsk_flags_t *flags, const double *time, const tsk_id_t *population,
+    const tsk_id_t *individual, const char *metadata, const tsk_size_t *metadata_length);
+int tsk_node_table_dump_text(const tsk_node_table_t *self, FILE *out);
+
+/**
+@defgroup EDGE_TABLE_API_GROUP Edge table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_METADATA
+    Do not allocate space to store metadata in this table. Operations
+    attempting to add non-empty metadata to the table will fail
+    with error TSK_ERR_METADATA_DISABLED.
+
+@endrst
+
+@param self A pointer to an uninitialised tsk_edge_table_t object.
+@param options Allocation time options.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_edge_table_init(tsk_edge_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_edge_table_t object.
+@return Always returns 0.
+*/
+int tsk_edge_table_free(tsk_edge_table_t *self);
+
+/**
+@brief Adds a row to this edge table.
+
+@rst
+Add a new edge with the specified ``left``, ``right``, ``parent``, ``child`` and
+``metadata`` to the table. See the :ref:`table definition <sec_edge_table_definition>`
+for details of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_edge_table_t object.
+@param left The left coordinate for the new edge.
+@param right The right coordinate for the new edge.
+@param parent The parent node for the new edge.
+@param child The child node for the new edge.
+@param metadata The metadata to be associated with the new edge. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+
+@return Return the ID of the newly added edge on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_edge_table_add_row(tsk_edge_table_t *self, double left, double right,
+    tsk_id_t parent, tsk_id_t child, const char *metadata, tsk_size_t metadata_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_edge_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
+@endrst
+
+@param self A pointer to a tsk_edge_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_edge_table_clear(tsk_edge_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_edge_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_edge_table_truncate(tsk_edge_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns,
+and their metadata schemas are byte-wise identical.
+
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata or metadata schemas in the comparison.
+
+@endrst
+
+@param self A pointer to a tsk_edge_table_t object.
+@param other A pointer to a tsk_edge_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_edge_table_equals(
+    const tsk_edge_table_t *self, const tsk_edge_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_edge_table_t object.
+@param dest A pointer to a tsk_edge_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised edge table. If not, it must
+    be an uninitialised edge table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_edge_table_copy(
+    const tsk_edge_table_t *self, tsk_edge_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified edge struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_edge_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_edge_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_edge_table_get_row(
+    const tsk_edge_table_t *self, tsk_id_t index, tsk_edge_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_edge_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_edge_table_set_metadata_schema(tsk_edge_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_edge_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_edge_table_print_state(const tsk_edge_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_edge_table_set_max_rows_increment(
+    tsk_edge_table_t *self, tsk_size_t max_rows_increment);
+int tsk_edge_table_set_max_metadata_length_increment(
+    tsk_edge_table_t *self, tsk_size_t max_metadata_length_increment);
+int tsk_edge_table_set_columns(tsk_edge_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *parent,
+    const tsk_id_t *child, const char *metadata, const tsk_size_t *metadata_length);
+int tsk_edge_table_append_columns(tsk_edge_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *parent,
+    const tsk_id_t *child, const char *metadata, const tsk_size_t *metadata_length);
+int tsk_edge_table_dump_text(const tsk_edge_table_t *self, FILE *out);
+
+int tsk_edge_table_squash(tsk_edge_table_t *self);
+
+/**
+@defgroup MIGRATION_TABLE_API_GROUP Migration table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+@endrst
+
+@param self A pointer to an uninitialised tsk_migration_table_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_migration_table_init(tsk_migration_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_migration_table_t object.
+@return Always returns 0.
+*/
+int tsk_migration_table_free(tsk_migration_table_t *self);
+
+/**
+@brief Adds a row to this migration table.
+
+@rst
+Add a new migration with the specified ``left``, ``right``, ``node``,
+``source``, ``dest``, ``time`` and ``metadata`` to the table.
+See the :ref:`table definition <sec_migration_table_definition>`
+for details of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_migration_table_t object.
+@param left The left coordinate for the new migration.
+@param right The right coordinate for the new migration.
+@param node The node ID for the new migration.
+@param source The source population ID for the new migration.
+@param dest The destination population ID for the new migration.
+@param time The time for the new migration.
+@param metadata The metadata to be associated with the new migration. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+
+@return Return the ID of the newly added migration on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_migration_table_add_row(tsk_migration_table_t *self, double left,
+    double right, tsk_id_t node, tsk_id_t source, tsk_id_t dest, double time,
+    const char *metadata, tsk_size_t metadata_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_migration_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
+@endrst
+
+@param self A pointer to a tsk_migration_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_migration_table_clear(tsk_migration_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_migration_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_migration_table_truncate(tsk_migration_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns,
+and their metadata schemas are byte-wise identical.
+
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata or metadata schemas in the comparison.
+
+@endrst
+
+@param self A pointer to a tsk_migration_table_t object.
+@param other A pointer to a tsk_migration_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_migration_table_equals(const tsk_migration_table_t *self,
+    const tsk_migration_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_migration_table_t object.
+@param dest A pointer to a tsk_migration_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised migration table. If not, it must
+    be an uninitialised migration table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_migration_table_copy(
+    const tsk_migration_table_t *self, tsk_migration_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified migration struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_migration_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_migration_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_migration_table_get_row(
+    const tsk_migration_table_t *self, tsk_id_t index, tsk_migration_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_migration_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_migration_table_set_metadata_schema(tsk_migration_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_migration_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_migration_table_print_state(const tsk_migration_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_migration_table_set_max_rows_increment(
+    tsk_migration_table_t *self, tsk_size_t max_rows_increment);
+int tsk_migration_table_set_max_metadata_length_increment(
+    tsk_migration_table_t *self, tsk_size_t max_metadata_length_increment);
+int tsk_migration_table_set_columns(tsk_migration_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *node,
+    const tsk_id_t *source, const tsk_id_t *dest, const double *time,
+    const char *metadata, const tsk_size_t *metadata_length);
+int tsk_migration_table_append_columns(tsk_migration_table_t *self, tsk_size_t num_rows,
+    const double *left, const double *right, const tsk_id_t *node,
+    const tsk_id_t *source, const tsk_id_t *dest, const double *time,
+    const char *metadata, const tsk_size_t *metadata_length);
+int tsk_migration_table_dump_text(const tsk_migration_table_t *self, FILE *out);
+
+/**
+@defgroup SITE_TABLE_API_GROUP Site table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+@endrst
+
+@param self A pointer to an uninitialised tsk_site_table_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_site_table_init(tsk_site_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_site_table_t object.
+@return Always returns 0.
+*/
+int tsk_site_table_free(tsk_site_table_t *self);
+
+/**
+@brief Adds a row to this site table.
+
+@rst
+Add a new site with the specified ``position``, ``ancestral_state``
+and ``metadata`` to the table. Copies of ``ancestral_state`` and ``metadata``
+are immediately taken. See the :ref:`table definition <sec_site_table_definition>`
+for details of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_site_table_t object.
+@param position The position coordinate for the new site.
+@param ancestral_state The ancestral_state for the new site.
+@param ancestral_state_length The length of the ancestral_state in bytes.
+@param metadata The metadata to be associated with the new site. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+@return Return the ID of the newly added site on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_site_table_add_row(tsk_site_table_t *self, double position,
+    const char *ancestral_state, tsk_size_t ancestral_state_length, const char *metadata,
+    tsk_size_t metadata_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_site_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
+@endrst
+
+@param self A pointer to a tsk_site_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_site_table_clear(tsk_site_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_site_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_site_table_truncate(tsk_site_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns,
+and their metadata schemas are byte-wise identical.
+
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata or metadata schemas in the comparison.
+
+@endrst
+
+@param self A pointer to a tsk_site_table_t object.
+@param other A pointer to a tsk_site_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_site_table_equals(
+    const tsk_site_table_t *self, const tsk_site_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_site_table_t object.
+@param dest A pointer to a tsk_site_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised site table. If not, it must
+    be an uninitialised site table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_site_table_copy(
+    const tsk_site_table_t *self, tsk_site_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified site struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_site_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_site_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_site_table_get_row(
+    const tsk_site_table_t *self, tsk_id_t index, tsk_site_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_site_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_site_table_set_metadata_schema(tsk_site_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_site_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_site_table_print_state(const tsk_site_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_site_table_set_max_rows_increment(
+    tsk_site_table_t *self, tsk_size_t max_rows_increment);
+int tsk_site_table_set_max_metadata_length_increment(
+    tsk_site_table_t *self, tsk_size_t max_metadata_length_increment);
+int tsk_site_table_set_max_ancestral_state_length_increment(
+    tsk_site_table_t *self, tsk_size_t max_ancestral_state_length_increment);
+int tsk_site_table_set_columns(tsk_site_table_t *self, tsk_size_t num_rows,
+    const double *position, const char *ancestral_state,
+    const tsk_size_t *ancestral_state_length, const char *metadata,
+    const tsk_size_t *metadata_length);
+int tsk_site_table_append_columns(tsk_site_table_t *self, tsk_size_t num_rows,
+    const double *position, const char *ancestral_state,
+    const tsk_size_t *ancestral_state_length, const char *metadata,
+    const tsk_size_t *metadata_length);
+int tsk_site_table_dump_text(const tsk_site_table_t *self, FILE *out);
+
+/**
+@defgroup MUTATION_TABLE_API_GROUP Mutation table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+@endrst
+
+@param self A pointer to an uninitialised tsk_mutation_table_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_mutation_table_init(tsk_mutation_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_mutation_table_t object.
+@return Always returns 0.
+*/
+int tsk_mutation_table_free(tsk_mutation_table_t *self);
+
+/**
+@brief Adds a row to this mutation table.
+
+@rst
+Add a new mutation with the specified ``site``, ``parent``, ``derived_state``
+and ``metadata`` to the table. Copies of ``derived_state`` and ``metadata``
+are immediately taken. See the :ref:`table definition <sec_mutation_table_definition>`
+for details of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_mutation_table_t object.
+@param site The site ID for the new mutation.
+@param node The ID of the node this mutation occurs over.
+@param parent The ID of the parent mutation.
+@param time The time of the mutation.
+@param derived_state The derived_state for the new mutation.
+@param derived_state_length The length of the derived_state in bytes.
+@param metadata The metadata to be associated with the new mutation. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+@return Return the ID of the newly added mutation on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_mutation_table_add_row(tsk_mutation_table_t *self, tsk_id_t site,
+    tsk_id_t node, tsk_id_t parent, double time, const char *derived_state,
+    tsk_size_t derived_state_length, const char *metadata, tsk_size_t metadata_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_mutation_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
+@endrst
+
+@param self A pointer to a tsk_mutation_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_mutation_table_clear(tsk_mutation_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_mutation_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_mutation_table_truncate(tsk_mutation_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns,
+and their metadata schemas are byte-wise identical.
+
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata or metadata schemas in the comparison.
+
+@endrst
+
+@param self A pointer to a tsk_mutation_table_t object.
+@param other A pointer to a tsk_mutation_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_mutation_table_equals(const tsk_mutation_table_t *self,
+    const tsk_mutation_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_mutation_table_t object.
+@param dest A pointer to a tsk_mutation_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised mutation table. If not, it must
+    be an uninitialised mutation table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_mutation_table_copy(
+    const tsk_mutation_table_t *self, tsk_mutation_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified mutation struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_mutation_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_mutation_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_mutation_table_get_row(
+    const tsk_mutation_table_t *self, tsk_id_t index, tsk_mutation_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_mutation_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_mutation_table_set_metadata_schema(tsk_mutation_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_mutation_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_mutation_table_print_state(const tsk_mutation_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_mutation_table_set_max_rows_increment(
+    tsk_mutation_table_t *self, tsk_size_t max_rows_increment);
+int tsk_mutation_table_set_max_metadata_length_increment(
+    tsk_mutation_table_t *self, tsk_size_t max_metadata_length_increment);
+int tsk_mutation_table_set_max_derived_state_length_increment(
+    tsk_mutation_table_t *self, tsk_size_t max_derived_state_length_increment);
+int tsk_mutation_table_set_columns(tsk_mutation_table_t *self, tsk_size_t num_rows,
+    const tsk_id_t *site, const tsk_id_t *node, const tsk_id_t *parent,
+    const double *time, const char *derived_state,
+    const tsk_size_t *derived_state_length, const char *metadata,
+    const tsk_size_t *metadata_length);
+int tsk_mutation_table_append_columns(tsk_mutation_table_t *self, tsk_size_t num_rows,
+    const tsk_id_t *site, const tsk_id_t *node, const tsk_id_t *parent,
+    const double *time, const char *derived_state,
+    const tsk_size_t *derived_state_length, const char *metadata,
+    const tsk_size_t *metadata_length);
+int tsk_mutation_table_dump_text(const tsk_mutation_table_t *self, FILE *out);
+
+/**
+@defgroup POPULATION_TABLE_API_GROUP Population table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+@endrst
+
+@param self A pointer to an uninitialised tsk_population_table_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_population_table_init(tsk_population_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_population_table_t object.
+@return Always returns 0.
+*/
+int tsk_population_table_free(tsk_population_table_t *self);
+
+/**
+@brief Adds a row to this population table.
+
+@rst
+Add a new population with the specified ``metadata`` to the table. A copy of the
+``metadata`` is immediately taken. See the :ref:`table definition
+<sec_population_table_definition>` for details of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_population_table_t object.
+@param metadata The metadata to be associated with the new population. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``metadata_length`` is 0.
+@param metadata_length The size of the metadata array in bytes.
+@return Return the ID of the newly added population on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_population_table_add_row(
+    tsk_population_table_t *self, const char *metadata, tsk_size_t metadata_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_population_table_free` to free the table's internal resources. Note that the
+metadata schema is not cleared.
+@endrst
+
+@param self A pointer to a tsk_population_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_population_table_clear(tsk_population_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_population_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_population_table_truncate(tsk_population_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns,
+and their metadata schemas are byte-wise identical.
+
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata in the comparison. Note that as metadata is the
+    only column in the population table, two population tables are considered
+    equal if they have the same number of rows if this flag is specified.
+
+@endrst
+
+@param self A pointer to a tsk_population_table_t object.
+@param other A pointer to a tsk_population_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_population_table_equals(const tsk_population_table_t *self,
+    const tsk_population_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_population_table_t object.
+@param dest A pointer to a tsk_population_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised population table. If not, it must
+    be an uninitialised population table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_population_table_copy(const tsk_population_table_t *self,
+    tsk_population_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified population struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_population_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_population_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_population_table_get_row(
+    const tsk_population_table_t *self, tsk_id_t index, tsk_population_t *row);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table, replacing any existing.
+@endrst
+@param self A pointer to a tsk_population_table_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_population_table_set_metadata_schema(tsk_population_table_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_population_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_population_table_print_state(const tsk_population_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_population_table_set_max_rows_increment(
+    tsk_population_table_t *self, tsk_size_t max_rows_increment);
+int tsk_population_table_set_max_metadata_length_increment(
+    tsk_population_table_t *self, tsk_size_t max_metadata_length_increment);
+int tsk_population_table_set_columns(tsk_population_table_t *self, tsk_size_t num_rows,
+    const char *metadata, const tsk_size_t *metadata_offset);
+int tsk_population_table_append_columns(tsk_population_table_t *self,
+    tsk_size_t num_rows, const char *metadata, const tsk_size_t *metadata_offset);
+int tsk_population_table_dump_text(const tsk_population_table_t *self, FILE *out);
+
+/**
+@defgroup PROVENANCE_TABLE_API_GROUP Provenance table API.
+@{
+*/
+
+/**
+@brief Initialises the table by allocating the internal memory.
+
+@rst
+This must be called before any operations are performed on the table.
+See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+@endrst
+
+@param self A pointer to an uninitialised tsk_provenance_table_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_provenance_table_init(tsk_provenance_table_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table.
+
+@param self A pointer to an initialised tsk_provenance_table_t object.
+@return Always returns 0.
+*/
+int tsk_provenance_table_free(tsk_provenance_table_t *self);
+
+/**
+@brief Adds a row to this provenance table.
+
+@rst
+Add a new provenance with the specified ``timestamp`` and ``record`` to the table.
+Copies of the ``timestamp`` and ``record`` are immediately taken.
+See the :ref:`table definition <sec_provenance_table_definition>`
+for details of the columns in this table.
+@endrst
+
+@param self A pointer to a tsk_provenance_table_t object.
+@param timestamp The timestamp to be associated with the new provenance. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``timestamp_length`` is 0.
+@param timestamp_length The size of the timestamp array in bytes.
+@param record The record to be associated with the new provenance. This
+    is a pointer to arbitrary memory. Can be ``NULL`` if ``record_length`` is 0.
+@param record_length The size of the record array in bytes.
+@return Return the ID of the newly added provenance on success,
+    or a negative value on failure.
+*/
+tsk_id_t tsk_provenance_table_add_row(tsk_provenance_table_t *self,
+    const char *timestamp, tsk_size_t timestamp_length, const char *record,
+    tsk_size_t record_length);
+
+/**
+@brief Clears this table, setting the number of rows to zero.
+
+@rst
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_provenance_table_free` to free the table's internal resources.
+@endrst
+
+@param self A pointer to a tsk_provenance_table_t object.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_provenance_table_clear(tsk_provenance_table_t *self);
+
+/**
+@brief Truncates this table so that only the first num_rows are retained.
+
+@param self A pointer to a tsk_provenance_table_t object.
+@param num_rows The number of rows to retain in the table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_provenance_table_truncate(tsk_provenance_table_t *self, tsk_size_t num_rows);
+
+/**
+@brief Returns true if the data in the specified table is identical to the data
+       in this table.
+
+@rst
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) tables are
+considered equal if they are byte-wise identical in all columns.
+
+TSK_CMP_IGNORE_TIMESTAMPS
+    Do not include the timestamp column when comparing provenance
+    tables.
+
+@endrst
+
+@param self A pointer to a tsk_provenance_table_t object.
+@param other A pointer to a tsk_provenance_table_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table is equal to this table.
+*/
+bool tsk_provenance_table_equals(const tsk_provenance_table_t *self,
+    const tsk_provenance_table_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_provenance_table_t object.
+@param dest A pointer to a tsk_provenance_table_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised provenance table. If not, it must
+    be an uninitialised provenance table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_provenance_table_copy(const tsk_provenance_table_t *self,
+    tsk_provenance_table_t *dest, tsk_flags_t options);
+
+/**
+@brief Get the row at the specified index.
+
+@rst
+Updates the specified provenance struct to reflect the values in the specified row.
+Pointers to memory within this struct are handled by the table and should **not**
+be freed by client code. These pointers are guaranteed to be valid until the
+next operation that modifies the table (e.g., by adding a new row), but not afterwards.
+@endrst
+
+@param self A pointer to a tsk_provenance_table_t object.
+@param index The requested table row.
+@param row A pointer to a tsk_provenance_t struct that is updated to reflect the
+    values in the specified row.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_provenance_table_get_row(
+    const tsk_provenance_table_t *self, tsk_id_t index, tsk_provenance_t *row);
+
+/**
+@brief Print out the state of this table to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_provenance_table_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_provenance_table_print_state(const tsk_provenance_table_t *self, FILE *out);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_provenance_table_set_max_rows_increment(
+    tsk_provenance_table_t *self, tsk_size_t max_rows_increment);
+int tsk_provenance_table_set_max_timestamp_length_increment(
+    tsk_provenance_table_t *self, tsk_size_t max_timestamp_length_increment);
+int tsk_provenance_table_set_max_record_length_increment(
+    tsk_provenance_table_t *self, tsk_size_t max_record_length_increment);
+int tsk_provenance_table_set_columns(tsk_provenance_table_t *self, tsk_size_t num_rows,
+    const char *timestamp, const tsk_size_t *timestamp_offset, const char *record,
+    const tsk_size_t *record_offset);
+int tsk_provenance_table_append_columns(tsk_provenance_table_t *self,
+    tsk_size_t num_rows, const char *timestamp, const tsk_size_t *timestamp_offset,
+    const char *record, const tsk_size_t *record_offset);
+int tsk_provenance_table_dump_text(const tsk_provenance_table_t *self, FILE *out);
+
+/****************************************************************************/
+/* Table collection .*/
+/****************************************************************************/
+
+/**
+@defgroup TABLE_COLLECTION_API_GROUP Table collection API.
+@{
+*/
+
+/**
+@brief Initialises the table collection by allocating the internal memory
+       and initialising all the constituent tables.
+
+@rst
+This must be called before any operations are performed on the table
+collection. See the :ref:`sec_c_api_overview_structure` for details on how objects
+are initialised and freed.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_EDGE_METADATA
+    Do not allocate space to store metadata in the edge table. Operations
+    attempting to add non-empty metadata to the edge table will fail
+    with error TSK_ERR_METADATA_DISABLED.
+
+@endrst
+
+@param self A pointer to an uninitialised tsk_table_collection_t object.
+@param options Allocation time options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_init(tsk_table_collection_t *self, tsk_flags_t options);
+
+/**
+@brief Free the internal memory for the specified table collection.
+
+@param self A pointer to an initialised tsk_table_collection_t object.
+@return Always returns 0.
+*/
+int tsk_table_collection_free(tsk_table_collection_t *self);
+
+/**
+@brief Clears data tables (and optionally provenances and metadata) in
+this table collection.
+
+@rst
+By default this operation clears all tables except the provenance table, retaining
+table metadata schemas and the tree-sequnce level metadata and schema.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_CLEAR_PROVENANCE
+    Additionally clear the provenance table
+TSK_CLEAR_METADATA_SCHEMAS
+    Additionally clear the table metadata schemas
+TSK_CLEAR_TS_METADATA_AND_SCHEMA
+    Additionally clear the tree-sequence metadata and schema
+
+No memory is freed as a result of this operation; please use
+:c:func:`tsk_table_collection_free` to free internal resources.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param options Bitwise clearing options
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_clear(tsk_table_collection_t *self, tsk_flags_t options);
+
+/**
+@brief Returns true if the data in the specified table collection is equal
+    to the data in this table collection.
+
+@rst
+
+Returns true if the two table collections are equal. The indexes are
+not considered as these are derived from the tables. We also do not
+consider the ``file_uuid``, since it is a property of the file that set
+of tables is stored in.
+
+**Options**
+
+Options to control the comparison can be specified by providing one or
+more of the following bitwise flags. By default (options=0) two table
+collections are considered equal if all of the tables are byte-wise
+identical, and the sequence lengths, metadata and metadata schemas
+of the two table collections are identical.
+
+TSK_CMP_IGNORE_PROVENANCE
+    Do not include the provenance table in comparison.
+TSK_CMP_IGNORE_METADATA
+    Do not include metadata when comparing the table collections.
+    This includes both the top-level tree sequence metadata as well as the
+    metadata for each of the tables (i.e, TSK_CMP_IGNORE_TS_METADATA is implied).
+    All metadata schemas are also ignored.
+TSK_CMP_IGNORE_TS_METADATA
+    Do not include the top-level tree sequence metadata and metadata schemas
+    in the comparison.
+TSK_CMP_IGNORE_TIMESTAMPS
+    Do not include the timestamp information when comparing the provenance
+    tables. This has no effect if TSK_CMP_IGNORE_PROVENANCE is specified.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param other A pointer to a tsk_table_collection_t object.
+@param options Bitwise comparison options.
+@return Return true if the specified table collection is equal to this table.
+*/
+bool tsk_table_collection_equals(const tsk_table_collection_t *self,
+    const tsk_table_collection_t *other, tsk_flags_t options);
+
+/**
+@brief Copies the state of this table collection into the specified destination.
+
+@rst
+By default the method initialises the specified destination table. If the
+destination is already initialised, the :c:macro:`TSK_NO_INIT` option should
+be supplied to avoid leaking memory.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param dest A pointer to a tsk_table_collection_t object. If the TSK_NO_INIT option
+    is specified, this must be an initialised provenance table. If not, it must
+    be an uninitialised provenance table.
+@param options Bitwise option flags.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_copy(const tsk_table_collection_t *self,
+    tsk_table_collection_t *dest, tsk_flags_t options);
+
+/**
+@brief Print out the state of this table collection to the specified stream.
+
+This method is intended for debugging purposes and should not be used
+in production code. The format of the output should **not** be depended
+on and may change arbitrarily between versions.
+
+@param self A pointer to a tsk_table_collection_t object.
+@param out The stream to write the summary to.
+*/
+void tsk_table_collection_print_state(const tsk_table_collection_t *self, FILE *out);
+
+/**
+@brief Load a table collection from a file path.
+
+@rst
+Loads the data from the specified file into this table collection.
+By default, the table collection is also initialised.
+The resources allocated must be freed using
+:c:func:`tsk_table_collection_free` even in error conditions.
+
+If the :c:macro:`TSK_NO_INIT` option is set, the table collection is
+not initialised, allowing an already initialised table collection to
+be overwritten with the data from a file.
+
+If the file contains multiple table collections, this function will load
+the first. Please see the :c:func:`tsk_table_collection_loadf` for details
+on how to sequentially load table collections from a stream.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_INIT
+    Do not initialise this :c:type:`tsk_table_collection_t` before loading.
+
+**Examples**
+
+.. code-block:: c
+
+    int ret;
+    tsk_table_collection_t tables;
+    ret = tsk_table_collection_load(&tables, "data.trees", 0);
+    if (ret != 0) {
+        fprintf(stderr, "Load error:%s\n", tsk_strerror(ret));
+        exit(EXIT_FAILURE);
+    }
+
+@endrst
+
+@param self A pointer to an uninitialised tsk_table_collection_t object
+    if the TSK_NO_INIT option is not set (default), or an initialised
+    tsk_table_collection_t otherwise.
+@param filename A NULL terminated string containing the filename.
+@param options Bitwise options. See above for details.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_load(
+    tsk_table_collection_t *self, const char *filename, tsk_flags_t options);
+
+/**
+@brief Load a table collection from a stream.
+
+@rst
+Loads a tables definition from the specified file stream to this table
+collection. By default, the table collection is also initialised.
+The resources allocated must be freed using
+:c:func:`tsk_table_collection_free` even in error conditions.
+
+If the :c:macro:`TSK_NO_INIT` option is set, the table collection is
+not initialised, allowing an already initialised table collection to
+be overwritten with the data from a file.
+
+If the stream contains multiple table collection definitions, this function
+will load the next table collection from the stream. If the stream contains no
+more table collection definitions the error value :c:macro:`TSK_ERR_EOF` will
+be returned. Note that EOF is only returned in the case where zero bytes are
+read from the stream --- malformed files or other errors will result in
+different error conditions. Please see the
+:ref:`sec_c_api_examples_file_streaming` section for an example of how to
+sequentially load tree sequences from a stream.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_INIT
+    Do not initialise this :c:type:`tsk_table_collection_t` before loading.
+
+@endrst
+
+@param self A pointer to an uninitialised tsk_table_collection_t object
+    if the TSK_NO_INIT option is not set (default), or an initialised
+    tsk_table_collection_t otherwise.
+@param file A FILE stream opened in an appropriate mode for reading (e.g.
+    "r", "r+" or "w+") positioned at the beginning of a table collection
+    definition.
+@param options Bitwise options. See above for details.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_loadf(
+    tsk_table_collection_t *self, FILE *file, tsk_flags_t options);
+
+/**
+@brief Write a table collection to file.
+
+@rst
+Writes the data from this table collection to the specified file.
+Usually we expect that data written to a file will be in a form that
+can be read directly and used to create a tree sequence; that is, we
+assume that by default the tables are :ref:`sorted <sec_table_sorting>`
+and :ref:`indexed <sec_table_indexes>`. Following these
+assumptions, if the tables are not already indexed, we index the tables
+before writing to file to save the cost of building these indexes at
+load time. This behaviour requires that the tables are sorted.
+If this automatic indexing is not desired, it can be disabled using
+the `TSK_NO_BUILD_INDEXES` option.
+
+If an error occurs the file path is deleted, ensuring that only complete
+and well formed files will be written.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_BUILD_INDEXES
+    Do not build indexes for this table before writing to file. This is useful
+    if you wish to write unsorted tables to file, as building the indexes
+    will raise an error if the table is unsorted.
+
+**Examples**
+
+.. code-block:: c
+
+    int ret;
+    tsk_table_collection_t tables;
+
+    ret = tsk_table_collection_init(&tables, 0);
+    error_check(ret);
+    tables.sequence_length = 1.0;
+    // Write out the empty tree sequence
+    ret = tsk_table_collection_dump(&tables, "empty.trees", 0);
+    error_check(ret);
+
+@endrst
+
+@param self A pointer to an initialised tsk_table_collection_t object.
+@param filename A NULL terminated string containing the filename.
+@param options Bitwise options. See above for details.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_dump(
+    tsk_table_collection_t *self, const char *filename, tsk_flags_t options);
+
+/**
+@brief Write a table collection to a stream.
+
+@rst
+Writes the data from this table collection to the specified FILE stream.
+Semantics are identical to :c:func:`tsk_table_collection_dump`.
+
+Please see the :ref:`sec_c_api_examples_file_streaming` section for an example
+of how to sequentially dump and load tree sequences from a stream.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_BUILD_INDEXES
+    Do not build indexes for this table before writing to file. This is useful
+    if you wish to write unsorted tables to file, as building the indexes
+    will raise an error if the table is unsorted.
+
+@endrst
+
+@param self A pointer to an initialised tsk_table_collection_t object.
+@param file A FILE stream opened in an appropriate mode for writing (e.g.
+    "w", "a", "r+" or "w+").
+@param options Bitwise options. See above for details.
+@return Return 0 on success or a negative value on failure.
+*/
+
+int tsk_table_collection_dumpf(
+    tsk_table_collection_t *self, FILE *file, tsk_flags_t options);
+
+/**
+@brief Record the number of rows in each table in the specified tsk_bookmark_t object.
+
+@param self A pointer to an initialised tsk_table_collection_t object.
+@param bookmark A pointer to a tsk_bookmark_t which is updated to contain the number of
+    rows in all tables.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_record_num_rows(
+    const tsk_table_collection_t *self, tsk_bookmark_t *bookmark);
+
+/**
+@brief Truncates the tables in this table collection according to the specified bookmark.
+
+@rst
+Truncate the tables in this collection so that each one has the number
+of rows specified in the parameter :c:type:`tsk_bookmark_t`. Use the
+:c:func:`tsk_table_collection_record_num_rows` function to record the
+number rows for each table in a table collection at a particular time.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param bookmark The number of rows to retain in each table.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_truncate(
+    tsk_table_collection_t *self, tsk_bookmark_t *bookmark);
+
+/**
+@brief Sorts the tables in this collection.
+
+@rst
+Some of the tables in a table collection must satisfy specific sortedness requirements
+in order to define a :ref:`valid tree sequence <sec_valid_tree_sequence_requirements>`.
+This method sorts the ``edge``, ``site`` and ``mutation`` tables such that
+these requirements are guaranteed to be fulfilled. The ``individual``,
+``node``, ``population`` and ``provenance`` tables do not have any sortedness
+requirements, and are therefore ignored by this method.
+
+.. note:: The current implementation **may** sort in such a way that exceeds
+    these requirements, but this behaviour should not be relied upon and later
+    versions may weaken the level of sortedness. However, the method does **guarantee**
+    that the resulting tables describes a valid tree sequence.
+
+.. warning:: Sorting migrations is currently not supported and an error will be raised
+    if a table collection containing a non-empty migration table is specified.
+
+The specified :c:type:`tsk_bookmark_t` allows us to specify a start position
+for sorting in each of the tables; rows before this value are assumed to already be
+in sorted order and this information is used to make sorting more efficient.
+Positions in tables that are not sorted (``individual``, ``node``, ``population``
+and ``provenance``) are ignored and can be set to arbitrary values.
+
+.. warning:: The current implementation only supports specifying a start
+    position for the ``edge`` table and in a limited form for the
+    ``site`` and ``mutation`` tables. Specifying a non-zero ``migration``,
+    start position results in an error. The start positions for the
+    ``site`` and ``mutation`` tables can either be 0 or the length of the
+    respective tables, allowing these tables to either be fully sorted, or
+    not sorted at all.
+
+The table collection will always be unindexed after sort successfully completes.
+
+See the :ref:`table sorting <sec_table_sorting>` section for more details.
+For more control over the sorting process, see the
+:ref:`sec_c_api_low_level_sorting` section.
+
+**Options**
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_NO_CHECK_INTEGRITY
+    Do not run integrity checks using
+    :c:func:`tsk_table_collection_check_integrity` before sorting,
+    potentially leading to a small reduction in execution time. This
+    performance optimisation should not be used unless the calling code can
+    guarantee reference integrity within the table collection. References
+    to rows not in the table or bad offsets will result in undefined
+    behaviour.
+
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param start The position to begin sorting in each table; all rows less than this
+    position must fulfill the tree sequence sortedness requirements. If this is
+    NULL, sort all rows.
+@param options Sort options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_sort(
+    tsk_table_collection_t *self, const tsk_bookmark_t *start, tsk_flags_t options);
+
+/**
+@brief Simplify the tables to remove redundant information.
+
+@rst
+Simplification transforms the tables to remove redundancy and canonicalise
+tree sequence data. See the :ref:`simplification <sec_table_simplification>` section for
+more details.
+
+A mapping from the node IDs in the table before simplification to their equivalent
+values after simplification can be obtained via the ``node_map`` argument. If this
+is non NULL, ``node_map[u]`` will contain the new ID for node ``u`` after simplification,
+or ``TSK_NULL`` if the node has been removed. Thus, ``node_map`` must be an array of
+at least ``self->nodes.num_rows`` :c:type:`tsk_id_t` values.
+
+**Options**:
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_FILTER_SITES
+    Remove sites from the output if there are no mutations that reference them.
+TSK_FILTER_POPULATIONS
+    Remove populations from the output if there are no nodes or migrations that
+    reference them.
+TSK_FILTER_INDIVIDUALS
+    Remove individuals from the output if there are no nodes that reference them.
+TSK_REDUCE_TO_SITE_TOPOLOGY
+    Reduce the topological information in the tables to the minimum necessary to
+    represent the trees that contain sites. If there are zero sites this will
+    result in an zero output edges. When the number of sites is greater than zero,
+    every tree in the output tree sequence will contain at least one site.
+    For a given site, the topology of the tree containing that site will be
+    identical (up to node ID remapping) to the topology of the corresponding tree
+    in the input.
+TSK_KEEP_UNARY
+    By default simplify removes unary nodes (i.e., nodes with exactly one child)
+    along the path from samples to root. If this option is specified such unary
+    nodes will be preserved in the output.
+TSK_KEEP_INPUT_ROOTS
+    By default simplify removes all topology ancestral the MRCAs of the samples.
+    This option inserts edges from these MRCAs back to the roots of the input
+    trees.
+
+.. note:: Migrations are currently not supported by simplify, and an error will
+    be raised if we attempt call simplify on a table collection with greater
+    than zero migrations. See `<https://github.com/tskit-dev/tskit/issues/20>`_
+
+The table collection will always be unindexed after simplify successfully
+completes.
+@endrst
+
+@param self A pointer to a tsk_individual_table_t object.
+@param samples Either NULL or an array of num_samples distinct and valid node IDs.
+    If non-null the nodes in this array will be marked as samples in the output.
+    If NULL, the num_samples parameter is ignored and the samples in the output
+    will be the same as the samples in the input. This is equivalent to populating
+    the samples array with all of the sample nodes in the input in increasing
+    order of ID.
+@param num_samples The number of node IDs in the input samples array. Ignored
+    if the samples array is NULL.
+@param options Simplify options; see above for the available bitwise flags.
+    For the default behaviour, a value of 0 should be provided.
+@param node_map If not NULL, this array will be filled to define the mapping
+    between nodes IDs in the table collection before and after simplification.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_simplify(tsk_table_collection_t *self, const tsk_id_t *samples,
+    tsk_size_t num_samples, tsk_flags_t options, tsk_id_t *node_map);
+
+/**
+@brief Subsets and reorders a table collection according to an array of nodes.
+
+@rst
+Reduces the table collection to contain only the entries referring to
+the provided list of nodes, with nodes reordered according to the order
+they appear in the ``nodes`` argument. Specifically, this subsets and reorders
+each of the tables as follows:
+
+1. Nodes: if in the list of nodes, and in the order provided.
+2. Individuals and Populations: if referred to by a retained node,
+   and in the order first seen when traversing the list of retained nodes.
+3. Edges: if both parent and child are retained nodes.
+4. Mutations: if the mutation's node is a retained node.
+5. Sites: if any mutations remain at the site after removing mutations.
+
+Retained edges, mutations, and sites appear in the same
+order as in the original tables.
+
+If ``nodes`` is the entire list of nodes in the tables, then the
+resulting tables will be identical to the original tables, but with
+nodes (and individuals and populations) reordered.
+
+.. note:: Migrations are currently not supported by susbset, and an error will
+    be raised if we attempt call subset on a table collection with greater
+    than zero migrations.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param nodes An array of num_nodes valid node IDs.
+@param num_nodes The number of node IDs in the input nodes array.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_subset(
+    tsk_table_collection_t *self, const tsk_id_t *nodes, tsk_size_t num_nodes);
+
+/**
+@brief Forms the node-wise union of two table collections.
+
+@rst
+Expands this table collection by adding the non-shared portions of another table
+collection to itself. The ``other_node_mapping`` encodes which nodes in ``other`` are
+equivalent to a node in ``self``. The positions in the ``other_node_mapping`` array
+correspond to node ids in ``other``, and the elements encode the equivalent
+node id in ``self`` or TSK_NULL if the node is exclusive to ``other``. Nodes
+that are exclusive ``other`` are added to ``self``, along with:
+
+1. Individuals which are new to ``self``.
+2. Edges whose parent or child are new to ``self``.
+3. Sites which were not present in ``self``.
+4. Mutations whose nodes are new to ``self``.
+
+By default, populations of newly added nodes are assumed to be new populations,
+and added to the population table as well.
+
+This operation will also sort the resulting tables, so the tables may change
+even if nothing new is added, if the original tables were not sorted.
+
+**Options**:
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_UNION_NO_CHECK_SHARED
+    By default, union checks that the portion of shared history between
+    ``self`` and ``other``, as implied by ``other_node_mapping``, are indeed
+    equivalent. It does so by subsetting both ``self`` and ``other`` on the
+    equivalent nodes specified in ``other_node_mapping``, and then checking for
+    equality of the subsets.
+TSK_UNION_NO_ADD_POP
+    By default, all nodes new to ``self`` are assigned new populations. If this
+    option is specified, nodes that are added to ``self`` will retain the
+    population IDs they have in ``other``.
+
+.. note:: Migrations are currently not supported by union, and an error will
+    be raised if we attempt call union on a table collection with migrations.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param other A pointer to a tsk_table_collection_t object.
+@param other_node_mapping An array of node IDs that relate nodes in other to nodes in
+self: the k-th element of other_node_mapping should be the index of the equivalent
+node in self, or TSK_NULL if the node is not present in self (in which case it
+will be added to self).
+@param options Union options; see above for the available bitwise flags.
+    For the default behaviour, a value of 0 should be provided.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_union(tsk_table_collection_t *self,
+    const tsk_table_collection_t *other, const tsk_id_t *other_node_mapping,
+    tsk_flags_t options);
+
+/**
+@brief Set the metadata
+@rst
+Copies the metadata string to this table collection, replacing any existing.
+@endrst
+@param self A pointer to a tsk_table_collection_t object.
+@param metadata A pointer to a char array
+@param metadata_length The size of the metadata in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_set_metadata(
+    tsk_table_collection_t *self, const char *metadata, tsk_size_t metadata_length);
+
+/**
+@brief Set the metadata schema
+@rst
+Copies the metadata schema string to this table collection, replacing any existing.
+@endrst
+@param self A pointer to a tsk_table_collection_t object.
+@param metadata_schema A pointer to a char array
+@param metadata_schema_length The size of the metadata schema in bytes.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_set_metadata_schema(tsk_table_collection_t *self,
+    const char *metadata_schema, tsk_size_t metadata_schema_length);
+
+/**
+@brief Returns true if this table collection is indexed.
+
+@rst
+This method returns true if the table collection has an index
+for the edge table. It guarantees that the index exists, and that
+it is for the same number of edges that are in the edge table. It
+does *not* guarantee that the index is valid (i.e., if the rows
+in the edge have been permuted in some way since the index was built).
+
+See the :ref:`sec_c_api_table_indexes` section for details on the index
+life-cycle.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param options Bitwise options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return true if there is an index present for this table collection.
+*/
+bool tsk_table_collection_has_index(
+    const tsk_table_collection_t *self, tsk_flags_t options);
+
+/**
+@brief Deletes the indexes for this table collection.
+
+@rst
+Unconditionally drop the indexes that may be present for this table collection. It
+is not an error to call this method on an unindexed table collection.
+See the :ref:`sec_c_api_table_indexes` section for details on the index
+life-cycle.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param options Bitwise options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Always returns 0.
+*/
+int tsk_table_collection_drop_index(tsk_table_collection_t *self, tsk_flags_t options);
+
+/**
+@brief Builds indexes for this table collection.
+
+@rst
+Builds the tree traversal :ref:`indexes <sec_table_indexes>` for this table
+collection. Any existing index is first dropped using
+:c:func:`tsk_table_collection_drop_index`. See the
+:ref:`sec_c_api_table_indexes` section for details on the index life-cycle.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param options Bitwise options. Currently unused; should be
+    set to zero to ensure compatibility with later versions of tskit.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_build_index(tsk_table_collection_t *self, tsk_flags_t options);
+
+/**
+@brief Sets the edge insertion/removal index for this table collection
+
+@rst
+This method sets the edge insertion/removal index for this table collection
+The index arrays should have the same number of edges that are in the
+edge table. The index is not checked for validity.
+
+See the :ref:`sec_c_api_table_indexes` section for details on the index
+life-cycle.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param edge_insertion_order Array of tsk_id_t edge ids.
+@param edge_removal_order Array of tsk_id_t edge ids.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_collection_set_indexes(tsk_table_collection_t *self,
+    tsk_id_t *edge_insertion_order, tsk_id_t *edge_removal_order);
+
+/**
+@brief Runs integrity checks on this table collection.
+
+@rst
+
+Checks the integrity of this table collection. The default checks (i.e., with
+options = 0) guarantee the integrity of memory and entity references within the
+table collection. All spatial values (along the genome) are checked
+to see if they are finite values and within the required bounds. Time values
+are checked to see if they are finite or marked as unknown.
+
+To check if a set of tables fulfills the :ref:`requirements
+<sec_valid_tree_sequence_requirements>` needed for a valid tree sequence, use
+the TSK_CHECK_TREES option. When this method is called with TSK_CHECK_TREES,
+the number of trees in the tree sequence is returned. Thus, to check for errors
+client code should verify that the return value is less than zero. All other
+options will return zero on success and a negative value on failure.
+
+More fine-grained checks can be achieved using bitwise combinations of the
+other options.
+
+**Options**:
+
+Options can be specified by providing one or more of the following bitwise
+flags:
+
+TSK_CHECK_EDGE_ORDERING
+    Check edge ordering constraints for a tree sequence.
+TSK_CHECK_SITE_ORDERING
+    Check that sites are in nondecreasing position order.
+TSK_CHECK_SITE_DUPLICATES
+    Check for any duplicate site positions.
+TSK_CHECK_MUTATION_ORDERING
+    Check contraints on the ordering of mutations. Any non-null
+    mutation parents and known times are checked for ordering
+    constraints.
+TSK_CHECK_INDEXES
+    Check that the table indexes exist, and contain valid edge
+    references.
+TSK_CHECK_TREES
+    All checks needed to define a valid tree sequence. Note that
+    this implies all of the above checks.
+
+It is sometimes useful to disregard some parts of the data model
+when performing checks:
+
+TSK_NO_CHECK_POPULATION_REFS
+    Do not check integrity of references to populations. This
+    can be safely combined with the other checks.
+@endrst
+
+@param self A pointer to a tsk_table_collection_t object.
+@param options Bitwise options.
+@return Return a negative error value on if any problems are detected
+   in the tree sequence. If the TSK_CHECK_TREES option is provided,
+   the number of trees in the tree sequence will be returned, on
+   success.
+*/
+tsk_id_t tsk_table_collection_check_integrity(
+    const tsk_table_collection_t *self, tsk_flags_t options);
+
+/** @} */
+
+/* Undocumented methods */
+
+int tsk_table_collection_link_ancestors(tsk_table_collection_t *self, tsk_id_t *samples,
+    tsk_size_t num_samples, tsk_id_t *ancestors, tsk_size_t num_ancestors,
+    tsk_flags_t options, tsk_edge_table_t *result);
+int tsk_table_collection_deduplicate_sites(
+    tsk_table_collection_t *tables, tsk_flags_t options);
+int tsk_table_collection_compute_mutation_parents(
+    tsk_table_collection_t *self, tsk_flags_t options);
+int tsk_table_collection_compute_mutation_times(
+    tsk_table_collection_t *self, double *random, tsk_flags_t TSK_UNUSED(options));
+
+/**
+@defgroup TABLE_SORTER_API_GROUP Low-level table sorter API.
+@{
+*/
+
+/* NOTE: We use the "struct _tsk_table_sorter_t" form here
+ * rather then the usual tsk_table_sorter_t alias because
+ * of problems with Doxygen. This was the only way I could
+ * get it to work - ideally, we'd use the usual typedefs
+ * to avoid confusing people.
+ */
+
+/**
+@brief Initialises the memory for the sorter object.
+
+@rst
+This must be called before any operations are performed on the
+table sorter and initialises all fields. The ``edge_sort`` function
+is set to the default method using qsort. The ``user_data``
+field is set to NULL.
+This method supports the same options as
+:c:func:`tsk_table_collection_sort`.
+
+@endrst
+
+@param self A pointer to an uninitialised tsk_table_sorter_t object.
+@param tables The table collection to sort.
+@param options Sorting options.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_sorter_init(struct _tsk_table_sorter_t *self,
+    tsk_table_collection_t *tables, tsk_flags_t options);
+
+/**
+@brief Runs the sort using the configured functions.
+
+@rst
+Runs the sorting process:
+
+1. Drop the table indexes.
+2. If the ``sort_edges`` function pointer is not NULL, run it. The
+   first parameter to the called function will be a pointer to this
+   table_sorter_t object. The second parameter will be the value
+   ``start.edges``. This specifies the offset at which sorting should
+   start in the edge table. This offset is guaranteed to be within the
+   bounds of the edge table.
+3. Sort the site table, building the mapping between site IDs in the
+   current and sorted tables.
+4. Sort the mutation table.
+
+If an error occurs during the execution of a user-supplied
+sorting function a non-zero value must be returned. This value
+will then be returned by ``tsk_table_sorter_run``. The error
+return value should be chosen to avoid conflicts with tskit error
+codes.
+
+See :c:func:`tsk_table_collection_sort` for details on the ``start`` parameter.
+
+@endrst
+
+@param self A pointer to a tsk_table_sorter_t object.
+@param start The position in the tables at which sorting starts.
+@return Return 0 on success or a negative value on failure.
+*/
+int tsk_table_sorter_run(struct _tsk_table_sorter_t *self, const tsk_bookmark_t *start);
+
+/**
+@brief Free the internal memory for the specified table sorter.
+
+@param self A pointer to an initialised tsk_table_sorter_t object.
+@return Always returns 0.
+*/
+int tsk_table_sorter_free(struct _tsk_table_sorter_t *self);
+
+/** @} */
+
+int tsk_squash_edges(
+    tsk_edge_t *edges, tsk_size_t num_edges, tsk_size_t *num_output_edges);
+
+/* IBD finder API. This is experimental and the interface may change. */
+int tsk_ibd_finder_init(tsk_ibd_finder_t *ibd_finder, tsk_table_collection_t *tables,
+    tsk_id_t *pairs, tsk_size_t num_pairs);
+int tsk_ibd_finder_set_min_length(tsk_ibd_finder_t *self, double min_length);
+int tsk_ibd_finder_set_max_time(tsk_ibd_finder_t *self, double max_time);
+int tsk_ibd_finder_free(tsk_ibd_finder_t *self);
+int tsk_ibd_finder_run(tsk_ibd_finder_t *ibd_finder);
+int tsk_ibd_finder_get_ibd_segments(tsk_ibd_finder_t *ibd_finder, tsk_id_t pair_index,
+    tsk_segment_t **ret_ibd_segments_head);
+void tsk_ibd_finder_print_state(tsk_ibd_finder_t *self, FILE *out);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/subprojects/tskit/tskit/trees.c
+++ b/subprojects/tskit/tskit/trees.c
@@ -1,0 +1,5130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019-2020 Tskit Developers
+ * Copyright (c) 2015-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <math.h>
+#include <assert.h>
+
+#include <tskit/trees.h>
+
+/* ======================================================== *
+ * tree sequence
+ * ======================================================== */
+
+static void
+tsk_treeseq_check_state(const tsk_treeseq_t *self)
+{
+    size_t j;
+    tsk_size_t k, l;
+    tsk_site_t site;
+    tsk_id_t site_id = 0;
+
+    for (j = 0; j < self->num_trees; j++) {
+        for (k = 0; k < self->tree_sites_length[j]; k++) {
+            site = self->tree_sites[j][k];
+            tsk_bug_assert(site.id == site_id);
+            site_id++;
+            for (l = 0; l < site.mutations_length; l++) {
+                tsk_bug_assert(site.mutations[l].site == site.id);
+            }
+        }
+    }
+}
+
+void
+tsk_treeseq_print_state(const tsk_treeseq_t *self, FILE *out)
+{
+    size_t j;
+    tsk_size_t k, l, m;
+    tsk_site_t site;
+
+    fprintf(out, "tree_sequence state\n");
+    fprintf(out, "num_trees = %d\n", (int) self->num_trees);
+    fprintf(out, "samples = (%d)\n", (int) self->num_samples);
+    for (j = 0; j < self->num_samples; j++) {
+        fprintf(out, "\t%d\n", (int) self->samples[j]);
+    }
+    tsk_table_collection_print_state(self->tables, out);
+    fprintf(out, "tree_sites = \n");
+    for (j = 0; j < self->num_trees; j++) {
+        fprintf(out, "tree %d\t%d sites\n", (int) j, self->tree_sites_length[j]);
+        for (k = 0; k < self->tree_sites_length[j]; k++) {
+            site = self->tree_sites[j][k];
+            fprintf(
+                out, "\tsite %d pos = %f ancestral state = ", site.id, site.position);
+            for (l = 0; l < site.ancestral_state_length; l++) {
+                fprintf(out, "%c", site.ancestral_state[l]);
+            }
+            fprintf(out, " %d mutations\n", site.mutations_length);
+            for (l = 0; l < site.mutations_length; l++) {
+                fprintf(out,
+                    "\t\tmutation %d node = %d derived_state = ", site.mutations[l].id,
+                    site.mutations[l].node);
+                for (m = 0; m < site.mutations[l].derived_state_length; m++) {
+                    fprintf(out, "%c", site.mutations[l].derived_state[m]);
+                }
+                fprintf(out, "\n");
+            }
+        }
+    }
+    tsk_treeseq_check_state(self);
+}
+
+int
+tsk_treeseq_free(tsk_treeseq_t *self)
+{
+    if (self->tables != NULL) {
+        tsk_table_collection_free(self->tables);
+    }
+    tsk_safe_free(self->tables);
+    tsk_safe_free(self->samples);
+    tsk_safe_free(self->sample_index_map);
+    tsk_safe_free(self->breakpoints);
+    tsk_safe_free(self->tree_sites);
+    tsk_safe_free(self->tree_sites_length);
+    tsk_safe_free(self->tree_sites_mem);
+    tsk_safe_free(self->site_mutations_mem);
+    tsk_safe_free(self->site_mutations_length);
+    tsk_safe_free(self->site_mutations);
+    tsk_safe_free(self->individual_nodes_mem);
+    tsk_safe_free(self->individual_nodes_length);
+    tsk_safe_free(self->individual_nodes);
+    return 0;
+}
+
+static int
+tsk_treeseq_init_sites(tsk_treeseq_t *self)
+{
+    tsk_id_t j, k;
+    int ret = 0;
+    size_t offset = 0;
+    const tsk_size_t num_mutations = self->tables->mutations.num_rows;
+    const tsk_size_t num_sites = self->tables->sites.num_rows;
+    const tsk_id_t *restrict mutation_site = self->tables->mutations.site;
+
+    self->site_mutations_mem = malloc(num_mutations * sizeof(tsk_mutation_t));
+    self->site_mutations_length = malloc(num_sites * sizeof(tsk_size_t));
+    self->site_mutations = malloc(num_sites * sizeof(tsk_mutation_t *));
+    self->tree_sites_mem = malloc(num_sites * sizeof(tsk_site_t));
+    if (self->site_mutations_mem == NULL || self->site_mutations_length == NULL
+        || self->site_mutations == NULL || self->tree_sites_mem == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    for (k = 0; k < (tsk_id_t) num_mutations; k++) {
+        ret = tsk_treeseq_get_mutation(self, k, self->site_mutations_mem + k);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    k = 0;
+    for (j = 0; j < (tsk_id_t) num_sites; j++) {
+        self->site_mutations[j] = self->site_mutations_mem + offset;
+        self->site_mutations_length[j] = 0;
+        /* Go through all mutations for this site */
+        while (k < (tsk_id_t) num_mutations && mutation_site[k] == j) {
+            self->site_mutations_length[j]++;
+            offset++;
+            k++;
+        }
+        ret = tsk_treeseq_get_site(self, j, self->tree_sites_mem + j);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_treeseq_init_individuals(tsk_treeseq_t *self)
+{
+    int ret = 0;
+    tsk_id_t node;
+    tsk_id_t ind;
+    tsk_size_t offset = 0;
+    tsk_size_t total_node_refs = 0;
+    tsk_size_t *node_count = NULL;
+    tsk_id_t *node_array;
+    const size_t num_inds = self->tables->individuals.num_rows;
+    const size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t *restrict node_individual = self->tables->nodes.individual;
+
+    // First find number of nodes per individual
+    self->individual_nodes_length = calloc(TSK_MAX(1, num_inds), sizeof(tsk_size_t));
+    node_count = calloc(TSK_MAX(1, num_inds), sizeof(size_t));
+
+    if (self->individual_nodes_length == NULL || node_count == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    for (node = 0; node < (tsk_id_t) num_nodes; node++) {
+        ind = node_individual[node];
+        if (ind != TSK_NULL) {
+            self->individual_nodes_length[ind]++;
+            total_node_refs++;
+        }
+    }
+
+    self->individual_nodes_mem
+        = malloc(TSK_MAX(1, total_node_refs) * sizeof(tsk_node_t));
+    self->individual_nodes = malloc(TSK_MAX(1, num_inds) * sizeof(tsk_node_t *));
+    if (self->individual_nodes_mem == NULL || self->individual_nodes == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    /* Now fill in the node IDs */
+    for (ind = 0; ind < (tsk_id_t) num_inds; ind++) {
+        self->individual_nodes[ind] = self->individual_nodes_mem + offset;
+        offset += self->individual_nodes_length[ind];
+    }
+    for (node = 0; node < (tsk_id_t) num_nodes; node++) {
+        ind = node_individual[node];
+        if (ind != TSK_NULL) {
+            node_array = self->individual_nodes[ind];
+            tsk_bug_assert(node_array - self->individual_nodes_mem
+                           < (tsk_id_t)(total_node_refs - node_count[ind]));
+            node_array[node_count[ind]] = node;
+            node_count[ind] += 1;
+        }
+    }
+out:
+    tsk_safe_free(node_count);
+    return ret;
+}
+
+/* Initialises memory associated with the trees.
+ */
+static int
+tsk_treeseq_init_trees(tsk_treeseq_t *self)
+{
+    int ret = TSK_ERR_GENERIC;
+    size_t j, k, tree_index;
+    tsk_id_t site;
+    double tree_left, tree_right;
+    const double sequence_length = self->tables->sequence_length;
+    const tsk_id_t num_sites = (tsk_id_t) self->tables->sites.num_rows;
+    const size_t num_edges = self->tables->edges.num_rows;
+    const double *restrict site_position = self->tables->sites.position;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_right = self->tables->edges.right;
+    const double *restrict edge_left = self->tables->edges.left;
+    /* Avoid malloc(0) */
+    size_t num_trees_alloc = self->num_trees + 1;
+
+    self->tree_sites_length = malloc(num_trees_alloc * sizeof(*self->tree_sites_length));
+    self->tree_sites = malloc(num_trees_alloc * sizeof(*self->tree_sites));
+    self->breakpoints = malloc(num_trees_alloc * sizeof(*self->breakpoints));
+    if (self->tree_sites == NULL || self->tree_sites_length == NULL
+        || self->breakpoints == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(
+        self->tree_sites_length, 0, self->num_trees * sizeof(*self->tree_sites_length));
+    memset(self->tree_sites, 0, self->num_trees * sizeof(*self->tree_sites));
+
+    tree_left = 0;
+    tree_right = sequence_length;
+    tree_index = 0;
+    site = 0;
+    j = 0;
+    k = 0;
+    while (j < num_edges || tree_left < sequence_length) {
+        self->breakpoints[tree_index] = tree_left;
+        while (k < num_edges && edge_right[O[k]] == tree_left) {
+            k++;
+        }
+        while (j < num_edges && edge_left[I[j]] == tree_left) {
+            j++;
+        }
+        tree_right = sequence_length;
+        if (j < num_edges) {
+            tree_right = TSK_MIN(tree_right, edge_left[I[j]]);
+        }
+        if (k < num_edges) {
+            tree_right = TSK_MIN(tree_right, edge_right[O[k]]);
+        }
+        self->tree_sites[tree_index] = self->tree_sites_mem + site;
+        while (site < num_sites && site_position[site] < tree_right) {
+            self->tree_sites_length[tree_index]++;
+            site++;
+        }
+        tree_left = tree_right;
+        tree_index++;
+    }
+    tsk_bug_assert(site == num_sites);
+    tsk_bug_assert(tree_index == self->num_trees);
+    self->breakpoints[tree_index] = tree_right;
+    ret = 0;
+out:
+    return ret;
+}
+
+static int
+tsk_treeseq_init_nodes(tsk_treeseq_t *self)
+{
+    size_t j, k;
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const uint32_t *restrict node_flags = self->tables->nodes.flags;
+    int ret = 0;
+
+    /* Determine the sample size */
+    self->num_samples = 0;
+    for (j = 0; j < num_nodes; j++) {
+        if (!!(node_flags[j] & TSK_NODE_IS_SAMPLE)) {
+            self->num_samples++;
+        }
+    }
+    /* TODO raise an error if < 2 samples?? */
+    self->samples = malloc(self->num_samples * sizeof(tsk_id_t));
+    self->sample_index_map = malloc(num_nodes * sizeof(tsk_id_t));
+    if (self->samples == NULL || self->sample_index_map == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    k = 0;
+    for (j = 0; j < num_nodes; j++) {
+        self->sample_index_map[j] = -1;
+        if (!!(node_flags[j] & TSK_NODE_IS_SAMPLE)) {
+            self->samples[k] = (tsk_id_t) j;
+            self->sample_index_map[j] = (tsk_id_t) k;
+            k++;
+        }
+    }
+    tsk_bug_assert(k == self->num_samples);
+out:
+    return ret;
+}
+
+/* TODO we need flags to be able to control how the input table is used.
+ * - The default behaviour is to take a copy. TSK_BUILD_INDEXES is allowed
+ *   in this case because we have an independent copy.
+ * - Need an option to take 'ownership' of the tables so that we keep the
+ *   tables and free them at the end of the treeseq's lifetime. This will be
+ *   used in tsk_treeseq_load below where we can avoid copying the tree sequence.
+ * - We should also allow a read-only "borrowed reference" where we use the
+ *   tables directly, but don't free it at the end.
+ */
+int TSK_WARN_UNUSED
+tsk_treeseq_init(
+    tsk_treeseq_t *self, const tsk_table_collection_t *tables, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_id_t num_trees;
+
+    memset(self, 0, sizeof(*self));
+    if (tables == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    self->tables = malloc(sizeof(*self->tables));
+    if (self->tables == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    /* Note that this copy reinstates metadata for a table collection with
+     * TSK_NO_EDGE_METADATA. Otherwise a table without metadata would
+     * crash tsk_diff_iter_next. This is something we will need to
+     * watch out for when we take a read-only view of the input table
+     * rather than a copy. */
+    ret = tsk_table_collection_copy(tables, self->tables, 0);
+
+    if (ret != 0) {
+        goto out;
+    }
+    if (!!(options & TSK_BUILD_INDEXES)) {
+        ret = tsk_table_collection_build_index(self->tables, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    num_trees = tsk_table_collection_check_integrity(self->tables, TSK_CHECK_TREES);
+    if (num_trees < 0) {
+        ret = (int) num_trees;
+        goto out;
+    }
+    self->num_trees = (tsk_size_t) num_trees;
+
+    /* This is a hack to workaround the fact we're copying the tables here.
+     * In general, we don't want the file_uuid to be copied, as this should
+     * only be present if the tables are genuinely backed by a file and in
+     * read-only mode (which we also need to do). So, we copy the file_uuid
+     * into the local copy of the table for now until we have proper read-only
+     * access to the tables set up, where any attempts to modify the tables
+     * will fail. */
+    if (tables->file_uuid != NULL) {
+        self->tables->file_uuid = malloc(TSK_UUID_SIZE + 1);
+        if (self->tables->file_uuid == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+        memcpy(self->tables->file_uuid, tables->file_uuid, TSK_UUID_SIZE + 1);
+    }
+
+    ret = tsk_treeseq_init_nodes(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_init_sites(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_init_individuals(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_init_trees(self);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_copy_tables(
+    const tsk_treeseq_t *self, tsk_table_collection_t *tables, tsk_flags_t options)
+{
+    return tsk_table_collection_copy(self->tables, tables, options);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_load(
+    tsk_treeseq_t *self, const char *filename, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_table_collection_t tables;
+
+    /* Need to make sure that we're zero'd out in case of error */
+    memset(self, 0, sizeof(*self));
+    ret = tsk_table_collection_load(&tables, filename, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    /* TODO the implementation is wasteful here, as we don't need to allocate
+     * a new table here but could load directly into the main table instead.
+     * See notes on the owned reference for treeseq_alloc above.
+     */
+    ret = tsk_treeseq_init(self, &tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    tsk_table_collection_free(&tables);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_loadf(tsk_treeseq_t *self, FILE *file, tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_table_collection_t tables;
+
+    /* Need to make sure that we're zero'd out in case of error */
+    memset(self, 0, sizeof(*self));
+    ret = tsk_table_collection_loadf(&tables, file, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    /* TODO the implementation is wasteful here, as we don't need to allocate
+     * a new table here but could load directly into the main table instead.
+     * See notes on the owned reference for treeseq_alloc above.
+     */
+    ret = tsk_treeseq_init(self, &tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    tsk_table_collection_free(&tables);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_dump(tsk_treeseq_t *self, const char *filename, tsk_flags_t options)
+{
+    return tsk_table_collection_dump(self->tables, filename, options);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_dumpf(tsk_treeseq_t *self, FILE *file, tsk_flags_t options)
+{
+    return tsk_table_collection_dumpf(self->tables, file, options);
+}
+
+/* Simple attribute getters */
+
+const char *
+tsk_treeseq_get_metadata(const tsk_treeseq_t *self)
+{
+    return self->tables->metadata;
+}
+
+tsk_size_t
+tsk_treeseq_get_metadata_length(const tsk_treeseq_t *self)
+{
+    return self->tables->metadata_length;
+}
+
+const char *
+tsk_treeseq_get_metadata_schema(const tsk_treeseq_t *self)
+{
+    return self->tables->metadata_schema;
+}
+
+tsk_size_t
+tsk_treeseq_get_metadata_schema_length(const tsk_treeseq_t *self)
+{
+    return self->tables->metadata_schema_length;
+}
+
+double
+tsk_treeseq_get_sequence_length(const tsk_treeseq_t *self)
+{
+    return self->tables->sequence_length;
+}
+
+const char *
+tsk_treeseq_get_file_uuid(const tsk_treeseq_t *self)
+{
+    return self->tables->file_uuid;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_samples(const tsk_treeseq_t *self)
+{
+    return self->num_samples;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_nodes(const tsk_treeseq_t *self)
+{
+    return self->tables->nodes.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_edges(const tsk_treeseq_t *self)
+{
+    return self->tables->edges.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_migrations(const tsk_treeseq_t *self)
+{
+    return self->tables->migrations.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_sites(const tsk_treeseq_t *self)
+{
+    return self->tables->sites.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_mutations(const tsk_treeseq_t *self)
+{
+    return self->tables->mutations.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_populations(const tsk_treeseq_t *self)
+{
+    return self->tables->populations.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_individuals(const tsk_treeseq_t *self)
+{
+    return self->tables->individuals.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_provenances(const tsk_treeseq_t *self)
+{
+    return self->tables->provenances.num_rows;
+}
+
+tsk_size_t
+tsk_treeseq_get_num_trees(const tsk_treeseq_t *self)
+{
+    return self->num_trees;
+}
+
+const double *
+tsk_treeseq_get_breakpoints(const tsk_treeseq_t *self)
+{
+    return self->breakpoints;
+}
+
+const tsk_id_t *
+tsk_treeseq_get_samples(const tsk_treeseq_t *self)
+{
+    return self->samples;
+}
+
+const tsk_id_t *
+tsk_treeseq_get_sample_index_map(const tsk_treeseq_t *self)
+{
+    return self->sample_index_map;
+}
+
+bool
+tsk_treeseq_is_sample(const tsk_treeseq_t *self, tsk_id_t u)
+{
+    bool ret = false;
+
+    if (u >= 0 && u < (tsk_id_t) self->tables->nodes.num_rows) {
+        ret = !!(self->tables->nodes.flags[u] & TSK_NODE_IS_SAMPLE);
+    }
+    return ret;
+}
+
+/* Stats functions */
+
+#define GET_2D_ROW(array, row_len, row) (array + (((size_t)(row_len)) * (size_t) row))
+
+static inline double *
+GET_3D_ROW(
+    double *base, size_t num_nodes, size_t output_dim, size_t window_index, tsk_id_t u)
+{
+    size_t offset = window_index * num_nodes * output_dim + ((size_t) u) * output_dim;
+    return base + offset;
+}
+
+/* Increments the n-dimensional array with the specified shape by the specified value at
+ * the specified coordinate. */
+static inline void
+increment_nd_array_value(double *array, tsk_size_t n, const tsk_size_t *shape,
+    const tsk_size_t *coordinate, double value)
+{
+    size_t offset = 0;
+    size_t product = 1;
+    int k;
+
+    for (k = (int) n - 1; k >= 0; k--) {
+        tsk_bug_assert(coordinate[k] < shape[k]);
+        offset += coordinate[k] * product;
+        product *= shape[k];
+    }
+    array[offset] += value;
+}
+
+/* TODO flatten the reference sets input here and follow the same pattern used
+ * in diversity, divergence, etc. */
+int TSK_WARN_UNUSED
+tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
+    const tsk_id_t *focal, size_t num_focal, const tsk_id_t *const *reference_sets,
+    const size_t *reference_set_size, size_t num_reference_sets,
+    tsk_flags_t TSK_UNUSED(options), double *ret_array)
+{
+    int ret = 0;
+    tsk_id_t u, v, p;
+    size_t j;
+    /* TODO It's probably not worth bothering with the int16_t here. */
+    int16_t k, focal_reference_set;
+    /* We use the K'th element of the array for the total. */
+    const int16_t K = (int16_t)(num_reference_sets + 1);
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_left = self->tables->edges.left;
+    const double *restrict edge_right = self->tables->edges.right;
+    const tsk_id_t *restrict edge_parent = self->tables->edges.parent;
+    const tsk_id_t *restrict edge_child = self->tables->edges.child;
+    const double sequence_length = self->tables->sequence_length;
+    tsk_id_t tj, tk, h;
+    double left, right, *A_row, scale, tree_length;
+    tsk_id_t *restrict parent = malloc(num_nodes * sizeof(*parent));
+    double *restrict length = calloc(num_focal, sizeof(*length));
+    uint32_t *restrict ref_count = calloc(((size_t) K) * num_nodes, sizeof(*ref_count));
+    int16_t *restrict reference_set_map = malloc(num_nodes * sizeof(*reference_set_map));
+    uint32_t *restrict row = NULL;
+    uint32_t *restrict child_row = NULL;
+    uint32_t total, delta;
+
+    /* We support a max of 8K focal sets */
+    if (num_reference_sets == 0 || num_reference_sets > (INT16_MAX - 1)) {
+        /* TODO: more specific error */
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if (parent == NULL || ref_count == NULL || reference_set_map == NULL
+        || length == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    memset(parent, 0xff, num_nodes * sizeof(*parent));
+    memset(reference_set_map, 0xff, num_nodes * sizeof(*reference_set_map));
+    memset(ret_array, 0, num_focal * num_reference_sets * sizeof(*ret_array));
+
+    total = 0; /* keep the compiler happy */
+
+    /* Set the initial conditions and check the input. */
+    for (k = 0; k < (int16_t) num_reference_sets; k++) {
+        for (j = 0; j < reference_set_size[k]; j++) {
+            u = reference_sets[k][j];
+            if (u < 0 || u >= (tsk_id_t) num_nodes) {
+                ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+                goto out;
+            }
+            if (reference_set_map[u] != TSK_NULL) {
+                /* FIXME Technically inaccurate here: duplicate focal not sample */
+                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                goto out;
+            }
+            reference_set_map[u] = k;
+            row = GET_2D_ROW(ref_count, K, u);
+            row[k] = 1;
+            /* Also set the count for the total among all sets */
+            row[K - 1] = 1;
+        }
+    }
+    for (j = 0; j < num_focal; j++) {
+        u = focal[j];
+        if (u < 0 || u >= (tsk_id_t) num_nodes) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+    }
+
+    /* Iterate over the trees */
+    tj = 0;
+    tk = 0;
+    left = 0;
+    while (tj < num_edges || left < sequence_length) {
+        while (tk < num_edges && edge_right[O[tk]] == left) {
+            h = O[tk];
+            tk++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = TSK_NULL;
+            child_row = GET_2D_ROW(ref_count, K, u);
+            while (v != TSK_NULL) {
+                row = GET_2D_ROW(ref_count, K, v);
+                for (k = 0; k < K; k++) {
+                    row[k] -= child_row[k];
+                }
+                v = parent[v];
+            }
+        }
+        while (tj < num_edges && edge_left[I[tj]] == left) {
+            h = I[tj];
+            tj++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = v;
+            child_row = GET_2D_ROW(ref_count, K, u);
+            while (v != TSK_NULL) {
+                row = GET_2D_ROW(ref_count, K, v);
+                for (k = 0; k < K; k++) {
+                    row[k] += child_row[k];
+                }
+                v = parent[v];
+            }
+        }
+        right = sequence_length;
+        if (tj < num_edges) {
+            right = TSK_MIN(right, edge_left[I[tj]]);
+        }
+        if (tk < num_edges) {
+            right = TSK_MIN(right, edge_right[O[tk]]);
+        }
+
+        tree_length = right - left;
+        /* Process this tree */
+        for (j = 0; j < num_focal; j++) {
+            u = focal[j];
+            focal_reference_set = reference_set_map[u];
+            delta = focal_reference_set != -1;
+            p = u;
+            while (p != TSK_NULL) {
+                row = GET_2D_ROW(ref_count, K, p);
+                total = row[K - 1];
+                if (total > delta) {
+                    break;
+                }
+                p = parent[p];
+            }
+            if (p != TSK_NULL) {
+                length[j] += tree_length;
+                scale = tree_length / (total - delta);
+                A_row = GET_2D_ROW(ret_array, num_reference_sets, j);
+                for (k = 0; k < K - 1; k++) {
+                    A_row[k] += row[k] * scale;
+                }
+                if (focal_reference_set != -1) {
+                    /* Remove the contribution for the reference set u belongs to and
+                     * insert the correct value. The long-hand version is
+                     * A_row[k] = A_row[k] - row[k] * scale + (row[k] - 1) * scale;
+                     * which cancels to give: */
+                    A_row[focal_reference_set] -= scale;
+                }
+            }
+        }
+
+        /* Move on to the next tree */
+        left = right;
+    }
+
+    /* Divide by the accumulated length for each node to normalise */
+    for (j = 0; j < num_focal; j++) {
+        A_row = GET_2D_ROW(ret_array, num_reference_sets, j);
+        if (length[j] > 0) {
+            for (k = 0; k < K - 1; k++) {
+                A_row[k] /= length[j];
+            }
+        }
+    }
+out:
+    /* Can't use msp_safe_free here because of restrict */
+    if (parent != NULL) {
+        free(parent);
+    }
+    if (ref_count != NULL) {
+        free(ref_count);
+    }
+    if (reference_set_map != NULL) {
+        free(reference_set_map);
+    }
+    if (length != NULL) {
+        free(length);
+    }
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
+    const tsk_id_t *const *reference_sets, const size_t *reference_set_size,
+    size_t num_reference_sets, tsk_flags_t TSK_UNUSED(options), double *ret_array)
+{
+    int ret = 0;
+    tsk_id_t u, v;
+    size_t j;
+    int32_t k;
+    /* We use the K'th element of the array for the total. */
+    const int32_t K = (int32_t)(num_reference_sets + 1);
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_left = self->tables->edges.left;
+    const double *restrict edge_right = self->tables->edges.right;
+    const tsk_id_t *restrict edge_parent = self->tables->edges.parent;
+    const tsk_id_t *restrict edge_child = self->tables->edges.child;
+    const double sequence_length = self->tables->sequence_length;
+    tsk_id_t tj, tk, h;
+    double left, right, length, *restrict C_row;
+    tsk_id_t *restrict parent = malloc(num_nodes * sizeof(*parent));
+    uint32_t *restrict ref_count = calloc(num_nodes * ((size_t) K), sizeof(*ref_count));
+    double *restrict last_update = calloc(num_nodes, sizeof(*last_update));
+    double *restrict total_length = calloc(num_nodes, sizeof(*total_length));
+    uint32_t *restrict row, *restrict child_row;
+
+    if (num_reference_sets == 0 || num_reference_sets > (INT32_MAX - 1)) {
+        /* TODO: more specific error */
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if (parent == NULL || ref_count == NULL || last_update == NULL
+        || total_length == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    /* TODO add check for duplicate values in the reference sets */
+
+    memset(parent, 0xff, num_nodes * sizeof(*parent));
+    memset(ret_array, 0, num_nodes * num_reference_sets * sizeof(*ret_array));
+
+    /* Set the initial conditions and check the input. */
+    for (k = 0; k < (int32_t) num_reference_sets; k++) {
+        for (j = 0; j < reference_set_size[k]; j++) {
+            u = reference_sets[k][j];
+            if (u < 0 || u >= (tsk_id_t) num_nodes) {
+                ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+                goto out;
+            }
+            row = GET_2D_ROW(ref_count, K, u);
+            row[k] = 1;
+            /* Also set the count for the total among all sets */
+            row[K - 1] = 1;
+        }
+    }
+
+    /* Iterate over the trees */
+    tj = 0;
+    tk = 0;
+    left = 0;
+    while (tj < num_edges || left < sequence_length) {
+        while (tk < num_edges && edge_right[O[tk]] == left) {
+            h = O[tk];
+            tk++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = TSK_NULL;
+            child_row = GET_2D_ROW(ref_count, K, u);
+            while (v != TSK_NULL) {
+                row = GET_2D_ROW(ref_count, K, v);
+                if (last_update[v] != left) {
+                    if (row[K - 1] > 0) {
+                        length = left - last_update[v];
+                        C_row = GET_2D_ROW(ret_array, num_reference_sets, v);
+                        for (k = 0; k < (int32_t) num_reference_sets; k++) {
+                            C_row[k] += length * row[k];
+                        }
+                        total_length[v] += length;
+                    }
+                    last_update[v] = left;
+                }
+                for (k = 0; k < K; k++) {
+                    row[k] -= child_row[k];
+                }
+                v = parent[v];
+            }
+        }
+        while (tj < num_edges && edge_left[I[tj]] == left) {
+            h = I[tj];
+            tj++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = v;
+            child_row = GET_2D_ROW(ref_count, K, u);
+            while (v != TSK_NULL) {
+                row = GET_2D_ROW(ref_count, K, v);
+                if (last_update[v] != left) {
+                    if (row[K - 1] > 0) {
+                        length = left - last_update[v];
+                        C_row = GET_2D_ROW(ret_array, num_reference_sets, v);
+                        for (k = 0; k < (int32_t) num_reference_sets; k++) {
+                            C_row[k] += length * row[k];
+                        }
+                        total_length[v] += length;
+                    }
+                    last_update[v] = left;
+                }
+                for (k = 0; k < K; k++) {
+                    row[k] += child_row[k];
+                }
+                v = parent[v];
+            }
+        }
+        right = sequence_length;
+        if (tj < num_edges) {
+            right = TSK_MIN(right, edge_left[I[tj]]);
+        }
+        if (tk < num_edges) {
+            right = TSK_MIN(right, edge_right[O[tk]]);
+        }
+        left = right;
+    }
+
+    /* Add the stats for the last tree and divide by the total length that
+     * each node was an ancestor to > 0 of the reference nodes. */
+    for (v = 0; v < (tsk_id_t) num_nodes; v++) {
+        row = GET_2D_ROW(ref_count, K, v);
+        C_row = GET_2D_ROW(ret_array, num_reference_sets, v);
+        if (row[K - 1] > 0) {
+            length = sequence_length - last_update[v];
+            total_length[v] += length;
+            for (k = 0; k < (int32_t) num_reference_sets; k++) {
+                C_row[k] += length * row[k];
+            }
+        }
+        if (total_length[v] > 0) {
+            length = total_length[v];
+            for (k = 0; k < (int32_t) num_reference_sets; k++) {
+                C_row[k] /= length;
+            }
+        }
+    }
+
+out:
+    /* Can't use msp_safe_free here because of restrict */
+    if (parent != NULL) {
+        free(parent);
+    }
+    if (ref_count != NULL) {
+        free(ref_count);
+    }
+    if (last_update != NULL) {
+        free(last_update);
+    }
+    if (total_length != NULL) {
+        free(total_length);
+    }
+    return ret;
+}
+
+/***********************************
+ * General stats framework
+ ***********************************/
+
+static int
+tsk_treeseq_check_windows(
+    const tsk_treeseq_t *self, size_t num_windows, const double *windows)
+{
+    int ret = TSK_ERR_BAD_WINDOWS;
+    size_t j;
+
+    if (num_windows < 1) {
+        ret = TSK_ERR_BAD_NUM_WINDOWS;
+        goto out;
+    }
+    /* TODO these restrictions can be lifted later if we want a specific interval. */
+    if (windows[0] != 0) {
+        goto out;
+    }
+    if (windows[num_windows] != self->tables->sequence_length) {
+        goto out;
+    }
+    for (j = 0; j < num_windows; j++) {
+        if (windows[j] >= windows[j + 1]) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+/* TODO make these functions more consistent in how the arguments are ordered */
+
+static inline void
+update_state(double *X, size_t state_dim, tsk_id_t dest, tsk_id_t source, int sign)
+{
+    size_t k;
+    double *X_dest = GET_2D_ROW(X, state_dim, dest);
+    double *X_source = GET_2D_ROW(X, state_dim, source);
+
+    for (k = 0; k < state_dim; k++) {
+        X_dest[k] += sign * X_source[k];
+    }
+}
+
+static inline int
+update_node_summary(tsk_id_t u, size_t result_dim, double *node_summary, double *X,
+    size_t state_dim, general_stat_func_t *f, void *f_params)
+{
+    double *X_u = GET_2D_ROW(X, state_dim, u);
+    double *summary_u = GET_2D_ROW(node_summary, result_dim, u);
+
+    return f(state_dim, X_u, result_dim, summary_u, f_params);
+}
+
+static inline void
+update_running_sum(tsk_id_t u, double sign, const double *restrict branch_length,
+    const double *summary, size_t result_dim, double *running_sum)
+{
+    const double *summary_u = GET_2D_ROW(summary, result_dim, u);
+    const double x = sign * branch_length[u];
+    size_t m;
+
+    for (m = 0; m < result_dim; m++) {
+        running_sum[m] += x * summary_u[m];
+    }
+}
+
+static int
+tsk_treeseq_branch_general_stat(const tsk_treeseq_t *self, size_t state_dim,
+    const double *sample_weights, size_t result_dim, general_stat_func_t *f,
+    void *f_params, size_t num_windows, const double *windows, double *result,
+    tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_id_t u, v;
+    size_t j, k, tree_index, window_index;
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_left = self->tables->edges.left;
+    const double *restrict edge_right = self->tables->edges.right;
+    const tsk_id_t *restrict edge_parent = self->tables->edges.parent;
+    const tsk_id_t *restrict edge_child = self->tables->edges.child;
+    const double *restrict time = self->tables->nodes.time;
+    const double sequence_length = self->tables->sequence_length;
+    tsk_id_t *restrict parent = malloc(num_nodes * sizeof(*parent));
+    double *restrict branch_length = calloc(num_nodes, sizeof(*branch_length));
+    tsk_id_t tj, tk, h;
+    double t_left, t_right, w_left, w_right, left, right, scale;
+    const double *weight_u;
+    double *state_u, *result_row, *summary_u;
+    double *state = calloc(num_nodes * state_dim, sizeof(*state));
+    double *summary = calloc(num_nodes * result_dim, sizeof(*summary));
+    double *running_sum = calloc(result_dim, sizeof(*running_sum));
+
+    if (parent == NULL || branch_length == NULL || state == NULL || running_sum == NULL
+        || summary == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, num_nodes * sizeof(*parent));
+
+    /* Set the initial conditions */
+    for (j = 0; j < self->num_samples; j++) {
+        u = self->samples[j];
+        state_u = GET_2D_ROW(state, state_dim, u);
+        weight_u = GET_2D_ROW(sample_weights, state_dim, j);
+        memcpy(state_u, weight_u, state_dim * sizeof(*state_u));
+        summary_u = GET_2D_ROW(summary, result_dim, u);
+        ret = f(state_dim, state_u, result_dim, summary_u, f_params);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    memset(result, 0, num_windows * result_dim * sizeof(*result));
+
+    /* Iterate over the trees */
+    tj = 0;
+    tk = 0;
+    t_left = 0;
+    tree_index = 0;
+    window_index = 0;
+    while (tj < num_edges || t_left < sequence_length) {
+        while (tk < num_edges && edge_right[O[tk]] == t_left) {
+            h = O[tk];
+            tk++;
+
+            u = edge_child[h];
+            update_running_sum(u, -1, branch_length, summary, result_dim, running_sum);
+            parent[u] = TSK_NULL;
+            branch_length[u] = 0;
+
+            u = edge_parent[h];
+            while (u != TSK_NULL) {
+                update_running_sum(
+                    u, -1, branch_length, summary, result_dim, running_sum);
+                update_state(state, state_dim, u, edge_child[h], -1);
+                ret = update_node_summary(
+                    u, result_dim, summary, state, state_dim, f, f_params);
+                if (ret != 0) {
+                    goto out;
+                }
+                update_running_sum(
+                    u, +1, branch_length, summary, result_dim, running_sum);
+                u = parent[u];
+            }
+        }
+
+        while (tj < num_edges && edge_left[I[tj]] == t_left) {
+            h = I[tj];
+            tj++;
+
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = v;
+            branch_length[u] = time[v] - time[u];
+            update_running_sum(u, +1, branch_length, summary, result_dim, running_sum);
+
+            u = v;
+            while (u != TSK_NULL) {
+                update_running_sum(
+                    u, -1, branch_length, summary, result_dim, running_sum);
+                update_state(state, state_dim, u, edge_child[h], +1);
+                ret = update_node_summary(
+                    u, result_dim, summary, state, state_dim, f, f_params);
+                if (ret != 0) {
+                    goto out;
+                }
+                update_running_sum(
+                    u, +1, branch_length, summary, result_dim, running_sum);
+                u = parent[u];
+            }
+        }
+
+        t_right = sequence_length;
+        if (tj < num_edges) {
+            t_right = TSK_MIN(t_right, edge_left[I[tj]]);
+        }
+        if (tk < num_edges) {
+            t_right = TSK_MIN(t_right, edge_right[O[tk]]);
+        }
+
+        while (windows[window_index] < t_right) {
+            tsk_bug_assert(window_index < num_windows);
+            w_left = windows[window_index];
+            w_right = windows[window_index + 1];
+            left = TSK_MAX(t_left, w_left);
+            right = TSK_MIN(t_right, w_right);
+            scale = (right - left);
+            tsk_bug_assert(scale > 0);
+            result_row = GET_2D_ROW(result, result_dim, window_index);
+            for (k = 0; k < result_dim; k++) {
+                result_row[k] += running_sum[k] * scale;
+            }
+
+            if (w_right <= t_right) {
+                window_index++;
+            } else {
+                /* This interval crosses a tree boundary, so we update it again in the */
+                /* for the next tree */
+                break;
+            }
+        }
+        /* Move to the next tree */
+        t_left = t_right;
+        tree_index++;
+    }
+    tsk_bug_assert(window_index == num_windows);
+out:
+    /* Can't use msp_safe_free here because of restrict */
+    if (parent != NULL) {
+        free(parent);
+    }
+    if (branch_length != NULL) {
+        free(branch_length);
+    }
+    tsk_safe_free(state);
+    tsk_safe_free(summary);
+    tsk_safe_free(running_sum);
+    return ret;
+}
+
+static int
+get_allele_weights(const tsk_site_t *site, const double *state, size_t state_dim,
+    const double *total_weight, tsk_size_t *ret_num_alleles, double **ret_allele_states)
+{
+    int ret = 0;
+    size_t k;
+    tsk_mutation_t mutation, parent_mut;
+    tsk_size_t mutation_index, allele, num_alleles, alt_allele_length;
+    /* The allele table */
+    size_t max_alleles = site->mutations_length + 1;
+    const char **alleles = malloc(max_alleles * sizeof(*alleles));
+    tsk_size_t *allele_lengths = calloc(max_alleles, sizeof(*allele_lengths));
+    double *allele_states = calloc(max_alleles * state_dim, sizeof(*allele_states));
+    double *allele_row;
+    const double *state_row;
+    const char *alt_allele;
+
+    if (alleles == NULL || allele_lengths == NULL || allele_states == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    tsk_bug_assert(state != NULL);
+    alleles[0] = site->ancestral_state;
+    allele_lengths[0] = site->ancestral_state_length;
+    memcpy(allele_states, total_weight, state_dim * sizeof(*allele_states));
+    num_alleles = 1;
+
+    for (mutation_index = 0; mutation_index < site->mutations_length; mutation_index++) {
+        mutation = site->mutations[mutation_index];
+        /* Compute the allele index for this derived state value. */
+        allele = 0;
+        while (allele < num_alleles) {
+            if (mutation.derived_state_length == allele_lengths[allele]
+                && memcmp(
+                       mutation.derived_state, alleles[allele], allele_lengths[allele])
+                       == 0) {
+                break;
+            }
+            allele++;
+        }
+        if (allele == num_alleles) {
+            tsk_bug_assert(allele < max_alleles);
+            alleles[allele] = mutation.derived_state;
+            allele_lengths[allele] = mutation.derived_state_length;
+            num_alleles++;
+        }
+
+        /* Add the state for the the mutation's node to this allele */
+        state_row = GET_2D_ROW(state, state_dim, mutation.node);
+        allele_row = GET_2D_ROW(allele_states, state_dim, allele);
+        for (k = 0; k < state_dim; k++) {
+            allele_row[k] += state_row[k];
+        }
+
+        /* Get the index for the alternate allele that we must substract from */
+        alt_allele = site->ancestral_state;
+        alt_allele_length = site->ancestral_state_length;
+        if (mutation.parent != TSK_NULL) {
+            parent_mut = site->mutations[mutation.parent - site->mutations[0].id];
+            alt_allele = parent_mut.derived_state;
+            alt_allele_length = parent_mut.derived_state_length;
+        }
+        allele = 0;
+        while (allele < num_alleles) {
+            if (alt_allele_length == allele_lengths[allele]
+                && memcmp(alt_allele, alleles[allele], allele_lengths[allele]) == 0) {
+                break;
+            }
+            allele++;
+        }
+        tsk_bug_assert(allele < num_alleles);
+
+        allele_row = GET_2D_ROW(allele_states, state_dim, allele);
+        for (k = 0; k < state_dim; k++) {
+            allele_row[k] -= state_row[k];
+        }
+    }
+    *ret_num_alleles = num_alleles;
+    *ret_allele_states = allele_states;
+    allele_states = NULL;
+out:
+    tsk_safe_free(alleles);
+    tsk_safe_free(allele_lengths);
+    tsk_safe_free(allele_states);
+    return ret;
+}
+
+static int
+compute_general_stat_site_result(tsk_site_t *site, double *state, size_t state_dim,
+    size_t result_dim, general_stat_func_t *f, void *f_params, double *total_weight,
+    bool polarised, double *result)
+{
+    int ret = 0;
+    size_t k;
+    tsk_size_t allele, num_alleles;
+    double *allele_states;
+    double *result_tmp = calloc(result_dim, sizeof(*result_tmp));
+
+    if (result_tmp == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(result, 0, result_dim * sizeof(*result));
+
+    ret = get_allele_weights(
+        site, state, state_dim, total_weight, &num_alleles, &allele_states);
+    if (ret != 0) {
+        goto out;
+    }
+    /* Sum over the allele weights. Skip the ancestral state if this is a polarised stat
+     */
+    for (allele = polarised ? 1 : 0; allele < num_alleles; allele++) {
+        ret = f(state_dim, GET_2D_ROW(allele_states, state_dim, allele), result_dim,
+            result_tmp, f_params);
+        if (ret != 0) {
+            goto out;
+        }
+        for (k = 0; k < result_dim; k++) {
+            result[k] += result_tmp[k];
+        }
+    }
+out:
+    tsk_safe_free(result_tmp);
+    tsk_safe_free(allele_states);
+    return ret;
+}
+
+static int
+tsk_treeseq_site_general_stat(const tsk_treeseq_t *self, size_t state_dim,
+    const double *sample_weights, size_t result_dim, general_stat_func_t *f,
+    void *f_params, size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_id_t u, v;
+    size_t j, k, tree_site, tree_index, window_index;
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_left = self->tables->edges.left;
+    const double *restrict edge_right = self->tables->edges.right;
+    const tsk_id_t *restrict edge_parent = self->tables->edges.parent;
+    const tsk_id_t *restrict edge_child = self->tables->edges.child;
+    const double sequence_length = self->tables->sequence_length;
+    tsk_id_t *restrict parent = malloc(num_nodes * sizeof(*parent));
+    tsk_site_t *site;
+    tsk_id_t tj, tk, h;
+    double t_left, t_right;
+    const double *weight_u;
+    double *state_u, *result_row;
+    double *state = calloc(num_nodes * state_dim, sizeof(*state));
+    double *total_weight = calloc(state_dim, sizeof(*total_weight));
+    double *site_result = calloc(result_dim, sizeof(*site_result));
+    bool polarised = false;
+
+    if (parent == NULL || state == NULL || total_weight == NULL || site_result == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, num_nodes * sizeof(*parent));
+
+    if (options & TSK_STAT_POLARISED) {
+        polarised = true;
+    }
+
+    /* Set the initial conditions */
+    for (j = 0; j < self->num_samples; j++) {
+        u = self->samples[j];
+        state_u = GET_2D_ROW(state, state_dim, u);
+        weight_u = GET_2D_ROW(sample_weights, state_dim, j);
+        memcpy(state_u, weight_u, state_dim * sizeof(*state_u));
+        for (k = 0; k < state_dim; k++) {
+            total_weight[k] += weight_u[k];
+        }
+    }
+    memset(result, 0, num_windows * result_dim * sizeof(*result));
+
+    /* Iterate over the trees */
+    tj = 0;
+    tk = 0;
+    t_left = 0;
+    tree_index = 0;
+    window_index = 0;
+    while (tj < num_edges || t_left < sequence_length) {
+        while (tk < num_edges && edge_right[O[tk]] == t_left) {
+            h = O[tk];
+            tk++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            while (v != TSK_NULL) {
+                update_state(state, state_dim, v, u, -1);
+                v = parent[v];
+            }
+            parent[u] = TSK_NULL;
+        }
+
+        while (tj < num_edges && edge_left[I[tj]] == t_left) {
+            h = I[tj];
+            tj++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = v;
+            while (v != TSK_NULL) {
+                update_state(state, state_dim, v, u, +1);
+                v = parent[v];
+            }
+        }
+        t_right = sequence_length;
+        if (tj < num_edges) {
+            t_right = TSK_MIN(t_right, edge_left[I[tj]]);
+        }
+        if (tk < num_edges) {
+            t_right = TSK_MIN(t_right, edge_right[O[tk]]);
+        }
+
+        /* Update the sites */
+        for (tree_site = 0; tree_site < self->tree_sites_length[tree_index];
+             tree_site++) {
+            site = self->tree_sites[tree_index] + tree_site;
+            ret = compute_general_stat_site_result(site, state, state_dim, result_dim, f,
+                f_params, total_weight, polarised, site_result);
+            if (ret != 0) {
+                goto out;
+            }
+
+            while (windows[window_index + 1] <= site->position) {
+                window_index++;
+                tsk_bug_assert(window_index < num_windows);
+            }
+            tsk_bug_assert(windows[window_index] <= site->position);
+            tsk_bug_assert(site->position < windows[window_index + 1]);
+            result_row = GET_2D_ROW(result, result_dim, window_index);
+            for (k = 0; k < result_dim; k++) {
+                result_row[k] += site_result[k];
+            }
+        }
+        tree_index++;
+        t_left = t_right;
+    }
+out:
+    /* Can't use msp_safe_free here because of restrict */
+    if (parent != NULL) {
+        free(parent);
+    }
+    tsk_safe_free(state);
+    tsk_safe_free(total_weight);
+    tsk_safe_free(site_result);
+    return ret;
+}
+
+static inline void
+increment_row(size_t length, double multiplier, double *source, double *dest)
+{
+    size_t j;
+
+    for (j = 0; j < length; j++) {
+        dest[j] += multiplier * source[j];
+    }
+}
+
+static int
+tsk_treeseq_node_general_stat(const tsk_treeseq_t *self, size_t state_dim,
+    const double *sample_weights, size_t result_dim, general_stat_func_t *f,
+    void *f_params, size_t num_windows, const double *windows, double *result,
+    tsk_flags_t TSK_UNUSED(options))
+{
+    int ret = 0;
+    tsk_id_t u, v;
+    size_t j, window_index;
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_left = self->tables->edges.left;
+    const double *restrict edge_right = self->tables->edges.right;
+    const tsk_id_t *restrict edge_parent = self->tables->edges.parent;
+    const tsk_id_t *restrict edge_child = self->tables->edges.child;
+    const double sequence_length = self->tables->sequence_length;
+    tsk_id_t *restrict parent = malloc(num_nodes * sizeof(*parent));
+    tsk_id_t tj, tk, h;
+    const double *weight_u;
+    double *state_u;
+    double *state = calloc(num_nodes * state_dim, sizeof(*state));
+    double *node_summary = calloc(num_nodes * result_dim, sizeof(*node_summary));
+    double *last_update = calloc(num_nodes, sizeof(*last_update));
+    double t_left, t_right, w_right;
+
+    if (parent == NULL || state == NULL || node_summary == NULL || last_update == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, num_nodes * sizeof(*parent));
+    memset(result, 0, num_windows * num_nodes * result_dim * sizeof(*result));
+
+    /* Set the initial conditions */
+    for (j = 0; j < self->num_samples; j++) {
+        u = self->samples[j];
+        state_u = GET_2D_ROW(state, state_dim, u);
+        weight_u = GET_2D_ROW(sample_weights, state_dim, j);
+        memcpy(state_u, weight_u, state_dim * sizeof(*state_u));
+    }
+    for (u = 0; u < (tsk_id_t) num_nodes; u++) {
+        ret = update_node_summary(
+            u, result_dim, node_summary, state, state_dim, f, f_params);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    /* Iterate over the trees */
+    tj = 0;
+    tk = 0;
+    t_left = 0;
+    window_index = 0;
+    while (tj < num_edges || t_left < sequence_length) {
+        tsk_bug_assert(window_index < num_windows);
+        while (tk < num_edges && edge_right[O[tk]] == t_left) {
+            h = O[tk];
+            tk++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            while (v != TSK_NULL) {
+                increment_row(result_dim, t_left - last_update[v],
+                    GET_2D_ROW(node_summary, result_dim, v),
+                    GET_3D_ROW(result, num_nodes, result_dim, window_index, v));
+                last_update[v] = t_left;
+                update_state(state, state_dim, v, u, -1);
+                ret = update_node_summary(
+                    v, result_dim, node_summary, state, state_dim, f, f_params);
+                if (ret != 0) {
+                    goto out;
+                }
+                v = parent[v];
+            }
+            parent[u] = TSK_NULL;
+        }
+
+        while (tj < num_edges && edge_left[I[tj]] == t_left) {
+            h = I[tj];
+            tj++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = v;
+            while (v != TSK_NULL) {
+                increment_row(result_dim, t_left - last_update[v],
+                    GET_2D_ROW(node_summary, result_dim, v),
+                    GET_3D_ROW(result, num_nodes, result_dim, window_index, v));
+                last_update[v] = t_left;
+                update_state(state, state_dim, v, u, +1);
+                ret = update_node_summary(
+                    v, result_dim, node_summary, state, state_dim, f, f_params);
+                if (ret != 0) {
+                    goto out;
+                }
+                v = parent[v];
+            }
+        }
+
+        t_right = sequence_length;
+        if (tj < num_edges) {
+            t_right = TSK_MIN(t_right, edge_left[I[tj]]);
+        }
+        if (tk < num_edges) {
+            t_right = TSK_MIN(t_right, edge_right[O[tk]]);
+        }
+
+        while (window_index < num_windows && windows[window_index + 1] <= t_right) {
+            w_right = windows[window_index + 1];
+            /* Flush the contributions of all nodes to the current window */
+            for (u = 0; u < (tsk_id_t) num_nodes; u++) {
+                tsk_bug_assert(last_update[u] < w_right);
+                increment_row(result_dim, w_right - last_update[u],
+                    GET_2D_ROW(node_summary, result_dim, u),
+                    GET_3D_ROW(result, num_nodes, result_dim, window_index, u));
+                last_update[u] = w_right;
+            }
+            window_index++;
+        }
+
+        t_left = t_right;
+    }
+out:
+    /* Can't use msp_safe_free here because of restrict */
+    if (parent != NULL) {
+        free(parent);
+    }
+    tsk_safe_free(state);
+    tsk_safe_free(node_summary);
+    tsk_safe_free(last_update);
+    return ret;
+}
+
+static void
+span_normalise(size_t num_windows, const double *windows, size_t row_size, double *array)
+{
+    size_t window_index, k;
+    double span, *row;
+
+    for (window_index = 0; window_index < num_windows; window_index++) {
+        span = windows[window_index + 1] - windows[window_index];
+        row = GET_2D_ROW(array, row_size, window_index);
+        for (k = 0; k < row_size; k++) {
+            row[k] /= span;
+        }
+    }
+}
+
+typedef struct {
+    general_stat_func_t *f;
+    void *f_params;
+    double *total_weight;
+    double *total_minus_state;
+    double *result_tmp;
+} unpolarised_summary_func_args;
+
+static int
+unpolarised_summary_func(size_t state_dim, const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    int ret = 0;
+    unpolarised_summary_func_args *upargs = (unpolarised_summary_func_args *) params;
+    const double *total_weight = upargs->total_weight;
+    double *total_minus_state = upargs->total_minus_state;
+    double *result_tmp = upargs->result_tmp;
+    size_t k, m;
+
+    ret = upargs->f(state_dim, state, result_dim, result, upargs->f_params);
+    if (ret != 0) {
+        goto out;
+    }
+    for (k = 0; k < state_dim; k++) {
+        total_minus_state[k] = total_weight[k] - state[k];
+    }
+    ret = upargs->f(
+        state_dim, total_minus_state, result_dim, result_tmp, upargs->f_params);
+    if (ret != 0) {
+        goto out;
+    }
+    for (m = 0; m < result_dim; m++) {
+        result[m] += result_tmp[m];
+    }
+out:
+    return ret;
+}
+
+/* Abstracts the running of node and branch stats where the summary function
+ * is run twice when non-polarised. We replace the call to the input summary
+ * function with a call of the required form when non-polarised, simplifying
+ * the implementation and memory management for the node and branch stats.
+ */
+static int
+tsk_polarisable_func_general_stat(const tsk_treeseq_t *self, size_t state_dim,
+    const double *sample_weights, size_t result_dim, general_stat_func_t *f,
+    void *f_params, size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    bool stat_branch = !!(options & TSK_STAT_BRANCH);
+    bool polarised = options & TSK_STAT_POLARISED;
+    general_stat_func_t *wrapped_f = f;
+    void *wrapped_f_params = f_params;
+    const double *weight_u;
+    unpolarised_summary_func_args upargs;
+    tsk_size_t j, k;
+
+    memset(&upargs, 0, sizeof(upargs));
+    if (!polarised) {
+        upargs.f = f;
+        upargs.f_params = f_params;
+        upargs.total_weight = calloc(state_dim, sizeof(double));
+        upargs.total_minus_state = calloc(state_dim, sizeof(double));
+        upargs.result_tmp = calloc(result_dim, sizeof(double));
+
+        if (upargs.total_weight == NULL || upargs.total_minus_state == NULL
+            || upargs.result_tmp == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+
+        /* Compute the total weight */
+        for (j = 0; j < self->num_samples; j++) {
+            weight_u = GET_2D_ROW(sample_weights, state_dim, j);
+            for (k = 0; k < state_dim; k++) {
+                upargs.total_weight[k] += weight_u[k];
+            }
+        }
+
+        wrapped_f = unpolarised_summary_func;
+        wrapped_f_params = &upargs;
+    }
+
+    if (stat_branch) {
+        ret = tsk_treeseq_branch_general_stat(self, state_dim, sample_weights,
+            result_dim, wrapped_f, wrapped_f_params, num_windows, windows, result,
+            options);
+    } else {
+        ret = tsk_treeseq_node_general_stat(self, state_dim, sample_weights, result_dim,
+            wrapped_f, wrapped_f_params, num_windows, windows, result, options);
+    }
+out:
+    tsk_safe_free(upargs.total_weight);
+    tsk_safe_free(upargs.total_minus_state);
+    tsk_safe_free(upargs.result_tmp);
+    return ret;
+}
+
+int
+tsk_treeseq_general_stat(const tsk_treeseq_t *self, size_t state_dim,
+    const double *sample_weights, size_t result_dim, general_stat_func_t *f,
+    void *f_params, size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    bool stat_site = !!(options & TSK_STAT_SITE);
+    bool stat_branch = !!(options & TSK_STAT_BRANCH);
+    bool stat_node = !!(options & TSK_STAT_NODE);
+    double default_windows[] = { 0, self->tables->sequence_length };
+    size_t row_size;
+
+    /* If no mode is specified, we default to site mode */
+    if (!(stat_site || stat_branch || stat_node)) {
+        stat_site = true;
+    }
+    /* It's an error to specify more than one mode */
+    if (stat_site + stat_branch + stat_node > 1) {
+        ret = TSK_ERR_MULTIPLE_STAT_MODES;
+        goto out;
+    }
+
+    if (state_dim < 1) {
+        ret = TSK_ERR_BAD_STATE_DIMS;
+        goto out;
+    }
+    if (result_dim < 1) {
+        ret = TSK_ERR_BAD_RESULT_DIMS;
+        goto out;
+    }
+    if (windows == NULL) {
+        num_windows = 1;
+        windows = default_windows;
+    } else {
+        ret = tsk_treeseq_check_windows(self, num_windows, windows);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    if (stat_site) {
+        ret = tsk_treeseq_site_general_stat(self, state_dim, sample_weights, result_dim,
+            f, f_params, num_windows, windows, result, options);
+    } else {
+        ret = tsk_polarisable_func_general_stat(self, state_dim, sample_weights,
+            result_dim, f, f_params, num_windows, windows, result, options);
+    }
+
+    if (options & TSK_STAT_SPAN_NORMALISE) {
+        row_size = result_dim;
+        if (stat_node) {
+            row_size = result_dim * tsk_treeseq_get_num_nodes(self);
+        }
+        span_normalise(num_windows, windows, row_size, result);
+    }
+
+out:
+    return ret;
+}
+
+static int
+check_set_indexes(
+    tsk_size_t num_sets, tsk_size_t num_set_indexes, const tsk_id_t *set_indexes)
+{
+    int ret = 0;
+    tsk_size_t j;
+
+    for (j = 0; j < num_set_indexes; j++) {
+        if (set_indexes[j] < 0 || set_indexes[j] >= (tsk_id_t) num_sets) {
+            ret = TSK_ERR_BAD_SAMPLE_SET_INDEX;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+tsk_treeseq_check_sample_sets(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets)
+{
+    int ret = 0;
+    size_t j, k, l;
+    const tsk_id_t num_nodes = (tsk_id_t) self->tables->nodes.num_rows;
+    tsk_id_t u, sample_index;
+
+    if (num_sample_sets == 0) {
+        ret = TSK_ERR_INSUFFICIENT_SAMPLE_SETS;
+        goto out;
+    }
+    j = 0;
+    for (k = 0; k < num_sample_sets; k++) {
+        if (sample_set_sizes[k] == 0) {
+            ret = TSK_ERR_EMPTY_SAMPLE_SET;
+            goto out;
+        }
+        for (l = 0; l < sample_set_sizes[k]; l++) {
+            u = sample_sets[j];
+            if (u < 0 || u >= num_nodes) {
+                ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+                goto out;
+            }
+            sample_index = self->sample_index_map[u];
+            if (sample_index == TSK_NULL) {
+                ret = TSK_ERR_BAD_SAMPLES;
+                goto out;
+            }
+            j++;
+        }
+    }
+out:
+    return ret;
+}
+
+typedef struct {
+    tsk_size_t num_samples;
+} weight_stat_params_t;
+
+typedef struct {
+    tsk_size_t num_samples;
+    tsk_size_t num_covariates;
+    double *V;
+} covariates_stat_params_t;
+
+typedef struct {
+    const tsk_id_t *sample_sets;
+    tsk_size_t num_sample_sets;
+    const tsk_size_t *sample_set_sizes;
+    const tsk_id_t *set_indexes;
+} sample_count_stat_params_t;
+
+static int
+tsk_treeseq_sample_count_stat(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t result_dim, const tsk_id_t *set_indexes, general_stat_func_t *f,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    const size_t num_samples = self->num_samples;
+    size_t j, k, l;
+    tsk_id_t u, sample_index;
+    double *weights = NULL;
+    double *weight_row;
+    sample_count_stat_params_t args = { .sample_sets = sample_sets,
+        .num_sample_sets = num_sample_sets,
+        .sample_set_sizes = sample_set_sizes,
+        .set_indexes = set_indexes };
+
+    ret = tsk_treeseq_check_sample_sets(
+        self, num_sample_sets, sample_set_sizes, sample_sets);
+    if (ret != 0) {
+        goto out;
+    }
+    weights = calloc(num_samples * num_sample_sets, sizeof(*weights));
+    if (weights == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    j = 0;
+    for (k = 0; k < num_sample_sets; k++) {
+        for (l = 0; l < sample_set_sizes[k]; l++) {
+            u = sample_sets[j];
+            sample_index = self->sample_index_map[u];
+            weight_row = GET_2D_ROW(weights, num_sample_sets, sample_index);
+            if (weight_row[k] != 0) {
+                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                goto out;
+            }
+            weight_row[k] = 1;
+            j++;
+        }
+    }
+    ret = tsk_treeseq_general_stat(self, num_sample_sets, weights, result_dim, f, &args,
+        num_windows, windows, result, options);
+out:
+    tsk_safe_free(weights);
+    return ret;
+}
+
+/***********************************
+ * Allele frequency spectrum
+ ***********************************/
+
+static inline void
+fold(tsk_size_t *restrict coordinate, const tsk_size_t *restrict dims,
+    tsk_size_t num_dims)
+{
+    tsk_size_t k;
+    double n = 0;
+    int s = 0;
+
+    for (k = 0; k < num_dims; k++) {
+        tsk_bug_assert(coordinate[k] < dims[k]);
+        n += dims[k] - 1;
+        s += (int) coordinate[k];
+    }
+    n /= 2;
+    k = num_dims;
+    while (s == n && k > 0) {
+        k--;
+        n -= ((double) (dims[k] - 1)) / 2;
+        s -= (int) coordinate[k];
+    }
+    if (s > n) {
+        for (k = 0; k < num_dims; k++) {
+            s = (int) (dims[k] - 1 - coordinate[k]);
+            tsk_bug_assert(s >= 0);
+            coordinate[k] = (tsk_size_t) s;
+        }
+    }
+}
+
+static int
+tsk_treeseq_update_site_afs(const tsk_treeseq_t *self, const tsk_site_t *site,
+    const double *total_counts, const double *counts, tsk_size_t num_sample_sets,
+    tsk_size_t window_index, tsk_size_t *result_dims, double *result,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_size_t afs_size;
+    tsk_size_t k, allele, num_alleles, all_samples;
+    double increment, *afs, *allele_counts, *allele_count;
+    tsk_size_t *coordinate = malloc(num_sample_sets * sizeof(*coordinate));
+    bool polarised = !!(options & TSK_STAT_POLARISED);
+    const tsk_size_t K = num_sample_sets + 1;
+
+    if (coordinate == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    ret = get_allele_weights(
+        site, counts, K, total_counts, &num_alleles, &allele_counts);
+    if (ret != 0) {
+        goto out;
+    }
+
+    afs_size = result_dims[num_sample_sets];
+    afs = result + afs_size * window_index;
+
+    increment = polarised ? 1 : 0.5;
+    /* Sum over the allele weights. Skip the ancestral state if polarised. */
+    for (allele = polarised ? 1 : 0; allele < num_alleles; allele++) {
+        allele_count = GET_2D_ROW(allele_counts, K, allele);
+        all_samples = (tsk_size_t) allele_count[num_sample_sets];
+        if (all_samples > 0 && all_samples < self->num_samples) {
+            for (k = 0; k < num_sample_sets; k++) {
+                coordinate[k] = (tsk_size_t) allele_count[k];
+            }
+            if (!polarised) {
+                fold(coordinate, result_dims, num_sample_sets);
+            }
+            increment_nd_array_value(
+                afs, num_sample_sets, result_dims, coordinate, increment);
+        }
+    }
+out:
+    tsk_safe_free(coordinate);
+    tsk_safe_free(allele_counts);
+    return ret;
+}
+
+static int
+tsk_treeseq_site_allele_frequency_spectrum(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes, double *counts,
+    tsk_size_t num_windows, const double *windows, tsk_size_t *result_dims,
+    double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_id_t u, v;
+    tsk_size_t tree_site, tree_index, window_index;
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_left = self->tables->edges.left;
+    const double *restrict edge_right = self->tables->edges.right;
+    const tsk_id_t *restrict edge_parent = self->tables->edges.parent;
+    const tsk_id_t *restrict edge_child = self->tables->edges.child;
+    const double sequence_length = self->tables->sequence_length;
+    tsk_id_t *restrict parent = malloc(num_nodes * sizeof(*parent));
+    tsk_site_t *site;
+    tsk_id_t tj, tk, h;
+    tsk_size_t j;
+    const tsk_size_t K = num_sample_sets + 1;
+    double t_left, t_right;
+    double *total_counts = malloc((1 + num_sample_sets) * sizeof(*total_counts));
+
+    if (parent == NULL || total_counts == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, num_nodes * sizeof(*parent));
+
+    for (j = 0; j < num_sample_sets; j++) {
+        total_counts[j] = sample_set_sizes[j];
+    }
+    total_counts[num_sample_sets] = self->num_samples;
+
+    /* Iterate over the trees */
+    tj = 0;
+    tk = 0;
+    t_left = 0;
+    tree_index = 0;
+    window_index = 0;
+    while (tj < num_edges || t_left < sequence_length) {
+        while (tk < num_edges && edge_right[O[tk]] == t_left) {
+            h = O[tk];
+            tk++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            while (v != TSK_NULL) {
+                update_state(counts, K, v, u, -1);
+                v = parent[v];
+            }
+            parent[u] = TSK_NULL;
+        }
+
+        while (tj < num_edges && edge_left[I[tj]] == t_left) {
+            h = I[tj];
+            tj++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = v;
+            while (v != TSK_NULL) {
+                update_state(counts, K, v, u, +1);
+                v = parent[v];
+            }
+        }
+        t_right = sequence_length;
+        if (tj < num_edges) {
+            t_right = TSK_MIN(t_right, edge_left[I[tj]]);
+        }
+        if (tk < num_edges) {
+            t_right = TSK_MIN(t_right, edge_right[O[tk]]);
+        }
+
+        /* Update the sites */
+        for (tree_site = 0; tree_site < self->tree_sites_length[tree_index];
+             tree_site++) {
+            site = self->tree_sites[tree_index] + tree_site;
+            while (windows[window_index + 1] <= site->position) {
+                window_index++;
+                tsk_bug_assert(window_index < num_windows);
+            }
+            ret = tsk_treeseq_update_site_afs(self, site, total_counts, counts,
+                num_sample_sets, window_index, result_dims, result, options);
+            if (ret != 0) {
+                goto out;
+            }
+            tsk_bug_assert(windows[window_index] <= site->position);
+            tsk_bug_assert(site->position < windows[window_index + 1]);
+        }
+        tree_index++;
+        t_left = t_right;
+    }
+out:
+    /* Can't use msp_safe_free here because of restrict */
+    if (parent != NULL) {
+        free(parent);
+    }
+    tsk_safe_free(total_counts);
+    return ret;
+}
+
+static int TSK_WARN_UNUSED
+tsk_treeseq_update_branch_afs(const tsk_treeseq_t *self, tsk_id_t u, double right,
+    const double *restrict branch_length, double *restrict last_update,
+    const double *counts, tsk_size_t num_sample_sets, size_t window_index,
+    const tsk_size_t *result_dims, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_size_t afs_size;
+    tsk_size_t k;
+    double *afs;
+    tsk_size_t *coordinate = malloc(num_sample_sets * sizeof(*coordinate));
+    bool polarised = !!(options & TSK_STAT_POLARISED);
+    const double *count_row = GET_2D_ROW(counts, num_sample_sets + 1, u);
+    double x = (right - last_update[u]) * branch_length[u];
+    const tsk_size_t all_samples = (tsk_size_t) count_row[num_sample_sets];
+
+    if (coordinate == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    if (0 < all_samples && all_samples < self->num_samples) {
+        if (!polarised) {
+            x *= 0.5;
+        }
+        afs_size = result_dims[num_sample_sets];
+        afs = result + afs_size * window_index;
+        for (k = 0; k < num_sample_sets; k++) {
+            coordinate[k] = (tsk_size_t) count_row[k];
+        }
+        if (!polarised) {
+            fold(coordinate, result_dims, num_sample_sets);
+        }
+        increment_nd_array_value(afs, num_sample_sets, result_dims, coordinate, x);
+    }
+    last_update[u] = right;
+out:
+    tsk_safe_free(coordinate);
+    return ret;
+}
+
+static int
+tsk_treeseq_branch_allele_frequency_spectrum(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, double *counts, tsk_size_t num_windows,
+    const double *windows, const tsk_size_t *result_dims, double *result,
+    tsk_flags_t options)
+{
+    int ret = 0;
+    tsk_id_t u, v;
+    size_t window_index;
+    size_t num_nodes = self->tables->nodes.num_rows;
+    const tsk_id_t num_edges = (tsk_id_t) self->tables->edges.num_rows;
+    const tsk_id_t *restrict I = self->tables->indexes.edge_insertion_order;
+    const tsk_id_t *restrict O = self->tables->indexes.edge_removal_order;
+    const double *restrict edge_left = self->tables->edges.left;
+    const double *restrict edge_right = self->tables->edges.right;
+    const tsk_id_t *restrict edge_parent = self->tables->edges.parent;
+    const tsk_id_t *restrict edge_child = self->tables->edges.child;
+    const double *restrict node_time = self->tables->nodes.time;
+    const double sequence_length = self->tables->sequence_length;
+    tsk_id_t *restrict parent = malloc(num_nodes * sizeof(*parent));
+    double *restrict last_update = calloc(num_nodes, sizeof(*last_update));
+    double *restrict branch_length = calloc(num_nodes, sizeof(*branch_length));
+    tsk_id_t tj, tk, h;
+    double t_left, t_right, w_right;
+    const tsk_size_t K = num_sample_sets + 1;
+
+    if (parent == NULL || last_update == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, num_nodes * sizeof(*parent));
+
+    /* Iterate over the trees */
+    tj = 0;
+    tk = 0;
+    t_left = 0;
+    window_index = 0;
+    while (tj < num_edges || t_left < sequence_length) {
+        tsk_bug_assert(window_index < num_windows);
+        while (tk < num_edges && edge_right[O[tk]] == t_left) {
+            h = O[tk];
+            tk++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            ret = tsk_treeseq_update_branch_afs(self, u, t_left, branch_length,
+                last_update, counts, num_sample_sets, window_index, result_dims, result,
+                options);
+            if (ret != 0) {
+                goto out;
+            }
+            while (v != TSK_NULL) {
+                ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
+                    last_update, counts, num_sample_sets, window_index, result_dims,
+                    result, options);
+                if (ret != 0) {
+                    goto out;
+                }
+                update_state(counts, K, v, u, -1);
+                v = parent[v];
+            }
+            parent[u] = TSK_NULL;
+            branch_length[u] = 0;
+        }
+
+        while (tj < num_edges && edge_left[I[tj]] == t_left) {
+            h = I[tj];
+            tj++;
+            u = edge_child[h];
+            v = edge_parent[h];
+            parent[u] = v;
+            branch_length[u] = node_time[v] - node_time[u];
+            while (v != TSK_NULL) {
+                ret = tsk_treeseq_update_branch_afs(self, v, t_left, branch_length,
+                    last_update, counts, num_sample_sets, window_index, result_dims,
+                    result, options);
+                if (ret != 0) {
+                    goto out;
+                }
+                update_state(counts, K, v, u, +1);
+                v = parent[v];
+            }
+        }
+
+        t_right = sequence_length;
+        if (tj < num_edges) {
+            t_right = TSK_MIN(t_right, edge_left[I[tj]]);
+        }
+        if (tk < num_edges) {
+            t_right = TSK_MIN(t_right, edge_right[O[tk]]);
+        }
+
+        while (window_index < num_windows && windows[window_index + 1] <= t_right) {
+            w_right = windows[window_index + 1];
+            /* Flush the contributions of all nodes to the current window */
+            for (u = 0; u < (tsk_id_t) num_nodes; u++) {
+                tsk_bug_assert(last_update[u] < w_right);
+                ret = tsk_treeseq_update_branch_afs(self, u, w_right, branch_length,
+                    last_update, counts, num_sample_sets, window_index, result_dims,
+                    result, options);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+            window_index++;
+        }
+
+        t_left = t_right;
+    }
+out:
+    /* Can't use msp_safe_free here because of restrict */
+    if (parent != NULL) {
+        free(parent);
+    }
+    if (last_update != NULL) {
+        free(last_update);
+    }
+    if (branch_length != NULL) {
+        free(branch_length);
+    }
+    return ret;
+}
+
+int
+tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
+    double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    bool stat_site = !!(options & TSK_STAT_SITE);
+    bool stat_branch = !!(options & TSK_STAT_BRANCH);
+    bool stat_node = !!(options & TSK_STAT_NODE);
+    double default_windows[] = { 0, self->tables->sequence_length };
+    const size_t num_nodes = self->tables->nodes.num_rows;
+    const size_t K = num_sample_sets + 1;
+    size_t j, k, l, afs_size;
+    tsk_id_t u;
+    tsk_size_t *result_dims = NULL;
+    /* These counts should really be ints, but we use doubles so that we can
+     * reuse code from the general_stats code paths. */
+    double *counts = NULL;
+    double *count_row;
+
+    if (stat_node) {
+        ret = TSK_ERR_UNSUPPORTED_STAT_MODE;
+        goto out;
+    }
+    /* If no mode is specified, we default to site mode */
+    if (!(stat_site || stat_branch)) {
+        stat_site = true;
+    }
+    /* It's an error to specify more than one mode */
+    if (stat_site + stat_branch > 1) {
+        ret = TSK_ERR_MULTIPLE_STAT_MODES;
+        goto out;
+    }
+    if (windows == NULL) {
+        num_windows = 1;
+        windows = default_windows;
+    } else {
+        ret = tsk_treeseq_check_windows(self, num_windows, windows);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    ret = tsk_treeseq_check_sample_sets(
+        self, num_sample_sets, sample_set_sizes, sample_sets);
+    if (ret != 0) {
+        goto out;
+    }
+
+    /* the last element of result_dims stores the total size of the dimenensions */
+    result_dims = malloc((num_sample_sets + 1) * sizeof(*result_dims));
+    counts = calloc(num_nodes * K, sizeof(*counts));
+    if (counts == NULL || result_dims == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    afs_size = 1;
+    j = 0;
+    for (k = 0; k < num_sample_sets; k++) {
+        result_dims[k] = 1 + sample_set_sizes[k];
+        afs_size *= result_dims[k];
+        for (l = 0; l < sample_set_sizes[k]; l++) {
+            u = sample_sets[j];
+            count_row = GET_2D_ROW(counts, K, u);
+            if (count_row[k] != 0) {
+                ret = TSK_ERR_DUPLICATE_SAMPLE;
+                goto out;
+            }
+            count_row[k] = 1;
+            j++;
+        }
+    }
+    for (j = 0; j < self->num_samples; j++) {
+        u = self->samples[j];
+        count_row = GET_2D_ROW(counts, K, u);
+        count_row[num_sample_sets] = 1;
+    }
+    result_dims[num_sample_sets] = (tsk_size_t) afs_size;
+
+    memset(result, 0, num_windows * afs_size * sizeof(*result));
+    if (stat_site) {
+        ret = tsk_treeseq_site_allele_frequency_spectrum(self, num_sample_sets,
+            sample_set_sizes, counts, num_windows, windows, result_dims, result,
+            options);
+    } else {
+        ret = tsk_treeseq_branch_allele_frequency_spectrum(self, num_sample_sets, counts,
+            num_windows, windows, result_dims, result, options);
+    }
+
+    if (options & TSK_STAT_SPAN_NORMALISE) {
+        span_normalise(num_windows, windows, afs_size, result);
+    }
+out:
+    tsk_safe_free(counts);
+    tsk_safe_free(result_dims);
+    return ret;
+}
+
+/***********************************
+ * One way stats
+ ***********************************/
+
+static int
+diversity_summary_func(size_t state_dim, const double *state,
+    size_t TSK_UNUSED(result_dim), double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double n;
+    size_t j;
+
+    for (j = 0; j < state_dim; j++) {
+        n = (double) args.sample_set_sizes[j];
+        result[j] = x[j] * (n - x[j]) / (n * (n - 1));
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_diversity(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+{
+    return tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_sample_sets, NULL, diversity_summary_func, num_windows, windows,
+        result, options);
+}
+
+static int
+trait_covariance_summary_func(size_t state_dim, const double *state,
+    size_t TSK_UNUSED(result_dim), double *result, void *params)
+{
+    weight_stat_params_t args = *(weight_stat_params_t *) params;
+    const double n = (double) args.num_samples;
+    const double *x = state;
+    size_t j;
+
+    for (j = 0; j < state_dim; j++) {
+        result[j] = (x[j] * x[j]) / (2 * (n - 1) * (n - 1));
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_trait_covariance(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options)
+{
+    tsk_size_t num_samples = self->num_samples;
+    size_t j, k;
+    int ret;
+    const double *row;
+    double *new_row;
+    double *means = calloc(num_weights, sizeof(double));
+    double *new_weights = malloc((num_weights + 1) * num_samples * sizeof(double));
+    weight_stat_params_t args = { num_samples = self->num_samples };
+
+    if (new_weights == NULL || means == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    // center weights
+    for (j = 0; j < num_samples; j++) {
+        row = GET_2D_ROW(weights, num_weights, j);
+        for (k = 0; k < num_weights; k++) {
+            means[k] += row[k];
+        }
+    }
+    for (k = 0; k < num_weights; k++) {
+        means[k] /= (double) num_samples;
+    }
+    for (j = 0; j < num_samples; j++) {
+        row = GET_2D_ROW(weights, num_weights, j);
+        new_row = GET_2D_ROW(new_weights, num_weights, j);
+        for (k = 0; k < num_weights; k++) {
+            new_row[k] = row[k] - means[k];
+        }
+    }
+
+    ret = tsk_treeseq_general_stat(self, num_weights, new_weights, num_weights,
+        trait_covariance_summary_func, &args, num_windows, windows, result, options);
+
+out:
+    tsk_safe_free(means);
+    tsk_safe_free(new_weights);
+    return ret;
+}
+
+static int
+trait_correlation_summary_func(size_t state_dim, const double *state,
+    size_t TSK_UNUSED(result_dim), double *result, void *params)
+{
+    weight_stat_params_t args = *(weight_stat_params_t *) params;
+    const double n = (double) args.num_samples;
+    const double *x = state;
+    double p;
+    size_t j;
+
+    p = x[state_dim - 1];
+    for (j = 0; j < state_dim - 1; j++) {
+        if ((p > 0.0) && (p < 1.0)) {
+            result[j] = (x[j] * x[j]) / (2 * (p * (1 - p)) * n * (n - 1));
+        } else {
+            result[j] = 0.0;
+        }
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_trait_correlation(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options)
+{
+    tsk_size_t num_samples = self->num_samples;
+    size_t j, k;
+    int ret;
+    double *means = calloc(num_weights, sizeof(double));
+    double *meansqs = calloc(num_weights, sizeof(double));
+    double *sds = calloc(num_weights, sizeof(double));
+    const double *row;
+    double *new_row;
+    double *new_weights = malloc((num_weights + 1) * num_samples * sizeof(double));
+    weight_stat_params_t args = { num_samples = self->num_samples };
+
+    if (new_weights == NULL || means == NULL || meansqs == NULL || sds == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    if (num_weights < 1) {
+        ret = TSK_ERR_BAD_STATE_DIMS;
+        goto out;
+    }
+
+    // center and scale weights
+    for (j = 0; j < num_samples; j++) {
+        row = GET_2D_ROW(weights, num_weights, j);
+        for (k = 0; k < num_weights; k++) {
+            means[k] += row[k];
+            meansqs[k] += row[k] * row[k];
+        }
+    }
+    for (k = 0; k < num_weights; k++) {
+        means[k] /= (double) num_samples;
+        meansqs[k] -= means[k] * means[k] * (double) num_samples;
+        meansqs[k] /= (double) (num_samples - 1);
+        sds[k] = sqrt(meansqs[k]);
+    }
+    for (j = 0; j < num_samples; j++) {
+        row = GET_2D_ROW(weights, num_weights, j);
+        new_row = GET_2D_ROW(new_weights, num_weights + 1, j);
+        for (k = 0; k < num_weights; k++) {
+            new_row[k] = (row[k] - means[k]) / sds[k];
+        }
+        // set final row to 1/n to compute frequency
+        new_row[num_weights] = 1.0 / (double) num_samples;
+    }
+
+    ret = tsk_treeseq_general_stat(self, num_weights + 1, new_weights, num_weights,
+        trait_correlation_summary_func, &args, num_windows, windows, result, options);
+
+out:
+    tsk_safe_free(means);
+    tsk_safe_free(meansqs);
+    tsk_safe_free(sds);
+    tsk_safe_free(new_weights);
+    return ret;
+}
+
+static int
+trait_linear_model_summary_func(size_t state_dim, const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    covariates_stat_params_t args = *(covariates_stat_params_t *) params;
+    const double num_samples = (double) args.num_samples;
+    const tsk_size_t k = args.num_covariates;
+    const double *V = args.V;
+    ;
+    const double *x = state;
+    const double *v;
+    double m, a, denom, z;
+    size_t i, j;
+    // x[0], ..., x[result_dim - 1] contains the traits, W
+    // x[result_dim], ..., x[state_dim - 2] contains the covariates, Z
+    // x[state_dim - 1] has the number of samples below the node
+
+    m = x[state_dim - 1];
+    for (i = 0; i < result_dim; i++) {
+        if ((m > 0.0) && (m < num_samples)) {
+            v = GET_2D_ROW(V, k, i);
+            a = x[i];
+            denom = m;
+            for (j = 0; j < k; j++) {
+                z = x[result_dim + j];
+                a -= z * v[j];
+                denom -= z * z;
+            }
+            // denom is the length of projection of the trait onto the subspace
+            // spanned by the covariates, so if it is zero then the system is
+            // singular and the solution is nonunique. This numerical tolerance
+            // could be smaller without hitting floating-point error, but being
+            // a tiny bit conservative about when the trait is almost in the
+            // span of the covariates is probably good.
+            if (denom < 1e-8) {
+                result[i] = 0.0;
+            } else {
+                result[i] = (a * a) / (2 * denom * denom);
+            }
+        } else {
+            result[i] = 0.0;
+        }
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_covariates, const double *covariates,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+{
+    tsk_size_t num_samples = self->num_samples;
+    size_t i, j, k;
+    int ret;
+    const double *w, *z;
+    double *v, *new_row;
+    double *V = calloc(num_covariates * num_weights, sizeof(double));
+    double *new_weights
+        = malloc((num_weights + num_covariates + 1) * num_samples * sizeof(double));
+
+    covariates_stat_params_t args
+        = { .num_samples = self->num_samples, .num_covariates = num_covariates, .V = V };
+
+    // We assume that the covariates have been *already standardised*,
+    // so that (a) 1 is in the span of the columns, and
+    // (b) their crossproduct is the identity.
+    // We could do this instead here with gsl linalg.
+
+    if (new_weights == NULL || V == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    if (num_weights < 1) {
+        ret = TSK_ERR_BAD_STATE_DIMS;
+        goto out;
+    }
+
+    // V = weights^T (matrix mult) covariates
+    for (k = 0; k < num_samples; k++) {
+        w = GET_2D_ROW(weights, num_weights, k);
+        z = GET_2D_ROW(covariates, num_covariates, k);
+        for (i = 0; i < num_weights; i++) {
+            v = GET_2D_ROW(V, num_covariates, i);
+            for (j = 0; j < num_covariates; j++) {
+                v[j] += w[i] * z[j];
+            }
+        }
+    }
+
+    for (k = 0; k < num_samples; k++) {
+        w = GET_2D_ROW(weights, num_weights, k);
+        z = GET_2D_ROW(covariates, num_covariates, k);
+        new_row = GET_2D_ROW(new_weights, num_covariates + num_weights + 1, k);
+        for (i = 0; i < num_weights; i++) {
+            new_row[i] = w[i];
+        }
+        for (i = 0; i < num_covariates; i++) {
+            new_row[i + num_weights] = z[i];
+        }
+        // set final row to 1 to count alleles
+        new_row[num_weights + num_covariates] = 1.0;
+    }
+
+    ret = tsk_treeseq_general_stat(self, num_weights + num_covariates + 1, new_weights,
+        num_weights, trait_linear_model_summary_func, &args, num_windows, windows,
+        result, options);
+
+out:
+    tsk_safe_free(V);
+    tsk_safe_free(new_weights);
+    return ret;
+}
+
+static int
+segregating_sites_summary_func(size_t state_dim, const double *state,
+    size_t TSK_UNUSED(result_dim), double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double n;
+    size_t j;
+
+    // this works because sum_{i=1}^k (1-p_i) = k-1
+    for (j = 0; j < state_dim; j++) {
+        n = (double) args.sample_set_sizes[j];
+        result[j] = (x[j] > 0) * (1 - x[j] / n);
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_segregating_sites(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+{
+    return tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_sample_sets, NULL, segregating_sites_summary_func, num_windows,
+        windows, result, options);
+}
+
+static int
+Y1_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double ni, denom, numer;
+    size_t i;
+
+    for (i = 0; i < result_dim; i++) {
+        ni = args.sample_set_sizes[i];
+        denom = ni * (ni - 1) * (ni - 2);
+        numer = x[i] * (ni - x[i]) * (ni - x[i] - 1);
+        result[i] = numer / denom;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_Y1(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options)
+{
+    return tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_sample_sets, NULL, Y1_summary_func, num_windows, windows,
+        result, options);
+}
+
+/***********************************
+ * Two way stats
+ ***********************************/
+
+static int
+check_sample_stat_inputs(tsk_size_t num_sample_sets, tsk_size_t tuple_size,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples)
+{
+    int ret = 0;
+
+    if (num_sample_sets < tuple_size) {
+        ret = TSK_ERR_INSUFFICIENT_SAMPLE_SETS;
+        goto out;
+    }
+    if (num_index_tuples < 1) {
+        ret = TSK_ERR_INSUFFICIENT_INDEX_TUPLES;
+        goto out;
+    }
+    ret = check_set_indexes(
+        num_sample_sets, tuple_size * num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+static int
+divergence_summary_func(size_t TSK_UNUSED(state_dim), const double *state,
+    size_t result_dim, double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double ni, nj, denom;
+    tsk_id_t i, j;
+    size_t k;
+
+    for (k = 0; k < result_dim; k++) {
+        i = args.set_indexes[2 * k];
+        j = args.set_indexes[2 * k + 1];
+        ni = args.sample_set_sizes[i];
+        nj = args.sample_set_sizes[j];
+        denom = ni * (nj - (i == j));
+        result[k] = x[i] * (nj - x[j]) / denom;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_divergence(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_index_tuples, index_tuples, divergence_summary_func,
+        num_windows, windows, result, options);
+out:
+    return ret;
+}
+
+static int
+genetic_relatedness_summary_func(size_t state_dim, const double *state,
+    size_t result_dim, double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    tsk_id_t i, j;
+    size_t k;
+    double sumx = 0;
+    double sumn = 0;
+    double meanx, ni, nj;
+
+    for (k = 0; k < state_dim; k++) {
+        sumx += x[k];
+        sumn += args.sample_set_sizes[k];
+    }
+
+    meanx = sumx / sumn;
+    for (k = 0; k < result_dim; k++) {
+        i = args.set_indexes[2 * k];
+        j = args.set_indexes[2 * k + 1];
+        ni = args.sample_set_sizes[i];
+        nj = args.sample_set_sizes[j];
+        result[k] = (x[i] - ni * meanx) * (x[j] - nj * meanx) / 2;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_index_tuples, index_tuples, genetic_relatedness_summary_func,
+        num_windows, windows, result, options);
+out:
+    return ret;
+}
+
+static int
+Y2_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double ni, nj, denom;
+    tsk_id_t i, j;
+    size_t k;
+
+    for (k = 0; k < result_dim; k++) {
+        i = args.set_indexes[2 * k];
+        j = args.set_indexes[2 * k + 1];
+        ni = args.sample_set_sizes[i];
+        nj = args.sample_set_sizes[j];
+        denom = ni * nj * (nj - 1);
+        result[k] = x[i] * (nj - x[j]) * (nj - x[j] - 1) / denom;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_Y2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_index_tuples, index_tuples, Y2_summary_func, num_windows,
+        windows, result, options);
+out:
+    return ret;
+}
+
+static int
+f2_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double ni, nj, denom, numer;
+    tsk_id_t i, j;
+    size_t k;
+
+    for (k = 0; k < result_dim; k++) {
+        i = args.set_indexes[2 * k];
+        j = args.set_indexes[2 * k + 1];
+        ni = args.sample_set_sizes[i];
+        nj = args.sample_set_sizes[j];
+        denom = ni * (ni - 1) * nj * (nj - 1);
+        numer = x[i] * (x[i] - 1) * (nj - x[j]) * (nj - x[j] - 1)
+                - x[i] * (ni - x[i]) * (nj - x[j]) * x[j];
+        result[k] = numer / denom;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_f2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    ret = check_sample_stat_inputs(num_sample_sets, 2, num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_index_tuples, index_tuples, f2_summary_func, num_windows,
+        windows, result, options);
+out:
+    return ret;
+}
+
+/***********************************
+ * Three way stats
+ ***********************************/
+
+static int
+Y3_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double ni, nj, nk, denom, numer;
+    tsk_id_t i, j, k;
+    size_t tuple_index;
+
+    for (tuple_index = 0; tuple_index < result_dim; tuple_index++) {
+        i = args.set_indexes[3 * tuple_index];
+        j = args.set_indexes[3 * tuple_index + 1];
+        k = args.set_indexes[3 * tuple_index + 2];
+        ni = args.sample_set_sizes[i];
+        nj = args.sample_set_sizes[j];
+        nk = args.sample_set_sizes[k];
+        denom = ni * nj * nk;
+        numer = x[i] * (nj - x[j]) * (nk - x[k]);
+        result[tuple_index] = numer / denom;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_Y3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    ret = check_sample_stat_inputs(num_sample_sets, 3, num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_index_tuples, index_tuples, Y3_summary_func, num_windows,
+        windows, result, options);
+out:
+    return ret;
+}
+
+static int
+f3_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double ni, nj, nk, denom, numer;
+    tsk_id_t i, j, k;
+    size_t tuple_index;
+
+    for (tuple_index = 0; tuple_index < result_dim; tuple_index++) {
+        i = args.set_indexes[3 * tuple_index];
+        j = args.set_indexes[3 * tuple_index + 1];
+        k = args.set_indexes[3 * tuple_index + 2];
+        ni = args.sample_set_sizes[i];
+        nj = args.sample_set_sizes[j];
+        nk = args.sample_set_sizes[k];
+        denom = ni * (ni - 1) * nj * nk;
+        numer = x[i] * (x[i] - 1) * (nj - x[j]) * (nk - x[k])
+                - x[i] * (ni - x[i]) * (nj - x[j]) * x[k];
+        result[tuple_index] = numer / denom;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_f3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    ret = check_sample_stat_inputs(num_sample_sets, 3, num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_index_tuples, index_tuples, f3_summary_func, num_windows,
+        windows, result, options);
+out:
+    return ret;
+}
+
+/***********************************
+ * Four way stats
+ ***********************************/
+
+static int
+f4_summary_func(size_t TSK_UNUSED(state_dim), const double *state, size_t result_dim,
+    double *result, void *params)
+{
+    sample_count_stat_params_t args = *(sample_count_stat_params_t *) params;
+    const double *x = state;
+    double ni, nj, nk, nl, denom, numer;
+    tsk_id_t i, j, k, l;
+    size_t tuple_index;
+
+    for (tuple_index = 0; tuple_index < result_dim; tuple_index++) {
+        i = args.set_indexes[4 * tuple_index];
+        j = args.set_indexes[4 * tuple_index + 1];
+        k = args.set_indexes[4 * tuple_index + 2];
+        l = args.set_indexes[4 * tuple_index + 3];
+        ni = args.sample_set_sizes[i];
+        nj = args.sample_set_sizes[j];
+        nk = args.sample_set_sizes[k];
+        nl = args.sample_set_sizes[l];
+        denom = ni * nj * nk * nl;
+        numer = x[i] * x[k] * (nj - x[j]) * (nl - x[l])
+                - x[i] * x[l] * (nj - x[j]) * (nk - x[k]);
+        result[tuple_index] = numer / denom;
+    }
+    return 0;
+}
+
+int
+tsk_treeseq_f4(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options)
+{
+    int ret = 0;
+    ret = check_sample_stat_inputs(num_sample_sets, 4, num_index_tuples, index_tuples);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_sample_count_stat(self, num_sample_sets, sample_set_sizes,
+        sample_sets, num_index_tuples, index_tuples, f4_summary_func, num_windows,
+        windows, result, options);
+out:
+    return ret;
+}
+
+/* Error-raising getter functions */
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_node(const tsk_treeseq_t *self, tsk_id_t index, tsk_node_t *node)
+{
+    return tsk_node_table_get_row(&self->tables->nodes, index, node);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_edge(const tsk_treeseq_t *self, tsk_id_t index, tsk_edge_t *edge)
+{
+    return tsk_edge_table_get_row(&self->tables->edges, index, edge);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_migration(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_migration_t *migration)
+{
+    return tsk_migration_table_get_row(&self->tables->migrations, index, migration);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_mutation(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_mutation_t *mutation)
+{
+    return tsk_mutation_table_get_row(&self->tables->mutations, index, mutation);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_site(const tsk_treeseq_t *self, tsk_id_t index, tsk_site_t *site)
+{
+    int ret = 0;
+
+    ret = tsk_site_table_get_row(&self->tables->sites, index, site);
+    if (ret != 0) {
+        goto out;
+    }
+    site->mutations = self->site_mutations[index];
+    site->mutations_length = self->site_mutations_length[index];
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_individual(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_individual_t *individual)
+{
+    int ret = 0;
+
+    ret = tsk_individual_table_get_row(&self->tables->individuals, index, individual);
+    if (ret != 0) {
+        goto out;
+    }
+    individual->nodes = self->individual_nodes[index];
+    individual->nodes_length = self->individual_nodes_length[index];
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_population(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_population_t *population)
+{
+    return tsk_population_table_get_row(&self->tables->populations, index, population);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_get_provenance(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_provenance_t *provenance)
+{
+    return tsk_provenance_table_get_row(&self->tables->provenances, index, provenance);
+}
+
+int TSK_WARN_UNUSED
+tsk_treeseq_simplify(const tsk_treeseq_t *self, const tsk_id_t *samples,
+    tsk_size_t num_samples, tsk_flags_t options, tsk_treeseq_t *output,
+    tsk_id_t *node_map)
+{
+    int ret = 0;
+    tsk_table_collection_t tables;
+
+    ret = tsk_treeseq_copy_tables(self, &tables, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_table_collection_simplify(
+        &tables, samples, num_samples, options, node_map);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_treeseq_init(output, &tables, TSK_BUILD_INDEXES);
+out:
+    tsk_table_collection_free(&tables);
+    return ret;
+}
+
+/* ======================================================== *
+ * Tree
+ * ======================================================== */
+
+int TSK_WARN_UNUSED
+tsk_tree_clear(tsk_tree_t *self)
+{
+    int ret = 0;
+    tsk_size_t j;
+    tsk_id_t u;
+    const tsk_size_t N = self->num_nodes;
+    const tsk_size_t num_samples = self->tree_sequence->num_samples;
+    const bool sample_counts = !(self->options & TSK_NO_SAMPLE_COUNTS);
+    const bool sample_lists = !!(self->options & TSK_SAMPLE_LISTS);
+
+    self->left = 0;
+    self->right = 0;
+    self->index = -1;
+    /* TODO we should profile this method to see if just doing a single loop over
+     * the nodes would be more efficient than multiple memsets.
+     */
+    memset(self->parent, 0xff, N * sizeof(tsk_id_t));
+    memset(self->left_child, 0xff, N * sizeof(tsk_id_t));
+    memset(self->right_child, 0xff, N * sizeof(tsk_id_t));
+    memset(self->left_sib, 0xff, N * sizeof(tsk_id_t));
+    memset(self->right_sib, 0xff, N * sizeof(tsk_id_t));
+
+    if (sample_counts) {
+        memset(self->num_samples, 0, N * sizeof(tsk_id_t));
+        memset(self->marked, 0, N * sizeof(uint8_t));
+        /* We can't reset the tracked samples via memset because we don't
+         * know where the tracked samples are.
+         */
+        for (j = 0; j < self->num_nodes; j++) {
+            if (!tsk_treeseq_is_sample(self->tree_sequence, (tsk_id_t) j)) {
+                self->num_tracked_samples[j] = 0;
+            }
+        }
+    }
+    if (sample_lists) {
+        memset(self->left_sample, 0xff, N * sizeof(tsk_id_t));
+        memset(self->right_sample, 0xff, N * sizeof(tsk_id_t));
+        memset(self->next_sample, 0xff, num_samples * sizeof(tsk_id_t));
+    }
+    /* Set the sample attributes */
+    for (j = 0; j < num_samples; j++) {
+        u = self->samples[j];
+        if (sample_counts) {
+            self->num_samples[u] = 1;
+        }
+        if (sample_lists) {
+            /* We are mapping to *indexes* into the list of samples here */
+            self->left_sample[u] = (tsk_id_t) j;
+            self->right_sample[u] = (tsk_id_t) j;
+        }
+    }
+    self->left_root = TSK_NULL;
+    if (sample_counts && self->root_threshold == 1 && num_samples > 0) {
+        self->left_root = self->samples[0];
+        for (j = 0; j < num_samples; j++) {
+            /* Set initial roots */
+            u = self->samples[j];
+            if (j < num_samples - 1) {
+                self->right_sib[u] = self->samples[j + 1];
+            }
+            if (j > 0) {
+                self->left_sib[u] = self->samples[j - 1];
+            }
+        }
+    }
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_init(tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options)
+{
+    int ret = TSK_ERR_NO_MEMORY;
+    tsk_size_t num_samples;
+    tsk_size_t num_nodes;
+
+    memset(self, 0, sizeof(tsk_tree_t));
+    if (tree_sequence == NULL) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if (options & TSK_SAMPLE_COUNTS) {
+        fprintf(stderr, "TSK_SAMPLE_COUNTS is no longer supported. "
+                        "Sample counts are tracked by default since 0.99.3, "
+                        "Please use TSK_NO_SAMPLE_COUNTS to turn off sample counts.");
+    }
+    num_nodes = tree_sequence->tables->nodes.num_rows;
+    num_samples = tree_sequence->num_samples;
+    self->num_nodes = num_nodes;
+    self->tree_sequence = tree_sequence;
+    self->samples = tree_sequence->samples;
+    self->options = options;
+    self->root_threshold = 1;
+    self->parent = malloc(num_nodes * sizeof(tsk_id_t));
+    self->left_child = malloc(num_nodes * sizeof(tsk_id_t));
+    self->right_child = malloc(num_nodes * sizeof(tsk_id_t));
+    self->left_sib = malloc(num_nodes * sizeof(tsk_id_t));
+    self->right_sib = malloc(num_nodes * sizeof(tsk_id_t));
+    if (self->parent == NULL || self->left_child == NULL || self->right_child == NULL
+        || self->left_sib == NULL || self->right_sib == NULL) {
+        goto out;
+    }
+    if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
+        self->num_samples = calloc(num_nodes, sizeof(tsk_id_t));
+        self->num_tracked_samples = calloc(num_nodes, sizeof(tsk_id_t));
+        self->marked = calloc(num_nodes, sizeof(uint8_t));
+        if (self->num_samples == NULL || self->num_tracked_samples == NULL
+            || self->marked == NULL) {
+            goto out;
+        }
+    }
+    if (self->options & TSK_SAMPLE_LISTS) {
+        self->left_sample = malloc(num_nodes * sizeof(*self->left_sample));
+        self->right_sample = malloc(num_nodes * sizeof(*self->right_sample));
+        self->next_sample = malloc(num_samples * sizeof(*self->next_sample));
+        if (self->left_sample == NULL || self->right_sample == NULL
+            || self->next_sample == NULL) {
+            goto out;
+        }
+    }
+    ret = tsk_tree_clear(self);
+out:
+    return ret;
+}
+
+int
+tsk_tree_set_root_threshold(tsk_tree_t *self, tsk_size_t root_threshold)
+{
+    int ret = 0;
+
+    if (root_threshold == 0) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    /* Don't allow the value to be set when the tree is out of the null
+     * state */
+    if (self->index != -1) {
+        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        goto out;
+    }
+    self->root_threshold = root_threshold;
+out:
+    return ret;
+}
+
+tsk_size_t
+tsk_tree_get_root_threshold(const tsk_tree_t *self)
+{
+    return self->root_threshold;
+}
+
+int
+tsk_tree_free(tsk_tree_t *self)
+{
+    tsk_safe_free(self->parent);
+    tsk_safe_free(self->left_child);
+    tsk_safe_free(self->right_child);
+    tsk_safe_free(self->left_sib);
+    tsk_safe_free(self->right_sib);
+    tsk_safe_free(self->num_samples);
+    tsk_safe_free(self->num_tracked_samples);
+    tsk_safe_free(self->marked);
+    tsk_safe_free(self->left_sample);
+    tsk_safe_free(self->right_sample);
+    tsk_safe_free(self->next_sample);
+    return 0;
+}
+
+bool
+tsk_tree_has_sample_lists(const tsk_tree_t *self)
+{
+    return !!(self->options & TSK_SAMPLE_LISTS);
+}
+
+bool
+tsk_tree_has_sample_counts(const tsk_tree_t *self)
+{
+    return !(self->options & TSK_NO_SAMPLE_COUNTS);
+}
+
+static int TSK_WARN_UNUSED
+tsk_tree_reset_tracked_samples(tsk_tree_t *self)
+{
+    int ret = 0;
+
+    if (!tsk_tree_has_sample_counts(self)) {
+        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        goto out;
+    }
+    memset(self->num_tracked_samples, 0, self->num_nodes * sizeof(tsk_id_t));
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_set_tracked_samples(
+    tsk_tree_t *self, size_t num_tracked_samples, const tsk_id_t *tracked_samples)
+{
+    int ret = TSK_ERR_GENERIC;
+    size_t j;
+    tsk_id_t u;
+
+    /* TODO This is not needed when the tree is new. We should use the
+     * state machine to check and only reset the tracked samples when needed.
+     */
+    ret = tsk_tree_reset_tracked_samples(self);
+    if (ret != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_tracked_samples; j++) {
+        u = tracked_samples[j];
+        if (u < 0 || u >= (tsk_id_t) self->num_nodes) {
+            ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (!tsk_treeseq_is_sample(self->tree_sequence, u)) {
+            ret = TSK_ERR_BAD_SAMPLES;
+            goto out;
+        }
+        if (self->num_tracked_samples[u] != 0) {
+            ret = TSK_ERR_DUPLICATE_SAMPLE;
+            goto out;
+        }
+        /* Propagate this upwards */
+        while (u != TSK_NULL) {
+            self->num_tracked_samples[u] += 1;
+            u = self->parent[u];
+        }
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_set_tracked_samples_from_sample_list(
+    tsk_tree_t *self, tsk_tree_t *other, tsk_id_t node)
+{
+    int ret = TSK_ERR_GENERIC;
+    tsk_id_t u, stop, index;
+    const tsk_id_t *next = other->next_sample;
+    const tsk_id_t *samples = other->tree_sequence->samples;
+
+    if (!tsk_tree_has_sample_lists(other)) {
+        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        goto out;
+    }
+    /* TODO This is not needed when the tree is new. We should use the
+     * state machine to check and only reset the tracked samples when needed.
+     */
+    ret = tsk_tree_reset_tracked_samples(self);
+    if (ret != 0) {
+        goto out;
+    }
+
+    index = other->left_sample[node];
+    if (index != TSK_NULL) {
+        stop = other->right_sample[node];
+        while (true) {
+            u = samples[index];
+            tsk_bug_assert(self->num_tracked_samples[u] == 0);
+            /* Propagate this upwards */
+            while (u != TSK_NULL) {
+                self->num_tracked_samples[u] += 1;
+                u = self->parent[u];
+            }
+            if (index == stop) {
+                break;
+            }
+            index = next[index];
+        }
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options)
+{
+    int ret = TSK_ERR_GENERIC;
+    size_t N = self->num_nodes;
+
+    if (!(options & TSK_NO_INIT)) {
+        ret = tsk_tree_init(dest, self->tree_sequence, options);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (self->tree_sequence != dest->tree_sequence) {
+        ret = TSK_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    dest->left = self->left;
+    dest->right = self->right;
+    dest->left_root = self->left_root;
+    dest->left_index = self->left_index;
+    dest->right_index = self->right_index;
+    dest->direction = self->direction;
+    dest->index = self->index;
+    dest->sites = self->sites;
+    dest->sites_length = self->sites_length;
+    dest->root_threshold = self->root_threshold;
+
+    memcpy(dest->parent, self->parent, N * sizeof(tsk_id_t));
+    memcpy(dest->left_child, self->left_child, N * sizeof(tsk_id_t));
+    memcpy(dest->right_child, self->right_child, N * sizeof(tsk_id_t));
+    memcpy(dest->left_sib, self->left_sib, N * sizeof(tsk_id_t));
+    memcpy(dest->right_sib, self->right_sib, N * sizeof(tsk_id_t));
+    if (!(dest->options & TSK_NO_SAMPLE_COUNTS)) {
+        if (self->options & TSK_NO_SAMPLE_COUNTS) {
+            ret = TSK_ERR_UNSUPPORTED_OPERATION;
+            goto out;
+        }
+        memcpy(dest->num_samples, self->num_samples, N * sizeof(*self->num_samples));
+        memcpy(dest->num_tracked_samples, self->num_tracked_samples,
+            N * sizeof(*self->num_tracked_samples));
+        memcpy(dest->marked, self->marked, N * sizeof(*self->marked));
+    }
+    if (dest->options & TSK_SAMPLE_LISTS) {
+        if (!(self->options & TSK_SAMPLE_LISTS)) {
+            ret = TSK_ERR_UNSUPPORTED_OPERATION;
+            goto out;
+        }
+        memcpy(dest->left_sample, self->left_sample, N * sizeof(tsk_id_t));
+        memcpy(dest->right_sample, self->right_sample, N * sizeof(tsk_id_t));
+        memcpy(dest->next_sample, self->next_sample,
+            self->tree_sequence->num_samples * sizeof(tsk_id_t));
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool TSK_WARN_UNUSED
+tsk_tree_equals(const tsk_tree_t *self, const tsk_tree_t *other)
+{
+    bool ret = false;
+
+    if (self->tree_sequence == other->tree_sequence) {
+        ret = self->index == other->index;
+    }
+    return ret;
+}
+
+static int
+tsk_tree_check_node(const tsk_tree_t *self, tsk_id_t u)
+{
+    int ret = 0;
+    if (u < 0 || u >= (tsk_id_t) self->num_nodes) {
+        ret = TSK_ERR_NODE_OUT_OF_BOUNDS;
+    }
+    return ret;
+}
+
+bool
+tsk_tree_is_descendant(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v)
+{
+    bool ret = false;
+    tsk_id_t w = u;
+    tsk_id_t *restrict parent = self->parent;
+
+    if (tsk_tree_check_node(self, u) == 0 && tsk_tree_check_node(self, v) == 0) {
+        while (w != v && w != TSK_NULL) {
+            w = parent[w];
+        }
+        ret = w == v;
+    }
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_get_mrca(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *mrca)
+{
+    int ret = 0;
+    tsk_id_t w = 0;
+    tsk_id_t *s1 = NULL;
+    tsk_id_t *s2 = NULL;
+    tsk_id_t j;
+    int l1, l2;
+
+    /* We have a NULL value in these stacks, so need to be sure that
+     * we have an extra space allocated */
+    s1 = malloc((1 + self->num_nodes) * sizeof(*s1));
+    s2 = malloc((1 + self->num_nodes) * sizeof(*s2));
+    if (s1 == NULL || s2 == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    ret = tsk_tree_check_node(self, u);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_tree_check_node(self, v);
+    if (ret != 0) {
+        goto out;
+    }
+    j = u;
+    l1 = 0;
+    while (j != TSK_NULL) {
+        tsk_bug_assert(l1 < (int) self->num_nodes);
+        s1[l1] = j;
+        l1++;
+        j = self->parent[j];
+    }
+    s1[l1] = TSK_NULL;
+    j = v;
+    l2 = 0;
+    while (j != TSK_NULL) {
+        tsk_bug_assert(l2 < (int) self->num_nodes);
+        s2[l2] = j;
+        l2++;
+        j = self->parent[j];
+    }
+    s2[l2] = TSK_NULL;
+    do {
+        w = s1[l1];
+        l1--;
+        l2--;
+    } while (l1 >= 0 && l2 >= 0 && s1[l1] == s2[l2]);
+    *mrca = w;
+    ret = 0;
+out:
+    tsk_safe_free(s1);
+    tsk_safe_free(s2);
+    return ret;
+}
+
+static int
+tsk_tree_get_num_samples_by_traversal(
+    const tsk_tree_t *self, tsk_id_t u, size_t *num_samples)
+{
+    int ret = 0;
+    tsk_id_t *stack = NULL;
+    tsk_id_t v;
+    size_t count = 0;
+    int stack_top = 0;
+
+    stack = malloc(self->num_nodes * sizeof(*stack));
+    if (stack == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    stack[0] = u;
+    while (stack_top >= 0) {
+        v = stack[stack_top];
+        stack_top--;
+        if (tsk_treeseq_is_sample(self->tree_sequence, v)) {
+            count++;
+        }
+        v = self->left_child[v];
+        while (v != TSK_NULL) {
+            stack_top++;
+            stack[stack_top] = v;
+            v = self->right_sib[v];
+        }
+    }
+    *num_samples = count;
+out:
+    tsk_safe_free(stack);
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_get_num_samples(const tsk_tree_t *self, tsk_id_t u, size_t *num_samples)
+{
+    int ret = 0;
+
+    ret = tsk_tree_check_node(self, u);
+    if (ret != 0) {
+        goto out;
+    }
+
+    if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
+        *num_samples = (size_t) self->num_samples[u];
+    } else {
+        ret = tsk_tree_get_num_samples_by_traversal(self, u, num_samples);
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_get_num_tracked_samples(
+    const tsk_tree_t *self, tsk_id_t u, size_t *num_tracked_samples)
+{
+    int ret = 0;
+
+    ret = tsk_tree_check_node(self, u);
+    if (ret != 0) {
+        goto out;
+    }
+    if (self->options & TSK_NO_SAMPLE_COUNTS) {
+        ret = TSK_ERR_UNSUPPORTED_OPERATION;
+        goto out;
+    }
+    *num_tracked_samples = (size_t) self->num_tracked_samples[u];
+out:
+    return ret;
+}
+
+bool
+tsk_tree_is_sample(const tsk_tree_t *self, tsk_id_t u)
+{
+    return tsk_treeseq_is_sample(self->tree_sequence, u);
+}
+
+tsk_size_t
+tsk_tree_get_num_roots(const tsk_tree_t *self)
+{
+    tsk_size_t num_roots = 0;
+    tsk_id_t u = self->left_root;
+
+    while (u != TSK_NULL) {
+        u = self->right_sib[u];
+        num_roots++;
+    }
+    return num_roots;
+}
+
+tsk_id_t
+tsk_tree_get_index(const tsk_tree_t *self)
+{
+    return self->index;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_get_parent(const tsk_tree_t *self, tsk_id_t u, tsk_id_t *parent)
+{
+    int ret = 0;
+
+    ret = tsk_tree_check_node(self, u);
+    if (ret != 0) {
+        goto out;
+    }
+    *parent = self->parent[u];
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_get_time(const tsk_tree_t *self, tsk_id_t u, double *t)
+{
+    int ret = 0;
+    tsk_node_t node;
+
+    ret = tsk_treeseq_get_node(self->tree_sequence, u, &node);
+    if (ret != 0) {
+        goto out;
+    }
+    *t = node.time;
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_get_sites(
+    const tsk_tree_t *self, const tsk_site_t **sites, tsk_size_t *sites_length)
+{
+    *sites = self->sites;
+    *sites_length = self->sites_length;
+    return 0;
+}
+
+/* u must be a valid node in the tree. For internal use */
+static tsk_size_t
+tsk_tree_get_depth(const tsk_tree_t *self, tsk_id_t u)
+{
+
+    tsk_id_t v;
+    tsk_size_t depth = 0;
+
+    for (v = self->parent[u]; v != TSK_NULL; v = self->parent[v]) {
+        depth++;
+    }
+
+    return depth;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_depth(const tsk_tree_t *self, tsk_id_t u, tsk_size_t *depth_ret)
+{
+    int ret = 0;
+
+    ret = tsk_tree_check_node(self, u);
+    if (ret != 0) {
+        goto out;
+    }
+
+    *depth_ret = tsk_tree_get_depth(self, u);
+out:
+    return ret;
+}
+
+static int
+tsk_tree_node_root(tsk_tree_t *self, tsk_id_t u)
+{
+    tsk_id_t v = u;
+    while (self->parent[v] != TSK_NULL) {
+        v = self->parent[v];
+    }
+
+    return v;
+}
+
+/* TODO Should push this through the stack since this is a python method and
+ * it's here anyway */
+static double
+tsk_tree_branch_length(const tsk_tree_t *self, tsk_id_t u)
+{
+    const double *times = self->tree_sequence->tables->nodes.time;
+    tsk_id_t parent = self->parent[u];
+
+    return parent == TSK_NULL ? 0 : times[parent] - times[u];
+}
+
+static void
+tsk_tree_check_state(const tsk_tree_t *self)
+{
+    tsk_id_t u, v;
+    size_t j, num_samples;
+    int err, c;
+    tsk_site_t site;
+    tsk_id_t *children = malloc(self->num_nodes * sizeof(tsk_id_t));
+    bool *is_root = calloc(self->num_nodes, sizeof(bool));
+
+    tsk_bug_assert(children != NULL);
+
+    for (j = 0; j < self->tree_sequence->num_samples; j++) {
+        u = self->samples[j];
+        while (self->parent[u] != TSK_NULL) {
+            u = self->parent[u];
+        }
+        is_root[u] = true;
+    }
+    if (self->tree_sequence->num_samples == 0) {
+        tsk_bug_assert(self->left_root == TSK_NULL);
+    } else {
+        tsk_bug_assert(self->left_sib[self->left_root] == TSK_NULL);
+    }
+    /* Iterate over the roots and make sure they are set */
+    for (u = self->left_root; u != TSK_NULL; u = self->right_sib[u]) {
+        tsk_bug_assert(is_root[u]);
+        is_root[u] = false;
+    }
+    for (u = 0; u < (tsk_id_t) self->num_nodes; u++) {
+        tsk_bug_assert(!is_root[u]);
+        c = 0;
+        for (v = self->left_child[u]; v != TSK_NULL; v = self->right_sib[v]) {
+            tsk_bug_assert(self->parent[v] == u);
+            children[c] = v;
+            c++;
+        }
+        for (v = self->right_child[u]; v != TSK_NULL; v = self->left_sib[v]) {
+            tsk_bug_assert(c > 0);
+            c--;
+            tsk_bug_assert(v == children[c]);
+        }
+    }
+    for (j = 0; j < self->sites_length; j++) {
+        site = self->sites[j];
+        tsk_bug_assert(self->left <= site.position);
+        tsk_bug_assert(site.position < self->right);
+    }
+
+    if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
+        tsk_bug_assert(self->num_samples != NULL);
+        tsk_bug_assert(self->num_tracked_samples != NULL);
+        for (u = 0; u < (tsk_id_t) self->num_nodes; u++) {
+            err = tsk_tree_get_num_samples_by_traversal(self, u, &num_samples);
+            tsk_bug_assert(err == 0);
+            tsk_bug_assert(num_samples == (size_t) self->num_samples[u]);
+        }
+    } else {
+        tsk_bug_assert(self->num_samples == NULL);
+        tsk_bug_assert(self->num_tracked_samples == NULL);
+    }
+    if (self->options & TSK_SAMPLE_LISTS) {
+        tsk_bug_assert(self->right_sample != NULL);
+        tsk_bug_assert(self->left_sample != NULL);
+        tsk_bug_assert(self->next_sample != NULL);
+    } else {
+        tsk_bug_assert(self->right_sample == NULL);
+        tsk_bug_assert(self->left_sample == NULL);
+        tsk_bug_assert(self->next_sample == NULL);
+    }
+
+    free(children);
+    free(is_root);
+}
+
+void
+tsk_tree_print_state(const tsk_tree_t *self, FILE *out)
+{
+    size_t j;
+    tsk_site_t site;
+
+    fprintf(out, "Tree state:\n");
+    fprintf(out, "options = %d\n", self->options);
+    fprintf(out, "root_threshold = %d\n", self->root_threshold);
+    fprintf(out, "left = %f\n", self->left);
+    fprintf(out, "right = %f\n", self->right);
+    fprintf(out, "left_root = %d\n", (int) self->left_root);
+    fprintf(out, "index = %d\n", (int) self->index);
+    fprintf(out, "node\tparent\tlchild\trchild\tlsib\trsib");
+    if (self->options & TSK_SAMPLE_LISTS) {
+        fprintf(out, "\thead\ttail");
+    }
+    fprintf(out, "\n");
+
+    for (j = 0; j < self->num_nodes; j++) {
+        fprintf(out, "%d\t%d\t%d\t%d\t%d\t%d", (int) j, self->parent[j],
+            self->left_child[j], self->right_child[j], self->left_sib[j],
+            self->right_sib[j]);
+        if (self->options & TSK_SAMPLE_LISTS) {
+            fprintf(out, "\t%d\t%d\t", self->left_sample[j], self->right_sample[j]);
+        }
+        if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
+            fprintf(out, "\t%d\t%d\t%d", (int) self->num_samples[j],
+                (int) self->num_tracked_samples[j], self->marked[j]);
+        }
+        fprintf(out, "\n");
+    }
+    fprintf(out, "sites = \n");
+    for (j = 0; j < self->sites_length; j++) {
+        site = self->sites[j];
+        fprintf(out, "\t%d\t%f\n", site.id, site.position);
+    }
+    tsk_tree_check_state(self);
+}
+
+/* Methods for positioning the tree along the sequence */
+
+/* parent, left_child and right_sib are restrict pointers in the calling function,
+ * so we pass these as parameters to ensure the relationships are clear to the
+ * compiler. */
+static inline void
+tsk_tree_update_sample_lists(tsk_tree_t *self, const tsk_id_t *restrict parent,
+    const tsk_id_t *restrict left_child, const tsk_id_t *restrict right_sib,
+    tsk_id_t node)
+{
+    tsk_id_t u, v, sample_index;
+    tsk_id_t *restrict left = self->left_sample;
+    tsk_id_t *restrict right = self->right_sample;
+    tsk_id_t *restrict next = self->next_sample;
+    const tsk_id_t *restrict sample_index_map = self->tree_sequence->sample_index_map;
+
+    for (u = node; u != TSK_NULL; u = parent[u]) {
+        sample_index = sample_index_map[u];
+        if (sample_index != TSK_NULL) {
+            right[u] = left[u];
+        } else {
+            left[u] = TSK_NULL;
+            right[u] = TSK_NULL;
+        }
+        for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
+            if (left[v] != TSK_NULL) {
+                tsk_bug_assert(right[v] != TSK_NULL);
+                if (left[u] == TSK_NULL) {
+                    left[u] = left[v];
+                    right[u] = right[v];
+                } else {
+                    next[right[u]] = left[v];
+                    right[u] = right[v];
+                }
+            }
+        }
+    }
+}
+
+static void
+tsk_tree_remove_edge(tsk_tree_t *self, tsk_id_t p, tsk_id_t c)
+{
+    tsk_id_t *restrict parent = self->parent;
+    tsk_id_t *restrict left_child = self->left_child;
+    tsk_id_t *restrict right_child = self->right_child;
+    tsk_id_t *restrict left_sib = self->left_sib;
+    tsk_id_t *restrict right_sib = self->right_sib;
+    tsk_id_t *restrict num_samples = self->num_samples;
+    tsk_id_t *restrict num_tracked_samples = self->num_tracked_samples;
+    uint8_t *restrict marked = self->marked;
+    const uint8_t mark = self->mark;
+    const tsk_id_t root_threshold = (tsk_id_t) self->root_threshold;
+    tsk_id_t lsib, rsib, u, path_end, lroot, rroot;
+    bool path_end_was_root;
+
+#define IS_ROOT(U) (num_samples[U] >= root_threshold)
+
+    lsib = left_sib[c];
+    rsib = right_sib[c];
+    if (lsib == TSK_NULL) {
+        left_child[p] = rsib;
+    } else {
+        right_sib[lsib] = rsib;
+    }
+    if (rsib == TSK_NULL) {
+        right_child[p] = lsib;
+    } else {
+        left_sib[rsib] = lsib;
+    }
+    parent[c] = TSK_NULL;
+    left_sib[c] = TSK_NULL;
+    right_sib[c] = TSK_NULL;
+
+    if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
+        /* keep the compiler happy */
+        path_end_was_root = false;
+        path_end = TSK_NULL;
+
+        u = p;
+        while (u != TSK_NULL) {
+            path_end = u;
+            path_end_was_root = IS_ROOT(u);
+            num_samples[u] -= num_samples[c];
+            num_tracked_samples[u] -= num_tracked_samples[c];
+            marked[u] = mark;
+            u = parent[u];
+        }
+        if (path_end_was_root && !IS_ROOT(path_end)) {
+            /* remove path_end from the list of roots */
+            lroot = left_sib[path_end];
+            rroot = right_sib[path_end];
+            self->left_root = TSK_NULL;
+            if (lroot != TSK_NULL) {
+                right_sib[lroot] = rroot;
+                self->left_root = lroot;
+            }
+            if (rroot != TSK_NULL) {
+                left_sib[rroot] = lroot;
+                self->left_root = rroot;
+            }
+            left_sib[path_end] = TSK_NULL;
+            right_sib[path_end] = TSK_NULL;
+        }
+        if (IS_ROOT(c)) {
+            if (self->left_root != TSK_NULL) {
+                lroot = left_sib[self->left_root];
+                if (lroot != TSK_NULL) {
+                    right_sib[lroot] = c;
+                }
+                left_sib[c] = lroot;
+                left_sib[self->left_root] = c;
+            }
+            right_sib[c] = self->left_root;
+            self->left_root = c;
+        }
+    }
+
+    if (self->options & TSK_SAMPLE_LISTS) {
+        tsk_tree_update_sample_lists(self, parent, left_child, right_sib, p);
+    }
+}
+
+static void
+tsk_tree_insert_edge(tsk_tree_t *self, tsk_id_t p, tsk_id_t c)
+{
+    tsk_id_t *restrict parent = self->parent;
+    tsk_id_t *restrict left_child = self->left_child;
+    tsk_id_t *restrict right_child = self->right_child;
+    tsk_id_t *restrict left_sib = self->left_sib;
+    tsk_id_t *restrict right_sib = self->right_sib;
+    tsk_id_t *restrict num_samples = self->num_samples;
+    tsk_id_t *restrict num_tracked_samples = self->num_tracked_samples;
+    uint8_t *restrict marked = self->marked;
+    const uint8_t mark = self->mark;
+    const tsk_id_t root_threshold = (tsk_id_t) self->root_threshold;
+    tsk_id_t lsib, rsib, u, path_end, lroot;
+    bool path_end_was_root;
+
+#define IS_ROOT(U) (num_samples[U] >= root_threshold)
+
+    parent[c] = p;
+    u = right_child[p];
+    lsib = left_sib[c];
+    rsib = right_sib[c];
+    if (u == TSK_NULL) {
+        left_child[p] = c;
+        left_sib[c] = TSK_NULL;
+        right_sib[c] = TSK_NULL;
+    } else {
+        right_sib[u] = c;
+        left_sib[c] = u;
+        right_sib[c] = TSK_NULL;
+    }
+    right_child[p] = c;
+
+    if (!(self->options & TSK_NO_SAMPLE_COUNTS)) {
+
+        /* keep compiler happy */
+        path_end = TSK_NULL;
+        path_end_was_root = false;
+
+        u = p;
+        while (u != TSK_NULL) {
+            path_end = u;
+            path_end_was_root = IS_ROOT(u);
+            num_samples[u] += num_samples[c];
+            num_tracked_samples[u] += num_tracked_samples[c];
+            marked[u] = mark;
+            u = parent[u];
+        }
+
+        if (IS_ROOT(c)) {
+            if (path_end_was_root) {
+                /* Remove c from the root list */
+                self->left_root = TSK_NULL;
+                if (lsib != TSK_NULL) {
+                    right_sib[lsib] = rsib;
+                    self->left_root = lsib;
+                }
+                if (rsib != TSK_NULL) {
+                    left_sib[rsib] = lsib;
+                    self->left_root = rsib;
+                }
+            } else {
+                /* Replace c with path_end in root list */
+                if (lsib != TSK_NULL) {
+                    right_sib[lsib] = path_end;
+                }
+                if (rsib != TSK_NULL) {
+                    left_sib[rsib] = path_end;
+                }
+                left_sib[path_end] = lsib;
+                right_sib[path_end] = rsib;
+                self->left_root = path_end;
+            }
+        } else {
+            if (IS_ROOT(path_end) && !path_end_was_root) {
+                /* Add a path_end as new root */
+                if (self->left_root != TSK_NULL) {
+                    lroot = left_sib[self->left_root];
+                    if (lroot != TSK_NULL) {
+                        right_sib[lroot] = path_end;
+                    }
+                    left_sib[path_end] = lroot;
+                    left_sib[self->left_root] = path_end;
+                }
+                right_sib[path_end] = self->left_root;
+                self->left_root = path_end;
+            }
+        }
+    }
+    if (self->options & TSK_SAMPLE_LISTS) {
+        tsk_tree_update_sample_lists(self, parent, left_child, right_sib, p);
+    }
+}
+
+static int
+tsk_tree_advance(tsk_tree_t *self, int direction, const double *restrict out_breakpoints,
+    const tsk_id_t *restrict out_order, tsk_id_t *out_index,
+    const double *restrict in_breakpoints, const tsk_id_t *restrict in_order,
+    tsk_id_t *in_index)
+{
+    int ret = 0;
+    const int direction_change = direction * (direction != self->direction);
+    tsk_id_t in = *in_index + direction_change;
+    tsk_id_t out = *out_index + direction_change;
+    tsk_id_t k;
+    const tsk_table_collection_t *tables = self->tree_sequence->tables;
+    const double sequence_length = tables->sequence_length;
+    const tsk_id_t num_edges = (tsk_id_t) tables->edges.num_rows;
+    const tsk_id_t *restrict edge_parent = tables->edges.parent;
+    const tsk_id_t *restrict edge_child = tables->edges.child;
+    double x;
+
+    if (direction == TSK_DIR_FORWARD) {
+        x = self->right;
+    } else {
+        x = self->left;
+    }
+    while (out >= 0 && out < num_edges && out_breakpoints[out_order[out]] == x) {
+        tsk_bug_assert(out < num_edges);
+        k = out_order[out];
+        out += direction;
+        tsk_tree_remove_edge(self, edge_parent[k], edge_child[k]);
+    }
+
+    while (in >= 0 && in < num_edges && in_breakpoints[in_order[in]] == x) {
+        k = in_order[in];
+        in += direction;
+        tsk_tree_insert_edge(self, edge_parent[k], edge_child[k]);
+    }
+
+    if (self->left_root != TSK_NULL) {
+        /* Ensure that left_root is the left-most root */
+        while (self->left_sib[self->left_root] != TSK_NULL) {
+            self->left_root = self->left_sib[self->left_root];
+        }
+    }
+
+    self->direction = direction;
+    self->index = self->index + direction;
+    if (direction == TSK_DIR_FORWARD) {
+        self->left = x;
+        self->right = sequence_length;
+        if (out >= 0 && out < num_edges) {
+            self->right = TSK_MIN(self->right, out_breakpoints[out_order[out]]);
+        }
+        if (in >= 0 && in < num_edges) {
+            self->right = TSK_MIN(self->right, in_breakpoints[in_order[in]]);
+        }
+    } else {
+        self->right = x;
+        self->left = 0;
+        if (out >= 0 && out < num_edges) {
+            self->left = TSK_MAX(self->left, out_breakpoints[out_order[out]]);
+        }
+        if (in >= 0 && in < num_edges) {
+            self->left = TSK_MAX(self->left, in_breakpoints[in_order[in]]);
+        }
+    }
+    tsk_bug_assert(self->left < self->right);
+    *out_index = out;
+    *in_index = in;
+    if (tables->sites.num_rows > 0) {
+        self->sites = self->tree_sequence->tree_sites[self->index];
+        self->sites_length = self->tree_sequence->tree_sites_length[self->index];
+    }
+    ret = 1;
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_first(tsk_tree_t *self)
+{
+    int ret = 1;
+    tsk_table_collection_t *tables = self->tree_sequence->tables;
+
+    self->left = 0;
+    self->index = 0;
+    self->right = tables->sequence_length;
+    self->sites = self->tree_sequence->tree_sites[0];
+    self->sites_length = self->tree_sequence->tree_sites_length[0];
+
+    if (tables->edges.num_rows > 0) {
+        /* TODO this is redundant if this is the first usage of the tree. We
+         * should add a state machine here so we know what state the tree is
+         * in and can take the appropriate actions.
+         */
+        ret = tsk_tree_clear(self);
+        if (ret != 0) {
+            goto out;
+        }
+        self->index = -1;
+        self->left_index = 0;
+        self->right_index = 0;
+        self->direction = TSK_DIR_FORWARD;
+        self->right = 0;
+
+        ret = tsk_tree_advance(self, TSK_DIR_FORWARD, tables->edges.right,
+            tables->indexes.edge_removal_order, &self->right_index, tables->edges.left,
+            tables->indexes.edge_insertion_order, &self->left_index);
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_last(tsk_tree_t *self)
+{
+    int ret = 1;
+    const tsk_treeseq_t *ts = self->tree_sequence;
+    const tsk_table_collection_t *tables = ts->tables;
+
+    self->left = 0;
+    self->right = tables->sequence_length;
+    self->index = 0;
+    self->sites = ts->tree_sites[0];
+    self->sites_length = ts->tree_sites_length[0];
+
+    if (tables->edges.num_rows > 0) {
+        /* TODO this is redundant if this is the first usage of the tree. We
+         * should add a state machine here so we know what state the tree is
+         * in and can take the appropriate actions.
+         */
+        ret = tsk_tree_clear(self);
+        if (ret != 0) {
+            goto out;
+        }
+        self->index = (tsk_id_t) tsk_treeseq_get_num_trees(ts);
+        self->left_index = (tsk_id_t) tables->edges.num_rows - 1;
+        self->right_index = (tsk_id_t) tables->edges.num_rows - 1;
+        self->direction = TSK_DIR_REVERSE;
+        self->left = tables->sequence_length;
+        self->right = 0;
+
+        ret = tsk_tree_advance(self, TSK_DIR_REVERSE, tables->edges.left,
+            tables->indexes.edge_insertion_order, &self->left_index, tables->edges.right,
+            tables->indexes.edge_removal_order, &self->right_index);
+    }
+out:
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_next(tsk_tree_t *self)
+{
+    int ret = 0;
+    const tsk_treeseq_t *ts = self->tree_sequence;
+    const tsk_table_collection_t *tables = ts->tables;
+    tsk_id_t num_trees = (tsk_id_t) tsk_treeseq_get_num_trees(ts);
+
+    if (self->index == -1) {
+        ret = tsk_tree_first(self);
+    } else if (self->index < num_trees - 1) {
+        ret = tsk_tree_advance(self, TSK_DIR_FORWARD, tables->edges.right,
+            tables->indexes.edge_removal_order, &self->right_index, tables->edges.left,
+            tables->indexes.edge_insertion_order, &self->left_index);
+    } else {
+        ret = tsk_tree_clear(self);
+    }
+    return ret;
+}
+
+int TSK_WARN_UNUSED
+tsk_tree_prev(tsk_tree_t *self)
+{
+    int ret = 0;
+    const tsk_table_collection_t *tables = self->tree_sequence->tables;
+
+    if (self->index == -1) {
+        ret = tsk_tree_last(self);
+    } else if (self->index > 0) {
+        ret = tsk_tree_advance(self, TSK_DIR_REVERSE, tables->edges.left,
+            tables->indexes.edge_insertion_order, &self->left_index, tables->edges.right,
+            tables->indexes.edge_removal_order, &self->right_index);
+    } else {
+        ret = tsk_tree_clear(self);
+    }
+    return ret;
+}
+
+/* Parsimony methods */
+
+static inline uint64_t
+set_bit(uint64_t value, int8_t bit)
+{
+    return value | (1ULL << bit);
+}
+
+static inline bool
+bit_is_set(uint64_t value, int8_t bit)
+{
+    return (value & (1ULL << bit)) != 0;
+}
+
+static inline int8_t
+get_smallest_set_bit(uint64_t v)
+{
+    /* This is an inefficient implementation, there are several better
+     * approaches. On GCC we can use
+     * return (uint8_t) (__builtin_ffsll((long long) v) - 1);
+     */
+    uint64_t t = 1;
+    int8_t r = 0;
+
+    assert(v != 0);
+    while ((v & t) == 0) {
+        t <<= 1;
+        r++;
+    }
+    return r;
+}
+
+#define HARTIGAN_MAX_ALLELES 64
+
+/* This interface is experimental. In the future, we should provide the option to
+ * use a general cost matrix, in which case we'll use the Sankoff algorithm. For
+ * now this is unused.
+ *
+ * The algorithm used here is Hartigan parsimony, "Minimum Mutation Fits to a
+ * Given Tree", Biometrics 1973.
+ */
+int TSK_WARN_UNUSED
+tsk_tree_map_mutations(tsk_tree_t *self, int8_t *genotypes,
+    double *TSK_UNUSED(cost_matrix), tsk_flags_t TSK_UNUSED(options),
+    int8_t *r_ancestral_state, tsk_size_t *r_num_transitions,
+    tsk_state_transition_t **r_transitions)
+{
+    int ret = 0;
+    struct stack_elem {
+        tsk_id_t node;
+        tsk_id_t transition_parent;
+        int8_t state;
+    };
+    const tsk_size_t num_samples = self->tree_sequence->num_samples;
+    const tsk_size_t num_nodes = self->num_nodes;
+    const tsk_id_t *restrict left_child = self->left_child;
+    const tsk_id_t *restrict right_sib = self->right_sib;
+    const tsk_id_t *restrict parent = self->parent;
+    const tsk_flags_t *restrict node_flags = self->tree_sequence->tables->nodes.flags;
+    uint64_t optimal_root_set;
+    uint64_t *restrict optimal_set = calloc(num_nodes, sizeof(*optimal_set));
+    tsk_id_t *restrict postorder_stack = malloc(num_nodes * sizeof(*postorder_stack));
+    struct stack_elem *restrict preorder_stack
+        = malloc(num_nodes * sizeof(*preorder_stack));
+    tsk_id_t postorder_parent, root, u, v;
+    /* The largest possible number of transitions is one over every sample */
+    tsk_state_transition_t *transitions = malloc(num_samples * sizeof(*transitions));
+    int8_t allele, ancestral_state;
+    int stack_top;
+    struct stack_elem s;
+    tsk_size_t j, num_transitions, max_allele_count;
+    tsk_size_t allele_count[HARTIGAN_MAX_ALLELES];
+    tsk_size_t non_missing = 0;
+    int8_t num_alleles = 0;
+
+    if (optimal_set == NULL || preorder_stack == NULL || postorder_stack == NULL
+        || transitions == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    for (j = 0; j < num_samples; j++) {
+        if (genotypes[j] >= HARTIGAN_MAX_ALLELES || genotypes[j] < TSK_MISSING_DATA) {
+            ret = TSK_ERR_BAD_GENOTYPE;
+            goto out;
+        }
+        u = self->tree_sequence->samples[j];
+        if (genotypes[j] == TSK_MISSING_DATA) {
+            /* All bits set */
+            optimal_set[u] = UINT64_MAX;
+        } else {
+            optimal_set[u] = set_bit(optimal_set[u], genotypes[j]);
+            num_alleles = TSK_MAX(genotypes[j], num_alleles);
+            non_missing++;
+        }
+    }
+
+    if (non_missing == 0) {
+        ret = TSK_ERR_GENOTYPES_ALL_MISSING;
+        goto out;
+    }
+    num_alleles++;
+
+    for (root = self->left_root; root != TSK_NULL; root = self->right_sib[root]) {
+        /* Do a post order traversal */
+        postorder_stack[0] = root;
+        stack_top = 0;
+        postorder_parent = TSK_NULL;
+        while (stack_top >= 0) {
+            u = postorder_stack[stack_top];
+            if (left_child[u] != TSK_NULL && u != postorder_parent) {
+                for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
+                    stack_top++;
+                    postorder_stack[stack_top] = v;
+                }
+            } else {
+                stack_top--;
+                postorder_parent = parent[u];
+
+                /* Visit u */
+                memset(allele_count, 0, ((size_t) num_alleles) * sizeof(*allele_count));
+                for (v = left_child[u]; v != TSK_NULL; v = right_sib[v]) {
+                    for (allele = 0; allele < num_alleles; allele++) {
+                        allele_count[allele] += bit_is_set(optimal_set[v], allele);
+                    }
+                }
+                if (!(node_flags[u] & TSK_NODE_IS_SAMPLE)) {
+                    max_allele_count = 0;
+                    for (allele = 0; allele < num_alleles; allele++) {
+                        max_allele_count
+                            = TSK_MAX(max_allele_count, allele_count[allele]);
+                    }
+                    for (allele = 0; allele < num_alleles; allele++) {
+                        if (allele_count[allele] == max_allele_count) {
+                            optimal_set[u] = set_bit(optimal_set[u], allele);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    optimal_root_set = 0;
+    /* TODO it's annoying that this is essentially the same as the
+     * visit function above. It would be nice if we had an extra
+     * node that was the parent of all roots, then the algorithm
+     * would work as-is */
+    memset(allele_count, 0, ((size_t) num_alleles) * sizeof(*allele_count));
+    for (root = self->left_root; root != TSK_NULL; root = right_sib[root]) {
+        for (allele = 0; allele < num_alleles; allele++) {
+            allele_count[allele] += bit_is_set(optimal_set[root], allele);
+        }
+    }
+    max_allele_count = 0;
+    for (allele = 0; allele < num_alleles; allele++) {
+        max_allele_count = TSK_MAX(max_allele_count, allele_count[allele]);
+    }
+    for (allele = 0; allele < num_alleles; allele++) {
+        if (allele_count[allele] == max_allele_count) {
+            optimal_root_set = set_bit(optimal_root_set, allele);
+        }
+    }
+    ancestral_state = get_smallest_set_bit(optimal_root_set);
+
+    num_transitions = 0;
+    for (root = self->left_root; root != TSK_NULL; root = self->right_sib[root]) {
+        /* Do a preorder traversal */
+        preorder_stack[0].node = root;
+        preorder_stack[0].state = ancestral_state;
+        preorder_stack[0].transition_parent = TSK_NULL;
+        stack_top = 0;
+        while (stack_top >= 0) {
+            s = preorder_stack[stack_top];
+            stack_top--;
+
+            if (!bit_is_set(optimal_set[s.node], s.state)) {
+                s.state = get_smallest_set_bit(optimal_set[s.node]);
+                transitions[num_transitions].node = s.node;
+                transitions[num_transitions].parent = s.transition_parent;
+                transitions[num_transitions].state = s.state;
+                s.transition_parent = (tsk_id_t) num_transitions;
+                num_transitions++;
+            }
+            for (v = left_child[s.node]; v != TSK_NULL; v = right_sib[v]) {
+                stack_top++;
+                s.node = v;
+                preorder_stack[stack_top] = s;
+            }
+        }
+    }
+
+    *r_transitions = transitions;
+    *r_num_transitions = num_transitions;
+    *r_ancestral_state = ancestral_state;
+    transitions = NULL;
+out:
+    tsk_safe_free(transitions);
+    /* Cannot safe_free because of 'restrict' */
+    if (optimal_set != NULL) {
+        free(optimal_set);
+    }
+    if (preorder_stack != NULL) {
+        free(preorder_stack);
+    }
+    if (postorder_stack != NULL) {
+        free(postorder_stack);
+    }
+    return ret;
+}
+
+/* ======================================================== *
+ * Tree diff iterator.
+ * ======================================================== */
+
+int TSK_WARN_UNUSED
+tsk_diff_iter_init(
+    tsk_diff_iter_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options)
+{
+    int ret = 0;
+
+    tsk_bug_assert(tree_sequence != NULL);
+    memset(self, 0, sizeof(tsk_diff_iter_t));
+    self->num_nodes = tsk_treeseq_get_num_nodes(tree_sequence);
+    self->num_edges = tsk_treeseq_get_num_edges(tree_sequence);
+    self->tree_sequence = tree_sequence;
+    self->insertion_index = 0;
+    self->removal_index = 0;
+    self->tree_left = 0;
+    self->tree_index = -1;
+    self->last_index = (tsk_id_t) tsk_treeseq_get_num_trees(tree_sequence);
+    if (options & TSK_INCLUDE_TERMINAL) {
+        self->last_index = self->last_index + 1;
+    }
+    self->edge_list_nodes = malloc(self->num_edges * sizeof(*self->edge_list_nodes));
+    if (self->edge_list_nodes == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+out:
+    return ret;
+}
+
+int
+tsk_diff_iter_free(tsk_diff_iter_t *self)
+{
+    tsk_safe_free(self->edge_list_nodes);
+    return 0;
+}
+
+void
+tsk_diff_iter_print_state(const tsk_diff_iter_t *self, FILE *out)
+{
+    fprintf(out, "tree_diff_iterator state\n");
+    fprintf(out, "num_edges = %d\n", (int) self->num_edges);
+    fprintf(out, "insertion_index = %d\n", (int) self->insertion_index);
+    fprintf(out, "removal_index = %d\n", (int) self->removal_index);
+    fprintf(out, "tree_left = %f\n", self->tree_left);
+    fprintf(out, "tree_index = %d\n", (int) self->tree_index);
+}
+
+int TSK_WARN_UNUSED
+tsk_diff_iter_next(tsk_diff_iter_t *self, double *ret_left, double *ret_right,
+    tsk_edge_list_t *edges_out_ret, tsk_edge_list_t *edges_in_ret)
+{
+    int ret = 0;
+    tsk_id_t k;
+    const double sequence_length = self->tree_sequence->tables->sequence_length;
+    double left = self->tree_left;
+    double right = sequence_length;
+    tsk_size_t next_edge_list_node = 0;
+    const tsk_treeseq_t *s = self->tree_sequence;
+    tsk_edge_list_node_t *out_head = NULL;
+    tsk_edge_list_node_t *out_tail = NULL;
+    tsk_edge_list_node_t *in_head = NULL;
+    tsk_edge_list_node_t *in_tail = NULL;
+    tsk_edge_list_node_t *w = NULL;
+    tsk_edge_list_t edges_out;
+    tsk_edge_list_t edges_in;
+    const tsk_edge_table_t *edges = &s->tables->edges;
+    const tsk_id_t *insertion_order = s->tables->indexes.edge_insertion_order;
+    const tsk_id_t *removal_order = s->tables->indexes.edge_removal_order;
+
+    memset(&edges_out, 0, sizeof(edges_out));
+    memset(&edges_in, 0, sizeof(edges_in));
+
+    if (self->tree_index + 1 < self->last_index) {
+        /* First we remove the stale records */
+        while (self->removal_index < (tsk_id_t) self->num_edges
+               && left == edges->right[removal_order[self->removal_index]]) {
+            k = removal_order[self->removal_index];
+            tsk_bug_assert(next_edge_list_node < self->num_edges);
+            w = &self->edge_list_nodes[next_edge_list_node];
+            next_edge_list_node++;
+            w->edge.id = k;
+            w->edge.left = edges->left[k];
+            w->edge.right = edges->right[k];
+            w->edge.parent = edges->parent[k];
+            w->edge.child = edges->child[k];
+            w->edge.metadata = edges->metadata + edges->metadata_offset[k];
+            w->edge.metadata_length
+                = edges->metadata_offset[k + 1] - edges->metadata_offset[k];
+            w->next = NULL;
+            w->prev = NULL;
+            if (out_head == NULL) {
+                out_head = w;
+                out_tail = w;
+            } else {
+                out_tail->next = w;
+                w->prev = out_tail;
+                out_tail = w;
+            }
+            self->removal_index++;
+        }
+        edges_out.head = out_head;
+        edges_out.tail = out_tail;
+
+        /* Now insert the new records */
+        while (self->insertion_index < (tsk_id_t) self->num_edges
+               && left == edges->left[insertion_order[self->insertion_index]]) {
+            k = insertion_order[self->insertion_index];
+            tsk_bug_assert(next_edge_list_node < self->num_edges);
+            w = &self->edge_list_nodes[next_edge_list_node];
+            next_edge_list_node++;
+            w->edge.id = k;
+            w->edge.left = edges->left[k];
+            w->edge.right = edges->right[k];
+            w->edge.parent = edges->parent[k];
+            w->edge.child = edges->child[k];
+            w->edge.metadata = edges->metadata + edges->metadata_offset[k];
+            w->edge.metadata_length
+                = edges->metadata_offset[k + 1] - edges->metadata_offset[k];
+            w->next = NULL;
+            w->prev = NULL;
+            if (in_head == NULL) {
+                in_head = w;
+                in_tail = w;
+            } else {
+                in_tail->next = w;
+                w->prev = in_tail;
+                in_tail = w;
+            }
+            self->insertion_index++;
+        }
+        edges_in.head = in_head;
+        edges_in.tail = in_tail;
+
+        right = sequence_length;
+        if (self->insertion_index < (tsk_id_t) self->num_edges) {
+            right = TSK_MIN(right, edges->left[insertion_order[self->insertion_index]]);
+        }
+        if (self->removal_index < (tsk_id_t) self->num_edges) {
+            right = TSK_MIN(right, edges->right[removal_order[self->removal_index]]);
+        }
+        self->tree_index++;
+        ret = 1;
+    }
+    *edges_out_ret = edges_out;
+    *edges_in_ret = edges_in;
+    *ret_left = left;
+    *ret_right = right;
+    /* Set the left coordinate for the next tree */
+    self->tree_left = right;
+    return ret;
+}
+
+/* ======================================================== *
+ * KC Distance
+ * ======================================================== */
+
+typedef struct {
+    tsk_size_t *m;
+    double *M;
+    tsk_id_t n;
+    tsk_id_t N;
+} kc_vectors;
+
+static int
+kc_vectors_alloc(kc_vectors *self, tsk_id_t n)
+{
+    int ret = 0;
+
+    self->n = n;
+    self->N = (n * (n - 1)) / 2;
+    self->m = calloc((size_t)(self->N + self->n), sizeof(tsk_size_t));
+    self->M = calloc((size_t)(self->N + self->n), sizeof(double));
+    if (self->m == NULL || self->M == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+static void
+kc_vectors_free(kc_vectors *self)
+{
+    tsk_safe_free(self->m);
+    tsk_safe_free(self->M);
+}
+
+static inline void
+update_kc_vectors_single_sample(
+    const tsk_treeseq_t *ts, kc_vectors *kc_vecs, tsk_id_t u, double time)
+{
+    const tsk_id_t *sample_index_map = ts->sample_index_map;
+    tsk_id_t u_index = sample_index_map[u];
+
+    kc_vecs->m[kc_vecs->N + u_index] = 1;
+    kc_vecs->M[kc_vecs->N + u_index] = time;
+}
+
+static inline void
+update_kc_vectors_all_pairs(const tsk_tree_t *tree, kc_vectors *kc_vecs, tsk_id_t u,
+    tsk_id_t v, tsk_size_t depth, double time)
+{
+    tsk_id_t sample1_index, sample2_index, n1, n2, tmp, pair_index;
+    const tsk_id_t *restrict left_sample = tree->left_sample;
+    const tsk_id_t *restrict right_sample = tree->right_sample;
+    const tsk_id_t *restrict next_sample = tree->next_sample;
+    tsk_size_t *restrict kc_m = kc_vecs->m;
+    double *restrict kc_M = kc_vecs->M;
+
+    sample1_index = left_sample[u];
+    while (sample1_index != TSK_NULL) {
+        sample2_index = left_sample[v];
+        while (sample2_index != TSK_NULL) {
+            n1 = sample1_index;
+            n2 = sample2_index;
+            if (n1 > n2) {
+                tmp = n1;
+                n1 = n2;
+                n2 = tmp;
+            }
+
+            /* We spend ~40% of our time here because these accesses
+             * are not in order and gets very poor cache behavior */
+            pair_index = n2 - n1 - 1 + (-1 * n1 * (n1 - 2 * kc_vecs->n + 1)) / 2;
+            kc_m[pair_index] = depth;
+            kc_M[pair_index] = time;
+
+            if (sample2_index == right_sample[v]) {
+                break;
+            }
+            sample2_index = next_sample[sample2_index];
+        }
+        if (sample1_index == right_sample[u]) {
+            break;
+        }
+        sample1_index = next_sample[sample1_index];
+    }
+}
+
+struct kc_stack_elmt {
+    tsk_id_t node;
+    tsk_size_t depth;
+};
+
+static int
+fill_kc_vectors(const tsk_tree_t *t, kc_vectors *kc_vecs)
+{
+    int stack_top;
+    tsk_size_t depth;
+    double time;
+    const double *times;
+    struct kc_stack_elmt *stack;
+    tsk_id_t root, u, c1, c2;
+    int ret = 0;
+    const tsk_treeseq_t *ts = t->tree_sequence;
+
+    stack = malloc(t->num_nodes * sizeof(*stack));
+    if (stack == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    times = t->tree_sequence->tables->nodes.time;
+
+    for (root = t->left_root; root != TSK_NULL; root = t->right_sib[root]) {
+        stack_top = 0;
+        stack[stack_top].node = root;
+        stack[stack_top].depth = 0;
+        while (stack_top >= 0) {
+            u = stack[stack_top].node;
+            depth = stack[stack_top].depth;
+            stack_top--;
+
+            if (tsk_tree_is_sample(t, u)) {
+                time = tsk_tree_branch_length(t, u);
+                update_kc_vectors_single_sample(ts, kc_vecs, u, time);
+            }
+
+            /* Don't bother going deeper if there are no samples under this node */
+            if (t->left_sample[u] != TSK_NULL) {
+                for (c1 = t->left_child[u]; c1 != TSK_NULL; c1 = t->right_sib[c1]) {
+                    stack_top++;
+                    stack[stack_top].node = c1;
+                    stack[stack_top].depth = depth + 1;
+
+                    for (c2 = t->right_sib[c1]; c2 != TSK_NULL; c2 = t->right_sib[c2]) {
+                        time = times[root] - times[u];
+                        update_kc_vectors_all_pairs(t, kc_vecs, c1, c2, depth, time);
+                    }
+                }
+            }
+        }
+    }
+
+out:
+    tsk_safe_free(stack);
+    return ret;
+}
+
+static double
+norm_kc_vectors(kc_vectors *self, kc_vectors *other, double lambda)
+{
+    double vT1, vT2, distance_sum;
+    tsk_id_t i;
+
+    distance_sum = 0;
+    for (i = 0; i < self->n + self->N; i++) {
+        vT1 = (self->m[i] * (1 - lambda)) + (lambda * self->M[i]);
+        vT2 = (other->m[i] * (1 - lambda)) + (lambda * other->M[i]);
+        distance_sum += (vT1 - vT2) * (vT1 - vT2);
+    }
+
+    return sqrt(distance_sum);
+}
+
+static int
+check_kc_distance_tree_inputs(const tsk_tree_t *self)
+{
+    tsk_id_t u, num_nodes, left_child;
+    int ret = 0;
+
+    if (tsk_tree_get_num_roots(self) != 1) {
+        ret = TSK_ERR_MULTIPLE_ROOTS;
+        goto out;
+    }
+    if (!tsk_tree_has_sample_lists(self)) {
+        ret = TSK_ERR_NO_SAMPLE_LISTS;
+        goto out;
+    }
+
+    num_nodes = (tsk_id_t) tsk_treeseq_get_num_nodes(self->tree_sequence);
+    for (u = 0; u < num_nodes; u++) {
+        left_child = self->left_child[u];
+        if (left_child != TSK_NULL && left_child == self->right_child[u]) {
+            ret = TSK_ERR_UNARY_NODES;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+check_kc_distance_samples_inputs(const tsk_treeseq_t *self, const tsk_treeseq_t *other)
+{
+    const tsk_id_t *samples, *other_samples;
+    tsk_id_t i, n;
+    int ret = 0;
+
+    if (self->num_samples != other->num_samples) {
+        ret = TSK_ERR_SAMPLE_SIZE_MISMATCH;
+        goto out;
+    }
+
+    samples = self->samples;
+    other_samples = other->samples;
+    n = (tsk_id_t) self->num_samples;
+    for (i = 0; i < n; i++) {
+        if (samples[i] != other_samples[i]) {
+            ret = TSK_ERR_SAMPLES_NOT_EQUAL;
+            goto out;
+        }
+    }
+out:
+    return ret;
+}
+
+int
+tsk_tree_kc_distance(
+    const tsk_tree_t *self, const tsk_tree_t *other, double lambda, double *result)
+{
+    tsk_id_t n, i;
+    kc_vectors vecs[2];
+    const tsk_tree_t *trees[2] = { self, other };
+    int ret = 0;
+
+    for (i = 0; i < 2; i++) {
+        memset(&vecs[i], 0, sizeof(kc_vectors));
+    }
+
+    ret = check_kc_distance_samples_inputs(self->tree_sequence, other->tree_sequence);
+    if (ret != 0) {
+        goto out;
+    }
+    for (i = 0; i < 2; i++) {
+        ret = check_kc_distance_tree_inputs(trees[i]);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    n = (tsk_id_t) self->tree_sequence->num_samples;
+    for (i = 0; i < 2; i++) {
+        ret = kc_vectors_alloc(&vecs[i], n);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = fill_kc_vectors(trees[i], &vecs[i]);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    *result = norm_kc_vectors(&vecs[0], &vecs[1], lambda);
+out:
+    for (i = 0; i < 2; i++) {
+        kc_vectors_free(&vecs[i]);
+    }
+    return ret;
+}
+
+static int
+check_kc_distance_tree_sequence_inputs(
+    const tsk_treeseq_t *self, const tsk_treeseq_t *other)
+{
+    int ret = 0;
+
+    if (self->tables->sequence_length != other->tables->sequence_length) {
+        ret = TSK_ERR_SEQUENCE_LENGTH_MISMATCH;
+        goto out;
+    }
+
+    ret = check_kc_distance_samples_inputs(self, other);
+    if (ret != 0) {
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+static void
+update_kc_pair_with_sample(const tsk_tree_t *self, kc_vectors *kc, tsk_id_t sample,
+    tsk_size_t *depths, double root_time)
+{
+    tsk_id_t c, p, sib;
+    double time;
+    tsk_size_t depth;
+    double *times = self->tree_sequence->tables->nodes.time;
+
+    c = sample;
+    for (p = self->parent[sample]; p != TSK_NULL; p = self->parent[p]) {
+        time = root_time - times[p];
+        depth = depths[p];
+        for (sib = self->left_child[p]; sib != TSK_NULL; sib = self->right_sib[sib]) {
+            if (sib != c) {
+                update_kc_vectors_all_pairs(self, kc, sample, sib, depth, time);
+            }
+        }
+        c = p;
+    }
+}
+
+static int
+update_kc_subtree_state(
+    tsk_tree_t *t, kc_vectors *kc, tsk_id_t u, tsk_size_t *depths, double root_time)
+{
+    int stack_top;
+    tsk_id_t v, c;
+    tsk_id_t *stack = NULL;
+    int ret = 0;
+
+    stack = malloc(t->num_nodes * sizeof(*stack));
+    if (stack == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    stack_top = 0;
+    stack[stack_top] = u;
+    while (stack_top >= 0) {
+        v = stack[stack_top];
+        stack_top--;
+
+        if (tsk_tree_is_sample(t, v)) {
+            update_kc_pair_with_sample(t, kc, v, depths, root_time);
+        }
+        for (c = t->left_child[v]; c != TSK_NULL; c = t->right_sib[c]) {
+            if (depths[c] != 0) {
+                depths[c] = depths[v] + 1;
+                stack_top++;
+                stack[stack_top] = c;
+            }
+        }
+    }
+
+out:
+    tsk_safe_free(stack);
+    return ret;
+}
+
+static int
+update_kc_incremental(tsk_tree_t *self, kc_vectors *kc, tsk_edge_list_t *edges_out,
+    tsk_edge_list_t *edges_in, tsk_size_t *depths)
+{
+    int ret = 0;
+    tsk_edge_list_node_t *record;
+    tsk_edge_t *e;
+    tsk_id_t u;
+    double root_time, time;
+    const double *times = self->tree_sequence->tables->nodes.time;
+
+    /* Update state of detached subtrees */
+    for (record = edges_out->tail; record != NULL; record = record->prev) {
+        e = &record->edge;
+        u = e->child;
+        depths[u] = 0;
+
+        if (self->parent[u] == TSK_NULL) {
+            root_time = times[tsk_tree_node_root(self, u)];
+            ret = update_kc_subtree_state(self, kc, u, depths, root_time);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+    }
+
+    /* Propagate state change down into reattached subtrees. */
+    for (record = edges_in->tail; record != NULL; record = record->prev) {
+        e = &record->edge;
+        u = e->child;
+
+        tsk_bug_assert(depths[e->child] == 0);
+        depths[u] = depths[e->parent] + 1;
+
+        root_time = times[tsk_tree_node_root(self, u)];
+        ret = update_kc_subtree_state(self, kc, u, depths, root_time);
+        if (ret != 0) {
+            goto out;
+        }
+
+        if (tsk_tree_is_sample(self, u)) {
+            time = tsk_tree_branch_length(self, u);
+            update_kc_vectors_single_sample(self->tree_sequence, kc, u, time);
+        }
+    }
+
+out:
+    return ret;
+}
+
+int
+tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *other,
+    double lambda_, double *result)
+{
+    int i;
+    tsk_id_t n;
+    tsk_size_t num_nodes;
+    double left, span, total;
+    const tsk_treeseq_t *treeseqs[2] = { self, other };
+    tsk_tree_t trees[2];
+    kc_vectors kcs[2];
+    tsk_diff_iter_t diff_iters[2];
+    tsk_edge_list_t edges_out[2];
+    tsk_edge_list_t edges_in[2];
+    tsk_size_t *depths[2];
+    double t0_left, t0_right, t1_left, t1_right;
+    int ret = 0;
+
+    for (i = 0; i < 2; i++) {
+        memset(&trees[i], 0, sizeof(trees[i]));
+        memset(&diff_iters[i], 0, sizeof(diff_iters[i]));
+        memset(&kcs[i], 0, sizeof(kcs[i]));
+        memset(&edges_out[i], 0, sizeof(edges_out[i]));
+        memset(&edges_in[i], 0, sizeof(edges_in[i]));
+        depths[i] = NULL;
+    }
+
+    ret = check_kc_distance_tree_sequence_inputs(self, other);
+    if (ret != 0) {
+        goto out;
+    }
+
+    n = (tsk_id_t) self->num_samples;
+    for (i = 0; i < 2; i++) {
+        ret = tsk_tree_init(&trees[i], treeseqs[i], TSK_SAMPLE_LISTS);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_diff_iter_init(&diff_iters[i], treeseqs[i], false);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = kc_vectors_alloc(&kcs[i], n);
+        if (ret != 0) {
+            goto out;
+        }
+        num_nodes = tsk_treeseq_get_num_nodes(treeseqs[i]);
+        depths[i] = calloc(num_nodes, sizeof(*depths[i]));
+        if (depths[i] == NULL) {
+            ret = TSK_ERR_NO_MEMORY;
+            goto out;
+        }
+    }
+
+    total = 0;
+    left = 0;
+
+    ret = tsk_tree_first(&trees[0]);
+    if (ret != 1) {
+        goto out;
+    }
+    ret = check_kc_distance_tree_inputs(&trees[0]);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = tsk_diff_iter_next(
+        &diff_iters[0], &t0_left, &t0_right, &edges_out[0], &edges_in[0]);
+    tsk_bug_assert(ret == 1);
+    ret = update_kc_incremental(
+        &trees[0], &kcs[0], &edges_out[0], &edges_in[0], depths[0]);
+    if (ret != 0) {
+        goto out;
+    }
+    while ((ret = tsk_tree_next(&trees[1])) == 1) {
+        ret = check_kc_distance_tree_inputs(&trees[1]);
+        if (ret != 0) {
+            goto out;
+        }
+        ret = tsk_diff_iter_next(
+            &diff_iters[1], &t1_left, &t1_right, &edges_out[1], &edges_in[1]);
+        tsk_bug_assert(ret == 1);
+
+        ret = update_kc_incremental(
+            &trees[1], &kcs[1], &edges_out[1], &edges_in[1], depths[1]);
+        if (ret != 0) {
+            goto out;
+        }
+        while (t0_right < t1_right) {
+            span = t0_right - left;
+            total += norm_kc_vectors(&kcs[0], &kcs[1], lambda_) * span;
+
+            left = t0_right;
+            ret = tsk_tree_next(&trees[0]);
+            tsk_bug_assert(ret == 1);
+            ret = check_kc_distance_tree_inputs(&trees[0]);
+            if (ret != 0) {
+                goto out;
+            }
+            ret = tsk_diff_iter_next(
+                &diff_iters[0], &t0_left, &t0_right, &edges_out[0], &edges_in[0]);
+            tsk_bug_assert(ret == 1);
+            ret = update_kc_incremental(
+                &trees[0], &kcs[0], &edges_out[0], &edges_in[0], depths[0]);
+            if (ret != 0) {
+                goto out;
+            }
+        }
+        span = t1_right - left;
+        left = t1_right;
+        total += norm_kc_vectors(&kcs[0], &kcs[1], lambda_) * span;
+    }
+    if (ret != 0) {
+        goto out;
+    }
+
+    *result = total / self->tables->sequence_length;
+out:
+    for (i = 0; i < 2; i++) {
+        tsk_tree_free(&trees[i]);
+        tsk_diff_iter_free(&diff_iters[i]);
+        kc_vectors_free(&kcs[i]);
+        tsk_safe_free(depths[i]);
+    }
+    return ret;
+}

--- a/subprojects/tskit/tskit/trees.h
+++ b/subprojects/tskit/tskit/trees.h
@@ -1,0 +1,458 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Tskit Developers
+ * Copyright (c) 2015-2018 University of Oxford
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file trees.h
+ * @brief Tskit core tree sequence operations.
+ */
+#ifndef TSK_TREES_H
+#define TSK_TREES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <tskit/tables.h>
+
+/* The TSK_SAMPLE_COUNTS was removed in version 0.99.3, where
+ * the default is now to always count samples except when
+ * TSK_NO_SAMPLE_COUNTS is specified. This macro can be undefined
+ * at some point in the future and the option reused for something
+ * else. */
+// clang-format off
+#define TSK_SAMPLE_COUNTS           (1 << 0)
+#define TSK_SAMPLE_LISTS            (1 << 1)
+#define TSK_NO_SAMPLE_COUNTS        (1 << 2)
+
+#define TSK_STAT_SITE               (1 << 0)
+#define TSK_STAT_BRANCH             (1 << 1)
+#define TSK_STAT_NODE               (1 << 2)
+
+/* Leave room for other stat types */
+#define TSK_STAT_POLARISED          (1 << 10)
+#define TSK_STAT_SPAN_NORMALISE     (1 << 11)
+
+#define TSK_DIR_FORWARD 1
+#define TSK_DIR_REVERSE -1
+
+/* For the edge diff iterator */
+#define TSK_INCLUDE_TERMINAL        (1 << 0)
+// clang-format on
+
+/**
+@brief The tree sequence object.
+*/
+typedef struct {
+    tsk_size_t num_trees;
+    tsk_size_t num_samples;
+    tsk_id_t *samples;
+    /* Breakpoints along the sequence, including 0 and L. */
+    double *breakpoints;
+    /* If a node is a sample, map to its index in the samples list */
+    tsk_id_t *sample_index_map;
+    /* Map individuals to the list of nodes that reference them */
+    tsk_id_t *individual_nodes_mem;
+    tsk_id_t **individual_nodes;
+    tsk_size_t *individual_nodes_length;
+    /* For each tree, a list of sites on that tree */
+    tsk_site_t *tree_sites_mem;
+    tsk_site_t **tree_sites;
+    tsk_size_t *tree_sites_length;
+    /* For each site, a list of mutations at that site */
+    tsk_mutation_t *site_mutations_mem;
+    tsk_mutation_t **site_mutations;
+    tsk_size_t *site_mutations_length;
+    /* The underlying tables */
+    tsk_table_collection_t *tables;
+} tsk_treeseq_t;
+
+/**
+@brief A single tree in a tree sequence.
+
+@rst
+A ``tsk_tree_t`` object has two basic functions:
+
+1. Represent the state of a single tree in a tree sequence;
+2. Provide methods to transform this state into different trees in the sequence.
+
+The state of a single tree in the tree sequence is represented using the
+quintuply linked encoding: please see the
+:ref:`data model <sec_data_model_tree_structure>` section for details on
+how this works. The left-to-right ordering of nodes in this encoding
+is arbitrary, and may change depending on the order in which trees are
+accessed within the sequence. Please see the
+:ref:`sec_c_api_examples_tree_traversals` examples for recommended
+usage.
+
+On initialisation, a tree is in a "null" state: each sample is a
+root and there are no edges. We must call one of the 'seeking' methods
+to make the state of the tree object correspond to a particular tree
+in the sequence. Please see the
+:ref:`sec_c_api_examples_tree_iteration` examples for recommended
+usage.
+
+@endrst
+ */
+typedef struct {
+    /**
+     * @brief The parent tree sequence.
+     */
+    const tsk_treeseq_t *tree_sequence;
+    /**
+     * @brief The leftmost root in the tree. Roots are siblings, and
+     * other roots can be found using right_sib.
+     */
+    tsk_id_t left_root;
+    /**
+     @brief The parent of node u is parent[u]. Equal to TSK_NULL if node u is a
+     root or is not a node in the current tree.
+     */
+    tsk_id_t *parent;
+    /**
+     @brief The leftmost child of node u is left_child[u]. Equal to TSK_NULL
+     if node u is a leaf or is not a node in the current tree.
+     */
+    tsk_id_t *left_child;
+    /**
+     @brief The rightmost child of node u is right_child[u]. Equal to TSK_NULL
+     if node u is a leaf or is not a node in the current tree.
+     */
+    tsk_id_t *right_child;
+    /**
+     @brief The sibling to the left of node u is left_sib[u]. Equal to TSK_NULL
+     if node u has no siblings to its left.
+     */
+    tsk_id_t *left_sib;
+    /**
+     @brief The sibling to the right of node u is right_sib[u]. Equal to TSK_NULL
+     if node u has no siblings to its right.
+     */
+    tsk_id_t *right_sib;
+
+    tsk_size_t num_nodes;
+    tsk_flags_t options;
+    tsk_size_t root_threshold;
+    const tsk_id_t *samples;
+    /* TODO before documenting this should be change to interval. */
+    /* Left and right physical coordinates of the tree */
+    double left;
+    double right;
+    tsk_id_t index;
+    /* These are involved in the optional sample tracking; num_samples counts
+     * all samples below a give node, and num_tracked_samples counts those
+     * from a specific subset. By default sample counts are tracked and roots
+     * maintained. If TSK_NO_SAMPLE_COUNTS is specified, then neither sample
+     * counts or roots are available. */
+    tsk_id_t *num_samples;
+    tsk_id_t *num_tracked_samples;
+    /* TODO the only place this feature seems to be used is in the ld_calculator.
+     * when this is being replaced we should come up with a better way of doing
+     * whatever this is being used for. */
+    /* All nodes that are marked during a particular transition are marked
+     * with a given value. */
+    uint8_t *marked;
+    uint8_t mark;
+    /* These are for the optional sample list tracking. */
+    tsk_id_t *left_sample;
+    tsk_id_t *right_sample;
+    tsk_id_t *next_sample;
+    /* The sites on this tree */
+    const tsk_site_t *sites;
+    tsk_size_t sites_length;
+    /* Counters needed for next() and prev() transformations. */
+    int direction;
+    tsk_id_t left_index;
+    tsk_id_t right_index;
+} tsk_tree_t;
+
+/* Diff iterator. TODO Not sure if we want to keep this, as it's not used
+ * very much in the C code. */
+typedef struct _tsk_edge_list_node_t {
+    tsk_edge_t edge;
+    struct _tsk_edge_list_node_t *next;
+    struct _tsk_edge_list_node_t *prev;
+} tsk_edge_list_node_t;
+
+typedef struct {
+    tsk_edge_list_node_t *head;
+    tsk_edge_list_node_t *tail;
+} tsk_edge_list_t;
+
+typedef struct {
+    tsk_size_t num_nodes;
+    tsk_size_t num_edges;
+    double tree_left;
+    const tsk_treeseq_t *tree_sequence;
+    tsk_id_t insertion_index;
+    tsk_id_t removal_index;
+    tsk_id_t tree_index;
+    tsk_id_t last_index;
+    tsk_edge_list_node_t *edge_list_nodes;
+} tsk_diff_iter_t;
+
+/****************************************************************************/
+/* Tree sequence.*/
+/****************************************************************************/
+
+/**
+@defgroup TREESEQ_API_GROUP Tree sequence API
+@{
+*/
+int tsk_treeseq_init(
+    tsk_treeseq_t *self, const tsk_table_collection_t *tables, tsk_flags_t options);
+
+int tsk_treeseq_load(tsk_treeseq_t *self, const char *filename, tsk_flags_t options);
+int tsk_treeseq_loadf(tsk_treeseq_t *self, FILE *file, tsk_flags_t options);
+
+int tsk_treeseq_dump(tsk_treeseq_t *self, const char *filename, tsk_flags_t options);
+int tsk_treeseq_dumpf(tsk_treeseq_t *self, FILE *file, tsk_flags_t options);
+int tsk_treeseq_copy_tables(
+    const tsk_treeseq_t *self, tsk_table_collection_t *tables, tsk_flags_t options);
+int tsk_treeseq_free(tsk_treeseq_t *self);
+void tsk_treeseq_print_state(const tsk_treeseq_t *self, FILE *out);
+
+/** @} */
+
+tsk_size_t tsk_treeseq_get_num_nodes(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_edges(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_migrations(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_sites(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_mutations(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_provenances(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_populations(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_individuals(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_trees(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_num_samples(const tsk_treeseq_t *self);
+const char *tsk_treeseq_get_metadata(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_metadata_length(const tsk_treeseq_t *self);
+const char *tsk_treeseq_get_metadata_schema(const tsk_treeseq_t *self);
+tsk_size_t tsk_treeseq_get_metadata_schema_length(const tsk_treeseq_t *self);
+const char *tsk_treeseq_get_file_uuid(const tsk_treeseq_t *self);
+double tsk_treeseq_get_sequence_length(const tsk_treeseq_t *self);
+const double *tsk_treeseq_get_breakpoints(const tsk_treeseq_t *self);
+const tsk_id_t *tsk_treeseq_get_samples(const tsk_treeseq_t *self);
+const tsk_id_t *tsk_treeseq_get_sample_index_map(const tsk_treeseq_t *self);
+bool tsk_treeseq_is_sample(const tsk_treeseq_t *self, tsk_id_t u);
+
+int tsk_treeseq_get_node(const tsk_treeseq_t *self, tsk_id_t index, tsk_node_t *node);
+int tsk_treeseq_get_edge(const tsk_treeseq_t *self, tsk_id_t index, tsk_edge_t *edge);
+int tsk_treeseq_get_migration(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_migration_t *migration);
+int tsk_treeseq_get_site(const tsk_treeseq_t *self, tsk_id_t index, tsk_site_t *site);
+int tsk_treeseq_get_mutation(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_mutation_t *mutation);
+int tsk_treeseq_get_provenance(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_provenance_t *provenance);
+int tsk_treeseq_get_population(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_population_t *population);
+int tsk_treeseq_get_individual(
+    const tsk_treeseq_t *self, tsk_id_t index, tsk_individual_t *individual);
+
+int tsk_treeseq_simplify(const tsk_treeseq_t *self, const tsk_id_t *samples,
+    tsk_size_t num_samples, tsk_flags_t options, tsk_treeseq_t *output,
+    tsk_id_t *node_map);
+
+int tsk_treeseq_kc_distance(const tsk_treeseq_t *self, const tsk_treeseq_t *other,
+    double lambda_, double *result);
+
+int tsk_treeseq_genealogical_nearest_neighbours(const tsk_treeseq_t *self,
+    const tsk_id_t *focal, size_t num_focal, const tsk_id_t *const *reference_sets,
+    const size_t *reference_set_size, size_t num_reference_sets, tsk_flags_t options,
+    double *ret_array);
+int tsk_treeseq_mean_descendants(const tsk_treeseq_t *self,
+    const tsk_id_t *const *reference_sets, const size_t *reference_set_size,
+    size_t num_reference_sets, tsk_flags_t options, double *ret_array);
+
+/* TODO change all these size_t's to tsk_size_t */
+
+typedef int general_stat_func_t(size_t state_dim, const double *state, size_t result_dim,
+    double *result, void *params);
+
+int tsk_treeseq_general_stat(const tsk_treeseq_t *self, size_t K, const double *W,
+    size_t M, general_stat_func_t *f, void *f_params, size_t num_windows,
+    const double *windows, double *sigma, tsk_flags_t options);
+
+/* One way weighted stats */
+
+typedef int one_way_weighted_method(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options);
+
+int tsk_treeseq_trait_covariance(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options);
+int tsk_treeseq_trait_correlation(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_windows, const double *windows, double *result,
+    tsk_flags_t options);
+
+/* One way weighted stats with covariates */
+
+typedef int one_way_covariates_method(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_covariates, const double *covariates,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+
+int tsk_treeseq_trait_linear_model(const tsk_treeseq_t *self, tsk_size_t num_weights,
+    const double *weights, tsk_size_t num_covariates, const double *covariates,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+
+/* One way sample set stats */
+
+typedef int one_way_sample_stat_method(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
+    double *result, tsk_flags_t options);
+
+int tsk_treeseq_diversity(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_segregating_sites(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_Y1(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_allele_frequency_spectrum(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t num_windows, const double *windows,
+    double *result, tsk_flags_t options);
+
+typedef int general_sample_stat_method(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t num_indexes, const tsk_id_t *indexes,
+    tsk_size_t num_windows, const double *windows, double *result, tsk_flags_t options);
+
+int tsk_treeseq_divergence(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_Y2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_f2(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_genetic_relatedness(const tsk_treeseq_t *self,
+    tsk_size_t num_sample_sets, const tsk_size_t *sample_set_sizes,
+    const tsk_id_t *sample_sets, tsk_size_t num_index_tuples,
+    const tsk_id_t *index_tuples, tsk_size_t num_windows, const double *windows,
+    double *result, tsk_flags_t options);
+
+/* Three way sample set stats */
+int tsk_treeseq_Y3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options);
+int tsk_treeseq_f3(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options);
+
+/* Four way sample set stats */
+int tsk_treeseq_f4(const tsk_treeseq_t *self, tsk_size_t num_sample_sets,
+    const tsk_size_t *sample_set_sizes, const tsk_id_t *sample_sets,
+    tsk_size_t num_index_tuples, const tsk_id_t *index_tuples, tsk_size_t num_windows,
+    const double *windows, double *result, tsk_flags_t options);
+
+/****************************************************************************/
+/* Tree */
+/****************************************************************************/
+
+/**
+@defgroup TREE_API_GROUP Tree sequence API
+@{
+*/
+
+int tsk_tree_init(
+    tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
+int tsk_tree_free(tsk_tree_t *self);
+
+tsk_id_t tsk_tree_get_index(const tsk_tree_t *self);
+tsk_size_t tsk_tree_get_num_roots(const tsk_tree_t *self);
+
+int tsk_tree_first(tsk_tree_t *self);
+int tsk_tree_last(tsk_tree_t *self);
+int tsk_tree_next(tsk_tree_t *self);
+int tsk_tree_prev(tsk_tree_t *self);
+int tsk_tree_clear(tsk_tree_t *self);
+
+void tsk_tree_print_state(const tsk_tree_t *self, FILE *out);
+/** @} */
+
+int tsk_tree_set_root_threshold(tsk_tree_t *self, tsk_size_t root_threshold);
+tsk_size_t tsk_tree_get_root_threshold(const tsk_tree_t *self);
+
+bool tsk_tree_has_sample_lists(const tsk_tree_t *self);
+bool tsk_tree_has_sample_counts(const tsk_tree_t *self);
+bool tsk_tree_equals(const tsk_tree_t *self, const tsk_tree_t *other);
+/* Returns true if u is a descendant of v; false otherwise */
+bool tsk_tree_is_descendant(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v);
+bool tsk_tree_is_sample(const tsk_tree_t *self, tsk_id_t u);
+
+int tsk_tree_copy(const tsk_tree_t *self, tsk_tree_t *dest, tsk_flags_t options);
+int tsk_tree_set_tracked_samples(
+    tsk_tree_t *self, size_t num_tracked_samples, const tsk_id_t *tracked_samples);
+int tsk_tree_set_tracked_samples_from_sample_list(
+    tsk_tree_t *self, tsk_tree_t *other, tsk_id_t node);
+
+int tsk_tree_get_parent(const tsk_tree_t *self, tsk_id_t u, tsk_id_t *parent);
+int tsk_tree_get_time(const tsk_tree_t *self, tsk_id_t u, double *t);
+int tsk_tree_get_mrca(const tsk_tree_t *self, tsk_id_t u, tsk_id_t v, tsk_id_t *mrca);
+int tsk_tree_get_num_samples(const tsk_tree_t *self, tsk_id_t u, size_t *num_samples);
+int tsk_tree_get_num_tracked_samples(
+    const tsk_tree_t *self, tsk_id_t u, size_t *num_tracked_samples);
+int tsk_tree_get_sites(
+    const tsk_tree_t *self, const tsk_site_t **sites, tsk_size_t *sites_length);
+int tsk_tree_depth(const tsk_tree_t *self, tsk_id_t u, tsk_size_t *depth);
+
+typedef struct {
+    tsk_id_t node;
+    tsk_id_t parent;
+    int8_t state;
+} tsk_state_transition_t;
+
+int tsk_tree_map_mutations(tsk_tree_t *self, int8_t *genotypes, double *cost_matrix,
+    tsk_flags_t options, int8_t *ancestral_state, tsk_size_t *num_transitions,
+    tsk_state_transition_t **transitions);
+
+int tsk_tree_kc_distance(
+    const tsk_tree_t *self, const tsk_tree_t *other, double lambda, double *result);
+
+/****************************************************************************/
+/* Diff iterator */
+/****************************************************************************/
+
+int tsk_diff_iter_init(
+    tsk_diff_iter_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
+int tsk_diff_iter_free(tsk_diff_iter_t *self);
+int tsk_diff_iter_next(tsk_diff_iter_t *self, double *left, double *right,
+    tsk_edge_list_t *edges_out, tsk_edge_list_t *edges_in);
+void tsk_diff_iter_print_state(const tsk_diff_iter_t *self, FILE *out);
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
To allow publication to crates.io, make the following changes:

* Directly include a stable version of tskit code
* Refactor how bindgen is used. Basically, we now follow (and understand!) their docs.

The idea of tskit as a submodule can be revisited later.  But for now, this avoids the symlink inception issue that happens due to the submodule. (The same paths are linked to > 1 time, so `cargo publish` fails.)

- [x] update README re: how this package works
