### PR TITLE
Remove duplication of TableCollection by a TreeSequence

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -103,22 +103,6 @@ macro_rules! build_tskit_type {
     };
 }
 
-macro_rules! build_consuming_tskit_type {
-    ($name: ident, $ll_name: ty, $drop: ident, $consumed: ty) => {
-        impl crate::ffi::WrapTskitConsumingType<$ll_name, $consumed> for $name {
-            fn wrap(consumed: $consumed) -> Self {
-                let temp: std::mem::MaybeUninit<$ll_name> = std::mem::MaybeUninit::uninit();
-                $name {
-                    consumed,
-                    inner: unsafe { Box::<$ll_name>::new(temp.assume_init()) },
-                }
-            }
-        }
-        tskit_type_access!($name, $ll_name);
-        drop_for_tskit_type!($name, $drop);
-    };
-}
-
 macro_rules! metadata_to_vector {
     ($self: expr, $row: expr) => {
         crate::metadata::char_column_to_vector(


### PR DESCRIPTION
A refactoring:

* The current tree sequence stores a the consumed table collection.  But, that table collection is copied into the tree sequence.
* This PR removes that redundancy.
* ~~Introduce a "table collection reference" type to allow non-owning "views" of the tables owned by a tree sequence.~~
* ~~This new reference type, though, does duplicate some API of TableCollection.~~