### PR TITLE
Unify table iteration

### DIFF
--- a/src/table_iterator.rs
+++ b/src/table_iterator.rs
@@ -1,13 +1,13 @@
 use crate::tsk_id_t;
 
-pub struct TableIterator<'a, T> {
-    pub(crate) table: &'a T,
+pub struct TableIterator<T> {
+    pub(crate) table: T,
     pub(crate) pos: tsk_id_t,
     pub(crate) decode_metadata: bool,
 }
 
 pub(crate) fn make_table_iterator<TABLE>(
-    table: &TABLE,
+    table: TABLE,
     decode_metadata: bool,
 ) -> TableIterator<TABLE> {
     TableIterator {


### PR DESCRIPTION
This PR builds on #52:

* Redefine TableIterator to store either a reference or an object.
* Implement standalone "get row" functions for each table.
* For each table `foo`, add `TableCollection::foo_iter`.  These are effectively convenience functions related to what came out of #52