### PR TITLE
Refactor the ffi module.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -45,14 +45,16 @@ macro_rules! build_tskit_type {
             }
         }
 
-        impl crate::ffi::TskitType<$ll_name> for $name {
+        impl crate::ffi::WrapTskitType<$ll_name> for $name {
             fn wrap() -> Self {
                 let temp: std::mem::MaybeUninit<$ll_name> = std::mem::MaybeUninit::uninit();
                 $name {
                     inner: unsafe { Box::<$ll_name>::new(temp.assume_init()) },
                 }
             }
+        }
 
+        impl crate::ffi::TskitTypeAccess<$ll_name> for $name {
             fn as_ptr(&self) -> *const $ll_name {
                 &*self.inner
             }
@@ -73,7 +75,7 @@ macro_rules! build_consuming_tskit_type {
             }
         }
 
-        impl crate::ffi::TskitConsumingType<$ll_name, $consumed> for $name {
+        impl crate::ffi::WrapTskitConsumingType<$ll_name, $consumed> for $name {
             fn wrap(consumed: $consumed) -> Self {
                 let temp: std::mem::MaybeUninit<$ll_name> = std::mem::MaybeUninit::uninit();
                 $name {
@@ -81,7 +83,9 @@ macro_rules! build_consuming_tskit_type {
                     inner: unsafe { Box::<$ll_name>::new(temp.assume_init()) },
                 }
             }
+        }
 
+        impl crate::ffi::TskitTypeAccess<$ll_name> for $name {
             fn as_ptr(&self) -> *const $ll_name {
                 &*self.inner
             }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,40 +1,28 @@
 //! Define traits related to wrapping tskit stuff
 
-/// Define what it means to wrap a tskit struct.
-/// In practice, one needs to implement Drop for
-/// test types, calling the tsk_foo_free() function
-/// corresponding to tsk_foo_t.
-pub trait TskitType<T> {
-    /// Encapsulate tsk_foo_t and return rust
-    /// object.  Best practices seem to
-    /// suggest using Box for this.
-    fn wrap() -> Self;
+/// Provide pointer access to underlying C types
+pub trait TskitTypeAccess<T> {
     /// Return const pointer
     fn as_ptr(&self) -> *const T;
     /// Return mutable pointer
     fn as_mut_ptr(&mut self) -> *mut T;
 }
 
-/// Define what it means to wrap a tskit struct
-/// that contains another tskit type C (the
-/// "consumed" type).
-/// This trait models a type that takes another
-/// type as input for initialization and effectively
-/// owns it.
-/// A key example of such a type is a [`crate::TreeSequence`],
-/// which owns the underying [`crate::TableCollection`].
-/// In practice, one needs to implement Drop for
-/// test types, calling the tsk_foo_free() function
-/// corresponding to tsk_foo_t.
-pub trait TskitConsumingType<T, C> {
+/// Wrap a tskit type
+pub(crate) trait WrapTskitType<T> {
+    /// Encapsulate tsk_foo_t and return rust
+    /// object.  Best practices seem to
+    /// suggest using Box for this.
+    fn wrap() -> Self;
+}
+
+/// Wrap a tskit type that consumes another
+/// tskit type.  The tree sequence is an example.
+pub(crate) trait WrapTskitConsumingType<T, C> {
     /// Encapsulate tsk_foo_t and return rust
     /// object.  Best practices seem to
     /// suggest using Box for this.
     fn wrap(consumed: C) -> Self;
-    /// Return const pointer
-    fn as_ptr(&self) -> *const T;
-    /// Return mutable pointer
-    fn as_mut_ptr(&mut self) -> *mut T;
 }
 
 #[cfg(test)]

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -1,6 +1,6 @@
 use crate::bindings as ll_bindings;
 use crate::error::TskitError;
-use crate::ffi::TskitType;
+use crate::ffi::{TskitTypeAccess, WrapTskitType};
 use crate::metadata::*;
 use crate::types::Bookmark;
 use crate::EdgeTable;

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1,6 +1,6 @@
 use crate::bindings as ll_bindings;
 use crate::error::TskitError;
-use crate::ffi::{TskitConsumingType, TskitType};
+use crate::ffi::{TskitTypeAccess, WrapTskitConsumingType};
 use crate::{tsk_flags_t, TableCollection, TSK_NULL};
 use ll_bindings::tsk_treeseq_free;
 


### PR DESCRIPTION
* Separate wrapping traits from pointer access traits.
* Only pointer access traits are visible outside this crate.